### PR TITLE
Fix OAuth code leak, Spotify ID validation, and iframe URL encoding

### DIFF
--- a/backend/src/main/java/com/mockhub/auth/security/OAuth2AuthenticationSuccessHandler.java
+++ b/backend/src/main/java/com/mockhub/auth/security/OAuth2AuthenticationSuccessHandler.java
@@ -213,9 +213,15 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
                 roles, user.getCreatedAt());
     }
 
-    private void cleanupExpired() {
+    @org.springframework.scheduling.annotation.Scheduled(fixedRateString = "${mockhub.oauth2.cleanup-interval-ms:300000}")
+    void cleanupExpired() {
+        int sizeBefore = pendingAuths.size();
         Instant now = Instant.now();
         pendingAuths.entrySet().removeIf(entry -> now.isAfter(entry.getValue().expiry()));
+        int removed = sizeBefore - pendingAuths.size();
+        if (removed > 0) {
+            log.info("Cleaned up {} expired OAuth pending auth codes", removed);
+        }
     }
 
     record PendingAuth(AuthResponse authResponse, String refreshToken, Instant expiry) {

--- a/backend/src/main/java/com/mockhub/event/dto/EventCreateRequest.java
+++ b/backend/src/main/java/com/mockhub/event/dto/EventCreateRequest.java
@@ -7,6 +7,7 @@ import java.util.List;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 
 @Schema(description = "Request to create or update an event")
@@ -42,6 +43,7 @@ public record EventCreateRequest(
         List<Long> tagIds,
         @Schema(description = "Whether this event is featured on the homepage")
         Boolean isFeatured,
+        @Pattern(regexp = "^[a-zA-Z0-9]{22}$", message = "Invalid Spotify artist ID format")
         @Schema(description = "Spotify artist ID for 'Listen on Spotify' link", example = "06HL4z0CvFAxyc27GXpf02")
         String spotifyArtistId
 ) {

--- a/backend/src/main/java/com/mockhub/spotify/service/SpotifyApiService.java
+++ b/backend/src/main/java/com/mockhub/spotify/service/SpotifyApiService.java
@@ -37,6 +37,8 @@ public class SpotifyApiService implements SpotifyService {
     private static final int MAX_RETRIES = 3;
     private static final long BASE_BACKOFF_MS = 1000;
     private static final String SANITIZE_PATTERN = "[\\r\\n]";
+    private static final java.util.regex.Pattern SPOTIFY_ID_PATTERN =
+            java.util.regex.Pattern.compile("^[a-zA-Z0-9]{22}$");
 
     private final RestClient authClient;
     private final RestClient apiClient;
@@ -72,6 +74,12 @@ public class SpotifyApiService implements SpotifyService {
 
     @Override
     public Optional<SpotifyArtistDto> getArtist(String spotifyArtistId) {
+        if (spotifyArtistId == null || !SPOTIFY_ID_PATTERN.matcher(spotifyArtistId).matches()) {
+            log.warn("Invalid Spotify artist ID format: {}",
+                    spotifyArtistId != null ? spotifyArtistId.replaceAll(SANITIZE_PATTERN, "") : "null");
+            return Optional.empty();
+        }
+
         CachedArtist cached = artistCache.get(spotifyArtistId);
         if (cached != null && Instant.now().isBefore(cached.expiry())) {
             log.debug("Spotify artist cache hit for {}", spotifyArtistId);

--- a/backend/src/test/java/com/mockhub/auth/security/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/backend/src/test/java/com/mockhub/auth/security/OAuth2AuthenticationSuccessHandlerTest.java
@@ -383,4 +383,78 @@ class OAuth2AuthenticationSuccessHandlerTest {
             assertNull(second, "Second exchange should return null (code already consumed)");
         }
     }
+
+    @Nested
+    @DisplayName("cleanupExpired")
+    class CleanupExpired {
+
+        @Test
+        @DisplayName("removes expired pending auth codes")
+        void cleanupExpired_removesExpiredCodes() throws IOException {
+            stubForSuccessfulLogin();
+
+            handler.onAuthenticationSuccess(request, response, createGoogleToken());
+            String redirectUrl = response.getRedirectedUrl();
+            assertNotNull(redirectUrl);
+            String code = redirectUrl.substring(redirectUrl.indexOf("code=") + 5);
+
+            // Simulate expiry by exchanging after TTL would have passed
+            // The cleanupExpired method is called internally by exchangeCode
+            // Verify the code is valid right now
+            AuthResponse result = handler.exchangeCode(code);
+            assertNotNull(result, "Code should be valid immediately after creation");
+        }
+
+        @Test
+        @DisplayName("scheduled cleanup can be called without errors when map is empty")
+        void cleanupExpired_emptyMap_noErrors() {
+            handler.cleanupExpired();
+            // No exception means success
+        }
+
+        @Test
+        @DisplayName("scheduled cleanup removes expired entries and logs count")
+        void cleanupExpired_withExpiredEntries_removesAndLogs() throws Exception {
+            // Use reflection to insert an already-expired entry into pendingAuths
+            java.lang.reflect.Field field =
+                    OAuth2AuthenticationSuccessHandler.class.getDeclaredField("pendingAuths");
+            field.setAccessible(true);
+            @SuppressWarnings("unchecked")
+            Map<String, ?> map = (Map<String, ?>) field.get(handler);
+
+            // Create an expired PendingAuth via the record constructor
+            Class<?> pendingAuthClass = Class.forName(
+                    "com.mockhub.auth.security.OAuth2AuthenticationSuccessHandler$PendingAuth");
+            java.lang.reflect.Constructor<?> constructor = pendingAuthClass.getDeclaredConstructors()[0];
+            constructor.setAccessible(true);
+            Object expiredEntry = constructor.newInstance(null, null, Instant.now().minusSeconds(60));
+
+            @SuppressWarnings("unchecked")
+            Map<String, Object> rawMap = (Map<String, Object>) map;
+            rawMap.put("expired-code", expiredEntry);
+
+            assertEquals(1, rawMap.size(), "Map should have 1 entry before cleanup");
+
+            handler.cleanupExpired();
+
+            assertEquals(0, rawMap.size(), "Expired entry should be removed");
+        }
+    }
+
+    private void stubForSuccessfulLogin() {
+        when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.of(testUser));
+        when(oAuthAccountRepository.existsByUserIdAndProvider(1L, "google")).thenReturn(true);
+        when(userRepository.save(any(User.class))).thenReturn(testUser);
+        when(jwtTokenProvider.generateAccessToken(any(SecurityUser.class))).thenReturn("access-token");
+        when(jwtTokenProvider.generateRefreshToken(any(SecurityUser.class))).thenReturn("refresh-token");
+        when(jwtTokenProvider.getAccessTokenExpirationMs()).thenReturn(3600000L);
+    }
+
+    private OAuth2AuthenticationToken createGoogleToken() {
+        OAuth2User oauth2User = new DefaultOAuth2User(
+                List.of(() -> "ROLE_USER"),
+                Map.of("email", "user@example.com", "sub", "google-123", "name", "John Doe"),
+                "email");
+        return new OAuth2AuthenticationToken(oauth2User, oauth2User.getAuthorities(), "google");
+    }
 }

--- a/backend/src/test/java/com/mockhub/spotify/service/SpotifyApiServiceTest.java
+++ b/backend/src/test/java/com/mockhub/spotify/service/SpotifyApiServiceTest.java
@@ -31,6 +31,15 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 class SpotifyApiServiceTest {
 
+    // Valid 22-char base62 Spotify IDs for tests
+    private static final String ARTIST_ID_1 = "1aB2cD3eF4gH5iJ6kL7mN8";
+    private static final String ARTIST_ID_2 = "2bC3dE4fG5hI6jK7lM8nO9";
+    private static final String ARTIST_ID_3 = "3cD4eF5gH6iJ7kL8mN9oP0";
+    private static final String ARTIST_ID_4 = "4dE5fG6hI7jK8lM9nO0pQ1";
+    private static final String ARTIST_ID_5 = "5eF6gH7iJ8kL9mN0oP1qR2";
+    private static final String ARTIST_ID_6 = "6fG7hI8jK9lM0nO1pQ2rS3";
+    private static final String ARTIST_ID_7 = "7gH8iJ9kL0mN1oP2qR3sT4";
+
     private MockRestServiceServer authServer;
     private MockRestServiceServer apiServer;
     private SpotifyApiService service;
@@ -52,11 +61,11 @@ class SpotifyApiServiceTest {
     @DisplayName("getArtist - given valid artist ID - returns artist metadata")
     void getArtist_givenValidArtistId_returnsArtistMetadata() {
         stubTokenResponse();
-        apiServer.expect(requestTo("https://api.spotify.com/v1/artists/abc123"))
+        apiServer.expect(requestTo("https://api.spotify.com/v1/artists/" + ARTIST_ID_1))
                 .andExpect(header("Authorization", "Bearer mock-access-token"))
                 .andRespond(withSuccess("""
                         {
-                            "id": "abc123",
+                            "id": "%s",
                             "name": "Test Artist",
                             "genres": ["rock", "indie"],
                             "followers": { "total": 500000 },
@@ -65,13 +74,13 @@ class SpotifyApiServiceTest {
                                 { "url": "https://img.spotify.com/small.jpg", "height": 64, "width": 64 }
                             ]
                         }
-                        """, MediaType.APPLICATION_JSON));
+                        """.formatted(ARTIST_ID_1), MediaType.APPLICATION_JSON));
 
-        Optional<SpotifyArtistDto> result = service.getArtist("abc123");
+        Optional<SpotifyArtistDto> result = service.getArtist(ARTIST_ID_1);
 
         assertTrue(result.isPresent());
         SpotifyArtistDto artist = result.get();
-        assertEquals("abc123", artist.id());
+        assertEquals(ARTIST_ID_1, artist.id());
         assertEquals("Test Artist", artist.name());
         assertEquals(List.of("rock", "indie"), artist.genres());
         assertEquals(500000, artist.followers());
@@ -82,10 +91,10 @@ class SpotifyApiServiceTest {
     @DisplayName("getArtist - given 404 from Spotify - returns empty")
     void getArtist_given404FromSpotify_returnsEmpty() {
         stubTokenResponse();
-        apiServer.expect(requestTo("https://api.spotify.com/v1/artists/bad-id"))
+        apiServer.expect(requestTo("https://api.spotify.com/v1/artists/" + ARTIST_ID_2))
                 .andRespond(withResourceNotFound());
 
-        Optional<SpotifyArtistDto> result = service.getArtist("bad-id");
+        Optional<SpotifyArtistDto> result = service.getArtist(ARTIST_ID_2);
 
         assertFalse(result.isPresent());
     }
@@ -94,30 +103,30 @@ class SpotifyApiServiceTest {
     @DisplayName("getArtist - given 500 from Spotify - throws RestClientException")
     void getArtist_given500FromSpotify_throwsRestClientException() {
         stubTokenResponse();
-        apiServer.expect(requestTo("https://api.spotify.com/v1/artists/error-id"))
+        apiServer.expect(requestTo("https://api.spotify.com/v1/artists/" + ARTIST_ID_3))
                 .andRespond(withServerError());
 
-        assertThrows(RestClientException.class, () -> service.getArtist("error-id"));
+        assertThrows(RestClientException.class, () -> service.getArtist(ARTIST_ID_3));
     }
 
     @Test
     @DisplayName("getArtist - given cached artist - does not call API again")
     void getArtist_givenCachedArtist_doesNotCallApiAgain() {
         stubTokenResponse();
-        apiServer.expect(requestTo("https://api.spotify.com/v1/artists/cached123"))
+        apiServer.expect(requestTo("https://api.spotify.com/v1/artists/" + ARTIST_ID_4))
                 .andRespond(withSuccess("""
                         {
-                            "id": "cached123",
+                            "id": "%s",
                             "name": "Cached Artist",
                             "genres": ["pop"],
                             "followers": { "total": 100 },
                             "images": []
                         }
-                        """, MediaType.APPLICATION_JSON));
+                        """.formatted(ARTIST_ID_4), MediaType.APPLICATION_JSON));
 
-        service.getArtist("cached123");
+        service.getArtist(ARTIST_ID_4);
         // Second call should use cache, not hit the server
-        Optional<SpotifyArtistDto> result = service.getArtist("cached123");
+        Optional<SpotifyArtistDto> result = service.getArtist(ARTIST_ID_4);
 
         assertTrue(result.isPresent());
         assertEquals("Cached Artist", result.get().name());
@@ -129,18 +138,18 @@ class SpotifyApiServiceTest {
     @DisplayName("getArtist - given artist with null genres and followers - handles gracefully")
     void getArtist_givenArtistWithNullFields_handlesGracefully() {
         stubTokenResponse();
-        apiServer.expect(requestTo("https://api.spotify.com/v1/artists/minimal"))
+        apiServer.expect(requestTo("https://api.spotify.com/v1/artists/" + ARTIST_ID_5))
                 .andRespond(withSuccess("""
                         {
-                            "id": "minimal",
+                            "id": "%s",
                             "name": "Minimal Artist",
                             "genres": null,
                             "followers": null,
                             "images": null
                         }
-                        """, MediaType.APPLICATION_JSON));
+                        """.formatted(ARTIST_ID_5), MediaType.APPLICATION_JSON));
 
-        Optional<SpotifyArtistDto> result = service.getArtist("minimal");
+        Optional<SpotifyArtistDto> result = service.getArtist(ARTIST_ID_5);
 
         assertTrue(result.isPresent());
         SpotifyArtistDto artist = result.get();
@@ -154,17 +163,17 @@ class SpotifyApiServiceTest {
     @DisplayName("getArtist - reuses token for second call")
     void getArtist_reusesTokenForSecondCall() {
         stubTokenResponse();
-        apiServer.expect(requestTo("https://api.spotify.com/v1/artists/first"))
+        apiServer.expect(requestTo("https://api.spotify.com/v1/artists/" + ARTIST_ID_6))
                 .andRespond(withSuccess("""
-                        { "id": "first", "name": "First", "genres": [], "followers": { "total": 1 }, "images": [] }
-                        """, MediaType.APPLICATION_JSON));
-        apiServer.expect(requestTo("https://api.spotify.com/v1/artists/second"))
+                        { "id": "%s", "name": "First", "genres": [], "followers": { "total": 1 }, "images": [] }
+                        """.formatted(ARTIST_ID_6), MediaType.APPLICATION_JSON));
+        apiServer.expect(requestTo("https://api.spotify.com/v1/artists/" + ARTIST_ID_7))
                 .andRespond(withSuccess("""
-                        { "id": "second", "name": "Second", "genres": [], "followers": { "total": 2 }, "images": [] }
-                        """, MediaType.APPLICATION_JSON));
+                        { "id": "%s", "name": "Second", "genres": [], "followers": { "total": 2 }, "images": [] }
+                        """.formatted(ARTIST_ID_7), MediaType.APPLICATION_JSON));
 
-        service.getArtist("first");
-        Optional<SpotifyArtistDto> result = service.getArtist("second");
+        service.getArtist(ARTIST_ID_6);
+        Optional<SpotifyArtistDto> result = service.getArtist(ARTIST_ID_7);
 
         assertTrue(result.isPresent());
         assertEquals("Second", result.get().name());
@@ -202,14 +211,14 @@ class SpotifyApiServiceTest {
                     .andRespond(withSuccess("""
                             { "access_token": "token", "token_type": "bearer", "expires_in": 3600 }
                             """, MediaType.APPLICATION_JSON));
-            retryApiServer.expect(requestTo("https://api.spotify.com/v1/artists/retry-id"))
+            retryApiServer.expect(requestTo("https://api.spotify.com/v1/artists/" + ARTIST_ID_1))
                     .andRespond(withTooManyRequests());
-            retryApiServer.expect(requestTo("https://api.spotify.com/v1/artists/retry-id"))
+            retryApiServer.expect(requestTo("https://api.spotify.com/v1/artists/" + ARTIST_ID_1))
                     .andRespond(withSuccess("""
-                            { "id": "retry-id", "name": "Retried Artist", "genres": ["pop"], "followers": { "total": 100 }, "images": [] }
-                            """, MediaType.APPLICATION_JSON));
+                            { "id": "%s", "name": "Retried Artist", "genres": ["pop"], "followers": { "total": 100 }, "images": [] }
+                            """.formatted(ARTIST_ID_1), MediaType.APPLICATION_JSON));
 
-            Optional<SpotifyArtistDto> result = retryService.getArtist("retry-id");
+            Optional<SpotifyArtistDto> result = retryService.getArtist(ARTIST_ID_1);
 
             assertTrue(result.isPresent());
             assertEquals("Retried Artist", result.get().name());
@@ -223,11 +232,11 @@ class SpotifyApiServiceTest {
                             { "access_token": "token", "token_type": "bearer", "expires_in": 3600 }
                             """, MediaType.APPLICATION_JSON));
             for (int i = 0; i <= 3; i++) {
-                retryApiServer.expect(requestTo("https://api.spotify.com/v1/artists/stuck-id"))
+                retryApiServer.expect(requestTo("https://api.spotify.com/v1/artists/" + ARTIST_ID_2))
                         .andRespond(withTooManyRequests());
             }
 
-            assertThrows(RestClientException.class, () -> retryService.getArtist("stuck-id"));
+            assertThrows(RestClientException.class, () -> retryService.getArtist(ARTIST_ID_2));
         }
     }
 
@@ -274,6 +283,64 @@ class SpotifyApiServiceTest {
         assertThrows(RestClientException.class, () -> service.sleep(100));
         // Clear the interrupt flag for test cleanup
         Thread.interrupted();
+    }
+
+    @Nested
+    @DisplayName("getArtist - ID format validation")
+    class ArtistIdValidation {
+
+        @Test
+        @DisplayName("given null ID - returns empty")
+        void givenNullId_returnsEmpty() {
+            Optional<SpotifyArtistDto> result = service.getArtist(null);
+
+            assertTrue(result.isEmpty(), "Null ID should return empty");
+        }
+
+        @Test
+        @DisplayName("given too short ID - returns empty")
+        void givenTooShortId_returnsEmpty() {
+            Optional<SpotifyArtistDto> result = service.getArtist("abc123");
+
+            assertTrue(result.isEmpty(), "Short ID should return empty");
+        }
+
+        @Test
+        @DisplayName("given ID with special characters - returns empty")
+        void givenIdWithSpecialChars_returnsEmpty() {
+            Optional<SpotifyArtistDto> result = service.getArtist("06HL4z0CvFAxyc27GXp?02");
+
+            assertTrue(result.isEmpty(), "ID with special chars should return empty");
+        }
+
+        @Test
+        @DisplayName("given too long ID - returns empty")
+        void givenTooLongId_returnsEmpty() {
+            Optional<SpotifyArtistDto> result = service.getArtist("06HL4z0CvFAxyc27GXpf02X");
+
+            assertTrue(result.isEmpty(), "Too long ID should return empty");
+        }
+
+        @Test
+        @DisplayName("given valid 22-char base62 ID - proceeds with API call")
+        void givenValidId_proceedsWithApiCall() {
+            stubTokenResponse();
+            apiServer.expect(requestTo("https://api.spotify.com/v1/artists/06HL4z0CvFAxyc27GXpf02"))
+                    .andRespond(withSuccess("""
+                            {
+                                "id": "06HL4z0CvFAxyc27GXpf02",
+                                "name": "Taylor Swift",
+                                "genres": ["pop"],
+                                "followers": {"total": 100000},
+                                "images": [{"url": "https://img.example.com/ts.jpg", "height": 640, "width": 640}]
+                            }
+                            """, MediaType.APPLICATION_JSON));
+
+            Optional<SpotifyArtistDto> result = service.getArtist("06HL4z0CvFAxyc27GXpf02");
+
+            assertTrue(result.isPresent(), "Valid ID should return artist");
+            assertEquals("Taylor Swift", result.get().name());
+        }
     }
 
     private void stubTokenResponse() {

--- a/frontend/src/pages/EventDetailPage.tsx
+++ b/frontend/src/pages/EventDetailPage.tsx
@@ -179,7 +179,7 @@ export function EventDetailPage() {
             {/* Spotify embedded player */}
             <div className="overflow-hidden rounded-xl">
               <iframe
-                src={`https://open.spotify.com/embed/artist/${event.spotifyArtistId}?utm_source=generator`}
+                src={`https://open.spotify.com/embed/artist/${encodeURIComponent(event.spotifyArtistId)}?utm_source=generator`}
                 width="100%"
                 height="352"
                 frameBorder="0"
@@ -196,7 +196,7 @@ export function EventDetailPage() {
 
             {/* Listen on Spotify link */}
             <a
-              href={`https://open.spotify.com/artist/${event.spotifyArtistId}`}
+              href={`https://open.spotify.com/artist/${encodeURIComponent(event.spotifyArtistId)}`}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex items-center gap-2 rounded-full bg-[#1DB954] px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#1ed760]"


### PR DESCRIPTION
## Summary

- **#117 — OAuth pending auth code cleanup:** Add `@Scheduled` cleanup (every 5 min) to remove expired entries from `pendingAuths` map, preventing unbounded memory growth from abandoned OAuth flows.
- **#118 — Spotify iframe URL encoding:** Use `encodeURIComponent()` on `spotifyArtistId` in both the embed iframe `src` and the "Open in Spotify" link `href` to prevent URL manipulation.
- **#119 — Spotify artist ID format validation:** Reject invalid IDs early with `^[a-zA-Z0-9]{22}$` regex in `SpotifyApiService.getArtist()` (returns `Optional.empty()`) and `@Pattern` annotation on `EventCreateRequest.spotifyArtistId`.

## Test plan

- [x] `OAuth2AuthenticationSuccessHandlerTest.CleanupExpired` — 3 tests: scheduled cleanup on empty map, valid code exchange, expired entry removal
- [x] `SpotifyApiServiceTest.ArtistIdValidation` — 5 tests: null, too short, special chars, too long, valid ID
- [x] Updated all existing `SpotifyApiServiceTest` IDs to valid 22-char base62 format
- [x] Full backend test suite passes
- [x] JaCoCo: 0 uncovered lines on new OAuth code, 0 uncovered lines on new Spotify validation code
- [x] Prettier check passes on frontend changes

Closes #117, closes #118, closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)