### PR TITLE
Fix .gitignore to ignore youtube symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,8 @@ frontend/.vite/
 .DS_Store
 Thumbs.db
 
-# YouTube video scripts and resources
-youtube/
+# YouTube video scripts and resources (symlink to Google Drive)
+youtube
 
 # Docker
 postgres_data/


### PR DESCRIPTION
## Summary
- The `youtube/` pattern (with trailing slash) only matched directories. Now that `youtube` is a symlink to Google Drive, removed the slash so git ignores it properly.

## Test plan
- [x] `git check-ignore -v youtube` confirms the symlink is ignored


🤖 Generated with [Claude Code](https://claude.com/claude-code)