### PR TITLE
Update all URLs to mockhub.kousenit.com

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -677,7 +677,7 @@ Naming convention: `methodName_givenCondition_expectedResult`
 
 ### Railway (Production)
 
-- **URL:** https://mockhub-production.up.railway.app
+- **URL:** https://mockhub.kousenit.com
 - **Architecture:** Single Docker container serves both Spring Boot API and React SPA (no CORS needed)
 - **SPA routing:** `SpaForwardingConfig` serves `index.html` for client-side routes, excludes `/api/`, `/actuator/`, `/mcp/`, `/swagger-ui/`, `/v3/` paths
 - **Ephemeral filesystem:** Seed images restored from classpath on every startup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ The codebase uses Java DOP patterns where they add value:
 - **`llms.txt`** — served at `/llms.txt` (static resource), describes all API endpoints, MCP tools, and ACP endpoints for AI agents.
 - **RFC 9457 Problem Details** — all error responses use Spring's `ProblemDetail` format for machine-readable errors.
 <<<<<<< HEAD
-- **MCP server** — 22 tools registered (EventTools, PricingTools, CartTools, OrderTools, MandateTools) via `spring-ai-starter-mcp-server-webmvc`. API key auth on `/mcp/**` via `McpApiKeyFilter`. Uses Streamable HTTP transport (protocol: `STREAMABLE`) at `/mcp`. Claude Desktop config: `{"url": "https://mockhub-production.up.railway.app/mcp", "headers": {"X-API-Key": "..."}}`.
+- **MCP server** — 22 tools registered (EventTools, PricingTools, CartTools, OrderTools, MandateTools) via `spring-ai-starter-mcp-server-webmvc`. API key auth on `/mcp/**` via `McpApiKeyFilter`. Uses Streamable HTTP transport (protocol: `STREAMABLE`) at `/mcp`. Claude Desktop config: `{"url": "https://mockhub.kousenit.com/mcp", "headers": {"X-API-Key": "..."}}`.
 - **MCP tools identify users by email** — cart and order tools accept `userEmail` parameter, not auth tokens.
 - **Complete agent purchase flow:** `findTickets` → `addToCart` → `checkout` → `confirmOrder` — agents can now execute full purchases.
 - **`findTickets` compound tool** — single-call search with query, category, city, price range, section filter, returning matching listings sorted by price. Reduces agent round-trips from 3 to 1.
@@ -201,7 +201,7 @@ The codebase uses Java DOP patterns where they add value:
 ## Deployment
 
 - **Platform:** Railway (Hobby plan, $5/mo minimum)
-- **URL:** https://mockhub-production.up.railway.app
+- **URL:** https://mockhub.kousenit.com
 - **Architecture:** Single Docker container serves both Spring Boot API and React SPA (no CORS needed)
 - **Dockerfile:** Root `Dockerfile` builds frontend (Node), bundles into Spring Boot jar, runs on JRE Alpine
 - **SPA routing:** `SpaForwardingConfig` serves `index.html` for client-side routes, excludes `api/`, `actuator/`, `mcp/`, `acp/`, `swagger-ui/`, `v3/` paths

--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -725,4 +725,4 @@ bc4e9ab Fix checkout page flash during mock payment processing
 *Last updated: 2026-03-22*
 *Built with: Claude Opus 4.6 (1M context) via Claude Code*
 *~450 tests passing (443 backend + 64 frontend unit + Playwright E2E)*
-*Live at: https://mockhub-production.up.railway.app*
+*Live at: https://mockhub.kousenit.com*

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A secondary concert ticket marketplace built as a teaching platform for AI integ
 
 MockHub mimics the functionality of sites like StubHub and TicketNetwork — registration, event browsing, seat selection, dynamic pricing, and checkout — providing a realistic, full-featured codebase for students to build AI features on top of.
 
-**Live demo:** [mockhub-production.up.railway.app](https://mockhub-production.up.railway.app) — log in with `buyer@mockhub.com` / `buyer123`
+**Live demo:** [mockhub.kousenit.com](https://mockhub.kousenit.com) — log in with `buyer@mockhub.com` / `buyer123`
 
 ![Homepage with search and featured events](docs/screenshots/homepage.png)
 


### PR DESCRIPTION
## Summary

- Update all references from `mockhub-production.up.railway.app` to `mockhub.kousenit.com` in README, CLAUDE.md, ARCHITECTURE.md, and PROJECT_JOURNAL.md
- GitHub repo homepage already updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)