### PR TITLE
Migrate to Gradle version catalogs

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,10 +1,10 @@
 plugins {
     java
     jacoco
-    id("org.springframework.boot") version "4.0.3"
-    id("io.spring.dependency-management") version "1.1.7"
-    id("org.sonarqube") version "7.2.3.7755"
-    id("com.diffplug.spotless") version "7.0.2"
+    alias(libs.plugins.spring.boot)
+    alias(libs.plugins.spring.dependency.management)
+    alias(libs.plugins.sonarqube)
+    alias(libs.plugins.spotless)
     checkstyle
 }
 
@@ -24,68 +24,68 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom("org.springframework.ai:spring-ai-bom:2.0.0-M3")
+        mavenBom("org.springframework.ai:spring-ai-bom:${libs.versions.spring.ai.get()}")
     }
 }
 
 dependencies {
     // Core Spring Boot starters
-    implementation("org.springframework.boot:spring-boot-starter-webmvc")
-    implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-    implementation("org.springframework.boot:spring-boot-starter-security")
-    implementation("org.springframework.boot:spring-boot-starter-validation")
-    implementation("org.springframework.boot:spring-boot-starter-cache")
-    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation(libs.spring.boot.starter.webmvc)
+    implementation(libs.spring.boot.starter.data.jpa)
+    implementation(libs.spring.boot.starter.security)
+    implementation(libs.spring.boot.starter.validation)
+    implementation(libs.spring.boot.starter.cache)
+    implementation(libs.spring.boot.starter.actuator)
 
     // Spring AI
-    implementation("org.springframework.ai:spring-ai-starter-model-anthropic")
-    implementation("org.springframework.ai:spring-ai-starter-model-openai")
-    implementation("org.springframework.ai:spring-ai-starter-model-ollama")
-    implementation("org.springframework.ai:spring-ai-starter-mcp-server-webmvc")
+    implementation(libs.spring.ai.starter.anthropic)
+    implementation(libs.spring.ai.starter.openai)
+    implementation(libs.spring.ai.starter.ollama)
+    implementation(libs.spring.ai.starter.mcp.server)
 
     // Database
-    runtimeOnly("org.postgresql:postgresql")
-    implementation("org.springframework.boot:spring-boot-starter-flyway")
-    implementation("org.flywaydb:flyway-database-postgresql")
+    runtimeOnly(libs.postgresql)
+    implementation(libs.spring.boot.starter.flyway)
+    implementation(libs.flyway.postgresql)
 
     // Security - JWT
-    implementation("io.jsonwebtoken:jjwt-api:0.12.6")
-    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.6")
-    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.6")
+    implementation(libs.jjwt.api)
+    runtimeOnly(libs.jjwt.impl)
+    runtimeOnly(libs.jjwt.jackson)
 
     // API Documentation
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")
+    implementation(libs.springdoc.openapi)
 
     // Payments
-    implementation("com.stripe:stripe-java:28.3.0")
+    implementation(libs.stripe)
 
     // Image processing
-    implementation("net.coobird:thumbnailator:0.4.20")
+    implementation(libs.thumbnailator)
 
     // PDF generation and QR codes
-    implementation("org.apache.pdfbox:pdfbox:3.0.4")
-    implementation("com.google.zxing:core:3.5.3")
-    implementation("com.google.zxing:javase:3.5.3")
+    implementation(libs.pdfbox)
+    implementation(libs.zxing.core)
+    implementation(libs.zxing.javase)
 
     // SMS delivery
-    implementation("com.twilio.sdk:twilio:10.9.2")
+    implementation(libs.twilio)
 
     // Email delivery
-    implementation("org.springframework.boot:spring-boot-starter-mail")
+    implementation(libs.spring.boot.starter.mail)
 
     // Data generation
-    implementation("net.datafaker:datafaker:2.4.2")
+    implementation(libs.datafaker)
 
     // Testing
-    testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
-    testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
-    testImplementation("org.springframework.boot:spring-boot-starter-security-test")
-    testImplementation("org.springframework.boot:spring-boot-resttestclient")
-    testImplementation("org.springframework.boot:spring-boot-testcontainers")
-    testImplementation("org.testcontainers:testcontainers-junit-jupiter")
-    testImplementation("org.testcontainers:testcontainers-postgresql")
-    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.spring.boot.starter.webmvc.test)
+    testImplementation(libs.spring.boot.starter.data.jpa.test)
+    testImplementation(libs.spring.boot.starter.security.test)
+    testImplementation(libs.spring.boot.resttestclient)
+    testImplementation(libs.spring.boot.testcontainers)
+    testImplementation(libs.testcontainers.junit.jupiter)
+    testImplementation(libs.testcontainers.postgresql)
+    testRuntimeOnly(libs.junit.platform.launcher)
 }
 
 sonar {
@@ -124,13 +124,13 @@ sonar {
 
 spotless {
     java {
-        googleJavaFormat("1.25.2")
+        googleJavaFormat(libs.versions.google.java.format.get())
         targetExclude("build/**")
     }
 }
 
 checkstyle {
-    toolVersion = "10.21.4"
+    toolVersion = libs.versions.checkstyle.get()
     maxWarnings = 0
     configFile = file("config/checkstyle/checkstyle.xml")
 }

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -1,0 +1,98 @@
+[versions]
+# Plugins
+spring-boot = "4.0.3"
+spring-dependency-management = "1.1.7"
+sonarqube = "7.2.3.7755"
+spotless = "7.0.2"
+
+# Spring AI BOM
+spring-ai = "2.0.0-M3"
+
+# Security - JWT
+jjwt = "0.12.6"
+
+# API Documentation
+springdoc = "2.8.6"
+
+# Payments
+stripe = "28.3.0"
+
+# Image processing
+thumbnailator = "0.4.20"
+
+# PDF generation and QR codes
+pdfbox = "3.0.4"
+zxing = "3.5.3"
+
+# SMS delivery
+twilio = "10.9.2"
+
+# Data generation
+datafaker = "2.4.2"
+
+# Code quality
+checkstyle = "10.21.4"
+google-java-format = "1.25.2"
+
+[libraries]
+# Core Spring Boot starters (versions managed by Spring BOM)
+spring-boot-starter-webmvc = { module = "org.springframework.boot:spring-boot-starter-webmvc" }
+spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
+spring-boot-starter-security = { module = "org.springframework.boot:spring-boot-starter-security" }
+spring-boot-starter-validation = { module = "org.springframework.boot:spring-boot-starter-validation" }
+spring-boot-starter-cache = { module = "org.springframework.boot:spring-boot-starter-cache" }
+spring-boot-starter-actuator = { module = "org.springframework.boot:spring-boot-starter-actuator" }
+spring-boot-starter-mail = { module = "org.springframework.boot:spring-boot-starter-mail" }
+spring-boot-starter-flyway = { module = "org.springframework.boot:spring-boot-starter-flyway" }
+
+# Spring AI (versions managed by Spring AI BOM)
+spring-ai-starter-anthropic = { module = "org.springframework.ai:spring-ai-starter-model-anthropic" }
+spring-ai-starter-openai = { module = "org.springframework.ai:spring-ai-starter-model-openai" }
+spring-ai-starter-ollama = { module = "org.springframework.ai:spring-ai-starter-model-ollama" }
+spring-ai-starter-mcp-server = { module = "org.springframework.ai:spring-ai-starter-mcp-server-webmvc" }
+
+# Database
+postgresql = { module = "org.postgresql:postgresql" }
+flyway-postgresql = { module = "org.flywaydb:flyway-database-postgresql" }
+
+# Security - JWT
+jjwt-api = { module = "io.jsonwebtoken:jjwt-api", version.ref = "jjwt" }
+jjwt-impl = { module = "io.jsonwebtoken:jjwt-impl", version.ref = "jjwt" }
+jjwt-jackson = { module = "io.jsonwebtoken:jjwt-jackson", version.ref = "jjwt" }
+
+# API Documentation
+springdoc-openapi = { module = "org.springdoc:springdoc-openapi-starter-webmvc-ui", version.ref = "springdoc" }
+
+# Payments
+stripe = { module = "com.stripe:stripe-java", version.ref = "stripe" }
+
+# Image processing
+thumbnailator = { module = "net.coobird:thumbnailator", version.ref = "thumbnailator" }
+
+# PDF generation and QR codes
+pdfbox = { module = "org.apache.pdfbox:pdfbox", version.ref = "pdfbox" }
+zxing-core = { module = "com.google.zxing:core", version.ref = "zxing" }
+zxing-javase = { module = "com.google.zxing:javase", version.ref = "zxing" }
+
+# SMS delivery
+twilio = { module = "com.twilio.sdk:twilio", version.ref = "twilio" }
+
+# Data generation
+datafaker = { module = "net.datafaker:datafaker", version.ref = "datafaker" }
+
+# Testing (versions managed by Spring BOM)
+spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test" }
+spring-boot-starter-webmvc-test = { module = "org.springframework.boot:spring-boot-starter-webmvc-test" }
+spring-boot-starter-data-jpa-test = { module = "org.springframework.boot:spring-boot-starter-data-jpa-test" }
+spring-boot-starter-security-test = { module = "org.springframework.boot:spring-boot-starter-security-test" }
+spring-boot-resttestclient = { module = "org.springframework.boot:spring-boot-resttestclient" }
+spring-boot-testcontainers = { module = "org.springframework.boot:spring-boot-testcontainers" }
+testcontainers-junit-jupiter = { module = "org.testcontainers:testcontainers-junit-jupiter" }
+testcontainers-postgresql = { module = "org.testcontainers:testcontainers-postgresql" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+
+[plugins]
+spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }
+spring-dependency-management = { id = "io.spring.dependency-management", version.ref = "spring-dependency-management" }
+sonarqube = { id = "org.sonarqube", version.ref = "sonarqube" }
+spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }


### PR DESCRIPTION
## Summary
- Create `gradle/libs.versions.toml` centralizing all 33 dependency versions, library coordinates, and plugin versions
- Update `build.gradle.kts` to use catalog references (`libs.spring.boot.starter.webmvc`, `libs.plugins.spring.boot`, etc.)
- Tool versions (checkstyle, google-java-format) also pulled from the catalog via `libs.versions.checkstyle.get()`
- Spring AI BOM version referenced as `libs.versions.spring.ai.get()`

## Test plan
- [x] `./gradlew test` — all backend tests pass
- [x] Build resolves all dependencies correctly
- [x] No behavior change — purely structural

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)