### PR TITLE
Treat empty mandate restrictions as unrestricted

### DIFF
--- a/backend/src/main/java/com/mockhub/mandate/service/MandateService.java
+++ b/backend/src/main/java/com/mockhub/mandate/service/MandateService.java
@@ -160,6 +160,7 @@ public class MandateService {
         }
 
         if (categorySlug != null && mandate.getAllowedCategories() != null
+                && !mandate.getAllowedCategories().isBlank()
                 && !parseCommaSeparated(mandate.getAllowedCategories()).contains(categorySlug)) {
             log.warn("Mandate {} does not allow category '{}'",
                     mandate.getMandateId(), categorySlug);
@@ -167,6 +168,7 @@ public class MandateService {
         }
 
         if (eventSlug != null && mandate.getAllowedEvents() != null
+                && !mandate.getAllowedEvents().isBlank()
                 && !parseCommaSeparated(mandate.getAllowedEvents()).contains(eventSlug)) {
             log.warn("Mandate {} does not allow event '{}'",
                     mandate.getMandateId(), eventSlug);

--- a/backend/src/test/java/com/mockhub/mandate/service/MandateServiceTest.java
+++ b/backend/src/test/java/com/mockhub/mandate/service/MandateServiceTest.java
@@ -274,6 +274,38 @@ class MandateServiceTest {
     }
 
     @Test
+    @DisplayName("validateAction treats empty allowedCategories as unrestricted")
+    void validateAction_givenEmptyAllowedCategories_treatsAsUnrestricted() {
+        Mandate mandate = createActiveMandate("m1", "agent-1", "user@example.com");
+        mandate.setScope("PURCHASE");
+        mandate.setAllowedCategories("");
+        when(mandateRepository.findByAgentIdAndUserEmailAndStatus("agent-1", "user@example.com", "ACTIVE"))
+                .thenReturn(List.of(mandate));
+
+        boolean result = mandateService.validateAction(
+                "agent-1", "user@example.com", "PURCHASE",
+                null, "classical-music", null);
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("validateAction treats empty allowedEvents as unrestricted")
+    void validateAction_givenEmptyAllowedEvents_treatsAsUnrestricted() {
+        Mandate mandate = createActiveMandate("m1", "agent-1", "user@example.com");
+        mandate.setScope("PURCHASE");
+        mandate.setAllowedEvents("");
+        when(mandateRepository.findByAgentIdAndUserEmailAndStatus("agent-1", "user@example.com", "ACTIVE"))
+                .thenReturn(List.of(mandate));
+
+        boolean result = mandateService.validateAction(
+                "agent-1", "user@example.com", "PURCHASE",
+                null, null, "yo-yo-ma-bach");
+
+        assertThat(result).isTrue();
+    }
+
+    @Test
     @DisplayName("validateAction returns false when no active mandate")
     void validateAction_givenNoActiveMandate_returnsFalse() {
         when(mandateRepository.findByAgentIdAndUserEmailAndStatus("agent-1", "user@example.com", "ACTIVE"))


### PR DESCRIPTION
## Summary

- Empty string `""` for `allowedCategories`/`allowedEvents` on a mandate was treated as "allow nothing" instead of "allow everything"
- Add `isBlank()` checks so empty strings behave the same as `null`
- Add 2 tests for the edge case

## Context

Discovered during a live Claude Desktop MCP demo. When Claude created a mandate with `allowedCategories: ""`, `addToCart` was blocked by `MandateCondition` because `parseCommaSeparated("")` returns an empty set that doesn't contain any category slug.

## Test plan

- [x] `validateAction_givenEmptyAllowedCategories_treatsAsUnrestricted`
- [x] `validateAction_givenEmptyAllowedEvents_treatsAsUnrestricted`
- [x] All existing mandate tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)