### PR TITLE
Add MCP tool timing instrumentation via AOP

### DIFF
--- a/backend/src/main/java/com/mockhub/mcp/config/ToolTimingAspect.java
+++ b/backend/src/main/java/com/mockhub/mcp/config/ToolTimingAspect.java
@@ -1,0 +1,33 @@
+package com.mockhub.mcp.config;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class ToolTimingAspect {
+
+    private static final Logger log = LoggerFactory.getLogger(ToolTimingAspect.class);
+
+    @Around("@annotation(org.springframework.ai.tool.annotation.Tool)")
+    public Object timeToolExecution(ProceedingJoinPoint joinPoint) throws Throwable {
+        String toolName = joinPoint.getSignature().getName();
+        String className = joinPoint.getTarget().getClass().getSimpleName();
+        long start = System.currentTimeMillis();
+
+        try {
+            Object result = joinPoint.proceed();
+            long elapsed = System.currentTimeMillis() - start;
+            log.info("MCP tool {}.{} completed in {}ms", className, toolName, elapsed);
+            return result;
+        } catch (Throwable e) {
+            long elapsed = System.currentTimeMillis() - start;
+            log.warn("MCP tool {}.{} failed in {}ms: {}", className, toolName, elapsed, e.getMessage());
+            throw e;
+        }
+    }
+}

--- a/backend/src/test/java/com/mockhub/mcp/config/ToolTimingAspectTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/config/ToolTimingAspectTest.java
@@ -1,0 +1,50 @@
+package com.mockhub.mcp.config;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.Signature;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ToolTimingAspectTest {
+
+    private ToolTimingAspect aspect;
+
+    @BeforeEach
+    void setUp() {
+        aspect = new ToolTimingAspect();
+    }
+
+    @Test
+    @DisplayName("timeToolExecution - given successful tool call - returns result and logs timing")
+    void timeToolExecution_givenSuccessfulCall_returnsResult() throws Throwable {
+        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+        Signature signature = mock(Signature.class);
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.getName()).thenReturn("findTickets");
+        when(joinPoint.getTarget()).thenReturn(new Object() {});
+        when(joinPoint.proceed()).thenReturn("result-json");
+
+        Object result = aspect.timeToolExecution(joinPoint);
+
+        assertEquals("result-json", result);
+    }
+
+    @Test
+    @DisplayName("timeToolExecution - given failing tool call - rethrows exception and logs timing")
+    void timeToolExecution_givenFailingCall_rethrowsException() throws Throwable {
+        ProceedingJoinPoint joinPoint = mock(ProceedingJoinPoint.class);
+        Signature signature = mock(Signature.class);
+        when(joinPoint.getSignature()).thenReturn(signature);
+        when(signature.getName()).thenReturn("addToCart");
+        when(joinPoint.getTarget()).thenReturn(new Object() {});
+        when(joinPoint.proceed()).thenThrow(new RuntimeException("DB connection failed"));
+
+        assertThrows(RuntimeException.class, () -> aspect.timeToolExecution(joinPoint));
+    }
+}


### PR DESCRIPTION
## Summary

- AOP aspect (`ToolTimingAspect`) intercepts all `@Tool`-annotated MCP methods and logs execution time in milliseconds
- INFO level for successful calls, WARN for failures — both include class name, method name, and elapsed time
- Zero changes to existing tool classes — pure cross-cutting concern
- Provides profiling data for #86 (MCP response time optimization)

Example log output:
```
MCP tool EventTools.findTickets completed in 142ms
MCP tool CartTools.addToCart completed in 38ms
MCP tool OrderTools.confirmOrder completed in 215ms
```

## Test plan

- [x] Unit tests for success and failure paths
- [x] Full backend suite passing

Related to #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)