### PR TITLE
Add custom domain CORS for mockhub.kousenit.com

### DIFF
--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -24,7 +24,7 @@ mockhub:
   cookie:
     secure: true
   cors:
-    allowed-origins: https://mockhub-production.up.railway.app
+    allowed-origins: https://mockhub.kousenit.com,https://mockhub-production.up.railway.app
 
 logging:
   level:


### PR DESCRIPTION
## Summary

- Add `https://mockhub.kousenit.com` to production CORS allowed origins
- Keep old Railway URL as fallback

One-line config change. Custom domain DNS is already live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)