### PR TITLE
Fix calendar LazyInitializationException and reset seed account PII

### DIFF
--- a/backend/src/main/java/com/mockhub/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/mockhub/common/exception/GlobalExceptionHandler.java
@@ -12,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -48,8 +49,8 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ProblemDetail> handleGeneral(Exception ex) {
-        log.error("Unhandled exception", ex);
+    public ResponseEntity<ProblemDetail> handleGeneral(Exception ex, WebRequest request) {
+        log.error("Unhandled exception on {}: {}", request.getDescription(false), ex.getMessage(), ex);
 
         ProblemDetail problem = ProblemDetail.forStatusAndDetail(
                 HttpStatus.INTERNAL_SERVER_ERROR, "An unexpected error occurred");

--- a/backend/src/main/java/com/mockhub/mcp/tools/OrderTools.java
+++ b/backend/src/main/java/com/mockhub/mcp/tools/OrderTools.java
@@ -197,7 +197,7 @@ public class OrderTools {
             }
             User user = resolveUser(userEmail);
             orderService.getOrder(user, orderNumber.strip()); // auth check
-            Order order = orderService.getOrderEntity(orderNumber.strip());
+            Order order = orderService.getOrderEntityWithItems(orderNumber.strip());
             return calendarService.generateIcs(order);
         } catch (Exception e) {
             log.error("Error generating calendar for order '{}': {}", orderNumber, e.getMessage(), e);

--- a/backend/src/main/java/com/mockhub/order/controller/OrderController.java
+++ b/backend/src/main/java/com/mockhub/order/controller/OrderController.java
@@ -95,7 +95,7 @@ public class OrderController {
             @PathVariable String orderNumber) {
         User user = resolveUser(securityUser);
         orderService.getOrder(user, orderNumber); // auth check — throws if not owner
-        com.mockhub.order.entity.Order orderEntity = orderService.getOrderEntity(orderNumber);
+        com.mockhub.order.entity.Order orderEntity = orderService.getOrderEntityWithItems(orderNumber);
         String ics = calendarService.generateIcs(orderEntity);
 
         String filename = "mockhub-" + orderNumber + ".ics";

--- a/backend/src/main/java/com/mockhub/order/repository/OrderRepository.java
+++ b/backend/src/main/java/com/mockhub/order/repository/OrderRepository.java
@@ -21,6 +21,9 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
 
     Optional<Order> findByOrderNumber(String orderNumber);
 
+    @Query("SELECT o FROM Order o JOIN FETCH o.items i JOIN FETCH i.listing l JOIN FETCH l.event e JOIN FETCH e.venue WHERE o.orderNumber = :orderNumber")
+    Optional<Order> findByOrderNumberWithItems(@Param("orderNumber") String orderNumber);
+
     Optional<Order> findByIdempotencyKey(String idempotencyKey);
 
     Optional<Order> findByPaymentIntentId(String paymentIntentId);

--- a/backend/src/main/java/com/mockhub/order/service/OrderService.java
+++ b/backend/src/main/java/com/mockhub/order/service/OrderService.java
@@ -243,6 +243,12 @@ public class OrderService {
                 .orElseThrow(() -> new ResourceNotFoundException(ORDER_RESOURCE, ORDER_NUMBER_FIELD, orderNumber));
     }
 
+    @Transactional(readOnly = true)
+    public Order getOrderEntityWithItems(String orderNumber) {
+        return orderRepository.findByOrderNumberWithItems(orderNumber)
+                .orElseThrow(() -> new ResourceNotFoundException(ORDER_RESOURCE, ORDER_NUMBER_FIELD, orderNumber));
+    }
+
     @Transactional
     public Order getOrderEntityByPaymentIntentId(String paymentIntentId) {
         return orderRepository.findByPaymentIntentId(paymentIntentId)

--- a/backend/src/main/java/com/mockhub/seed/UserSeeder.java
+++ b/backend/src/main/java/com/mockhub/seed/UserSeeder.java
@@ -1,6 +1,7 @@
 package com.mockhub.seed;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -37,7 +38,8 @@ public class UserSeeder {
     @Transactional
     public void seed() {
         if (userRepository.existsByEmail("admin@mockhub.com")) {
-            log.info("Users already seeded, skipping");
+            log.info("Users already seeded, resetting seed account fields");
+            resetSeedAccounts();
             return;
         }
 
@@ -75,6 +77,28 @@ public class UserSeeder {
         }
 
         log.info("Seeded 8 users (admin, buyer, seller, 5 random)");
+    }
+
+    private static final Map<String, String> SEED_ACCOUNT_PHONES = Map.of(
+            "admin@mockhub.com", "555-0100",
+            "buyer@mockhub.com", "555-0101",
+            "seller@mockhub.com", "555-0102"
+    );
+
+    private void resetSeedAccounts() {
+        SEED_ACCOUNT_PHONES.forEach((email, phone) ->
+                userRepository.findByEmail(email).ifPresent(user -> {
+                    boolean changed = false;
+                    if (!phone.equals(user.getPhone())) {
+                        user.setPhone(phone);
+                        changed = true;
+                    }
+                    if (changed) {
+                        userRepository.save(user);
+                        log.info("Reset seed account {} to default phone", email);
+                    }
+                })
+        );
     }
 
     private void createUser(String email, String password, String firstName,

--- a/backend/src/test/java/com/mockhub/common/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/mockhub/common/exception/GlobalExceptionHandlerTest.java
@@ -6,9 +6,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.WebRequest;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 class GlobalExceptionHandlerTest {
 
@@ -75,6 +78,23 @@ class GlobalExceptionHandlerTest {
         assertNotNull(body);
         assertEquals(401, body.getStatus());
         assertEquals("Unauthorized", body.getTitle());
+    }
+
+    @Test
+    @DisplayName("handleGeneral - returns 500 ProblemDetail with generic message")
+    void handleGeneral_returns500ProblemDetail() {
+        WebRequest request = mock(WebRequest.class);
+        when(request.getDescription(false)).thenReturn("uri=/api/v1/orders/MH-20260328-0001/calendar");
+        RuntimeException ex = new RuntimeException("Something broke");
+
+        ResponseEntity<ProblemDetail> response = handler.handleGeneral(ex, request);
+
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        ProblemDetail body = response.getBody();
+        assertNotNull(body);
+        assertEquals(500, body.getStatus());
+        assertEquals("Internal Server Error", body.getTitle());
+        assertEquals("An unexpected error occurred", body.getDetail());
     }
 
     @Test

--- a/backend/src/test/java/com/mockhub/mcp/tools/OrderToolsTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/tools/OrderToolsTest.java
@@ -521,7 +521,7 @@ class OrderToolsTest {
             when(orderService.getOrder(testUser, "MH-20260326-0001")).thenReturn(orderDto);
             Order order = new Order();
             order.setOrderNumber("MH-20260326-0001");
-            when(orderService.getOrderEntity("MH-20260326-0001")).thenReturn(order);
+            when(orderService.getOrderEntityWithItems("MH-20260326-0001")).thenReturn(order);
             when(calendarService.generateIcs(order)).thenReturn("BEGIN:VCALENDAR\r\nEND:VCALENDAR\r\n");
 
             String result = orderTools.getCalendarEntry("buyer@example.com", "MH-20260326-0001");

--- a/backend/src/test/java/com/mockhub/order/service/OrderServiceTest.java
+++ b/backend/src/test/java/com/mockhub/order/service/OrderServiceTest.java
@@ -470,4 +470,26 @@ class OrderServiceTest {
         assertNotNull(result, "Paged response should not be null");
         assertEquals(1, result.content().size(), "Should contain one order");
     }
+
+    @Test
+    @DisplayName("getOrderEntityWithItems - given existing order - returns order")
+    void getOrderEntityWithItems_givenExistingOrder_returnsOrder() {
+        when(orderRepository.findByOrderNumberWithItems("MH-20260317-0001"))
+                .thenReturn(Optional.of(testOrder));
+
+        Order result = orderService.getOrderEntityWithItems("MH-20260317-0001");
+
+        assertNotNull(result);
+        assertEquals("MH-20260317-0001", result.getOrderNumber());
+    }
+
+    @Test
+    @DisplayName("getOrderEntityWithItems - given missing order - throws ResourceNotFoundException")
+    void getOrderEntityWithItems_givenMissingOrder_throwsResourceNotFoundException() {
+        when(orderRepository.findByOrderNumberWithItems("MH-MISSING"))
+                .thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> orderService.getOrderEntityWithItems("MH-MISSING"));
+    }
 }

--- a/backend/src/test/java/com/mockhub/seed/UserSeederTest.java
+++ b/backend/src/test/java/com/mockhub/seed/UserSeederTest.java
@@ -1,0 +1,94 @@
+package com.mockhub.seed;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.mockhub.auth.entity.User;
+import com.mockhub.auth.repository.RoleRepository;
+import com.mockhub.auth.repository.UserRepository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserSeederTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RoleRepository roleRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserSeeder userSeeder;
+
+    @BeforeEach
+    void setUp() {
+        // Common setup if needed
+    }
+
+    @Test
+    @DisplayName("seed - given existing users with modified phone - resets to default")
+    void seed_givenExistingUsersWithModifiedPhone_resetsToDefault() {
+        when(userRepository.existsByEmail("admin@mockhub.com")).thenReturn(true);
+
+        User buyer = new User();
+        buyer.setEmail("buyer@mockhub.com");
+        buyer.setPhone("+18605551234"); // modified from default
+        when(userRepository.findByEmail("buyer@mockhub.com")).thenReturn(Optional.of(buyer));
+
+        User admin = new User();
+        admin.setEmail("admin@mockhub.com");
+        admin.setPhone("555-0100"); // unchanged
+        when(userRepository.findByEmail("admin@mockhub.com")).thenReturn(Optional.of(admin));
+
+        User seller = new User();
+        seller.setEmail("seller@mockhub.com");
+        seller.setPhone("555-0102"); // unchanged
+        when(userRepository.findByEmail("seller@mockhub.com")).thenReturn(Optional.of(seller));
+
+        userSeeder.seed();
+
+        verify(userRepository).save(buyer);
+        assertEquals("555-0101", buyer.getPhone());
+    }
+
+    @Test
+    @DisplayName("seed - given existing users with default phone - does not save")
+    void seed_givenExistingUsersWithDefaultPhone_doesNotSave() {
+        when(userRepository.existsByEmail("admin@mockhub.com")).thenReturn(true);
+
+        User buyer = new User();
+        buyer.setEmail("buyer@mockhub.com");
+        buyer.setPhone("555-0101"); // already default
+        when(userRepository.findByEmail("buyer@mockhub.com")).thenReturn(Optional.of(buyer));
+
+        User admin = new User();
+        admin.setEmail("admin@mockhub.com");
+        admin.setPhone("555-0100");
+        when(userRepository.findByEmail("admin@mockhub.com")).thenReturn(Optional.of(admin));
+
+        User seller = new User();
+        seller.setEmail("seller@mockhub.com");
+        seller.setPhone("555-0102");
+        when(userRepository.findByEmail("seller@mockhub.com")).thenReturn(Optional.of(seller));
+
+        userSeeder.seed();
+
+        verify(userRepository, never()).save(any(User.class));
+    }
+}


### PR DESCRIPTION
## Summary

- **Fix #99**: Calendar endpoint (`GET /api/v1/orders/{orderNumber}/calendar`) threw `LazyInitializationException` because `order.items` was lazily loaded but accessed outside a Hibernate session. Added a fetch join query (`findByOrderNumberWithItems`) that eagerly loads the full object graph. Fixed in both `OrderController` and `OrderTools` (MCP).
- **Fix #100**: Seed accounts (`buyer@mockhub.com`, etc.) retained real PII (phone numbers) across Railway redeploys. `UserSeeder` now resets seed account phone numbers to fake `555-*` values on every startup.
- **Improved error logging**: `GlobalExceptionHandler` now logs the request URI on unhandled exceptions for easier production triage.

## Test plan

- [x] `OrderServiceTest` — 2 new tests for `getOrderEntityWithItems` (found + not found)
- [x] `UserSeederTest` — 2 new tests (reset modified phone, skip unchanged phone)
- [x] `GlobalExceptionHandlerTest` — 1 new test for `handleGeneral` with `WebRequest`
- [x] `OrderToolsTest` — updated mock to use `getOrderEntityWithItems`
- [x] Full backend suite: 642 tests passing
- [x] Full frontend suite: 114 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)