### PR TITLE
Fix MCP stale session errors after Railway redeploy

### DIFF
--- a/backend/src/main/java/com/mockhub/mcp/McpSessionRecoveryFilter.java
+++ b/backend/src/main/java/com/mockhub/mcp/McpSessionRecoveryFilter.java
@@ -1,0 +1,74 @@
+package com.mockhub.mcp;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+/**
+ * Converts Spring AI's "Session not found" JSON-RPC errors to HTTP 404 responses.
+ *
+ * Spring AI 2.0.0-M3 returns session-not-found errors as HTTP 200 with a JSON-RPC
+ * error body. MCP clients (like mcp-remote) can't recover from this because they
+ * see a successful HTTP response with an opaque error payload.
+ *
+ * Per the MCP spec, an unknown session ID should return HTTP 404, which signals
+ * the client to discard the stale session and re-initialize. This filter wraps
+ * the response and converts session-not-found errors to proper 404 responses.
+ *
+ * This is needed because Railway (and similar platforms) redeploy containers,
+ * wiping Spring AI's in-memory session store while clients still hold old
+ * session IDs.
+ */
+@Component
+@ConditionalOnProperty(name = "mockhub.mcp.enabled", havingValue = "true")
+@Order(Ordered.HIGHEST_PRECEDENCE + 20)
+public class McpSessionRecoveryFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(McpSessionRecoveryFilter.class);
+    private static final String MCP_PATH_PREFIX = "/mcp/";
+    private static final String SESSION_NOT_FOUND = "Session not found";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String requestPath = request.getRequestURI();
+
+        if (!requestPath.startsWith(MCP_PATH_PREFIX)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        ContentCachingResponseWrapper wrappedResponse = new ContentCachingResponseWrapper(response);
+        filterChain.doFilter(request, wrappedResponse);
+
+        byte[] body = wrappedResponse.getContentAsByteArray();
+        if (body.length > 0 && wrappedResponse.getStatus() == 200) {
+            String responseBody = new String(body, wrappedResponse.getCharacterEncoding());
+            if (responseBody.contains(SESSION_NOT_FOUND)) {
+                log.warn("MCP session not found — returning 404 to trigger client re-initialization");
+                wrappedResponse.resetBuffer();
+                wrappedResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                wrappedResponse.setContentType("application/json");
+                wrappedResponse.getWriter().write(
+                        "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32600,\"message\":\"Session expired. Please reconnect.\"}}");
+                wrappedResponse.copyBodyToResponse();
+                return;
+            }
+        }
+
+        wrappedResponse.copyBodyToResponse();
+    }
+}

--- a/backend/src/test/java/com/mockhub/mcp/McpSessionRecoveryFilterTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/McpSessionRecoveryFilterTest.java
@@ -1,0 +1,103 @@
+package com.mockhub.mcp;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+class McpSessionRecoveryFilterTest {
+
+    private final McpSessionRecoveryFilter filter = new McpSessionRecoveryFilter();
+
+    @Test
+    @DisplayName("doFilter - given session-not-found response - returns 404")
+    void doFilter_givenSessionNotFoundResponse_returns404() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/mcp/");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        FilterChain chain = (req, res) -> {
+            HttpServletResponse httpResponse = (HttpServletResponse) res;
+            httpResponse.setStatus(200);
+            httpResponse.setContentType("application/json");
+            PrintWriter writer = httpResponse.getWriter();
+            writer.write("{\"jsonRpcError\":{\"code\":-32603,\"message\":\"Session not found: abc-123\"}}");
+            writer.flush();
+        };
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertEquals(404, response.getStatus());
+        assertTrue(response.getContentAsString().contains("Session expired"));
+    }
+
+    @Test
+    @DisplayName("doFilter - given normal MCP response - passes through unchanged")
+    void doFilter_givenNormalResponse_passesThroughUnchanged() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/mcp/");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        FilterChain chain = (req, res) -> {
+            HttpServletResponse httpResponse = (HttpServletResponse) res;
+            httpResponse.setStatus(200);
+            httpResponse.setContentType("application/json");
+            PrintWriter writer = httpResponse.getWriter();
+            writer.write("{\"jsonrpc\":\"2.0\",\"result\":{\"tools\":[]},\"id\":1}");
+            writer.flush();
+        };
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+        assertTrue(response.getContentAsString().contains("tools"));
+    }
+
+    @Test
+    @DisplayName("doFilter - given non-MCP path - skips filter entirely")
+    void doFilter_givenNonMcpPath_skipsFilter() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/v1/events");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        FilterChain chain = (req, res) -> {
+            HttpServletResponse httpResponse = (HttpServletResponse) res;
+            httpResponse.setStatus(200);
+        };
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertEquals(200, response.getStatus());
+    }
+
+    @Test
+    @DisplayName("doFilter - given non-200 MCP response - passes through unchanged")
+    void doFilter_givenNon200Response_passesThroughUnchanged() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/mcp/");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        FilterChain chain = (req, res) -> {
+            HttpServletResponse httpResponse = (HttpServletResponse) res;
+            httpResponse.setStatus(401);
+            httpResponse.setContentType("application/json");
+            PrintWriter writer = httpResponse.getWriter();
+            writer.write("{\"error\":\"Unauthorized\"}");
+            writer.flush();
+        };
+
+        filter.doFilterInternal(request, response, chain);
+
+        assertEquals(401, response.getStatus());
+    }
+}


### PR DESCRIPTION
## Summary

- **New `McpSessionRecoveryFilter`**: Intercepts Spring AI's "Session not found" JSON-RPC errors (returned as HTTP 200) and converts them to HTTP 404 responses per the MCP spec
- This enables MCP clients (like `mcp-remote`) to detect stale sessions and re-initialize automatically after Railway container redeploys

## Problem

Spring AI 2.0.0-M3 stores MCP sessions in memory. When Railway redeploys, all sessions are lost. Clients that hold old session IDs get back HTTP 200 with a JSON-RPC error body — they can't distinguish this from a real response and report it as a timeout.

The MCP spec says unknown session IDs should return HTTP 404, which is a signal to the client to reconnect. Spring AI doesn't do this yet (milestone release), so this filter bridges the gap.

## Also

Updated Claude Desktop config to use custom domain (`mockhub.kousenit.com` instead of `mockhub-production.up.railway.app`).

## Test plan

- [x] Unit tests for filter: session-not-found → 404, normal response passthrough, non-MCP path skip, non-200 passthrough
- [x] Full backend test suite passes
- [ ] Deploy to Railway, restart Claude Desktop MCP, verify tools respond
- [ ] Trigger a redeploy and verify Claude Desktop recovers without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)