### PR TITLE
Fix findTickets timeout: push LIMIT into database query

### DIFF
--- a/backend/src/main/java/com/mockhub/ticket/repository/ListingRepository.java
+++ b/backend/src/main/java/com/mockhub/ticket/repository/ListingRepository.java
@@ -107,7 +107,8 @@ public interface ListingRepository extends JpaRepository<Listing, Long> {
             @Param("maxPrice") BigDecimal maxPrice,
             @Param("section") String section,
             @Param("dateFrom") Instant dateFrom,
-            @Param("dateTo") Instant dateTo);
+            @Param("dateTo") Instant dateTo,
+            org.springframework.data.domain.Pageable pageable);
 
     @Query("""
             SELECT l FROM Listing l

--- a/backend/src/main/java/com/mockhub/ticket/service/ListingService.java
+++ b/backend/src/main/java/com/mockhub/ticket/service/ListingService.java
@@ -333,10 +333,10 @@ public class ListingService {
         List<Listing> listings = listingRepository.searchActiveListings(
                 normalizedQuery, normalizedCategory, normalizedCity,
                 minPrice, maxPrice, normalizedSection,
-                effectiveDateFrom, dateTo);
+                effectiveDateFrom, dateTo,
+                org.springframework.data.domain.PageRequest.of(0, limit));
 
         return listings.stream()
-                .limit(limit)
                 .map(this::toTicketSearchResultDto)
                 .toList();
     }

--- a/backend/src/test/java/com/mockhub/ticket/service/ListingServiceTest.java
+++ b/backend/src/test/java/com/mockhub/ticket/service/ListingServiceTest.java
@@ -274,7 +274,7 @@ class ListingServiceTest {
     @DisplayName("searchTickets - given matching listings - returns search result DTOs")
     void searchTickets_givenMatchingListings_returnsSearchResultDtos() {
         Listing listing = createFullListing(false, false);
-        when(listingRepository.searchActiveListings(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), isNull()))
+        when(listingRepository.searchActiveListings(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), isNull(), any(org.springframework.data.domain.Pageable.class)))
                 .thenReturn(List.of(listing));
 
         List<TicketSearchResultDto> results = listingService.searchTickets(
@@ -291,7 +291,7 @@ class ListingServiceTest {
     @DisplayName("searchTickets - given listing with seat - includes row and seat info")
     void searchTickets_givenListingWithSeat_includesRowAndSeatInfo() {
         Listing listing = createFullListing(true, false);
-        when(listingRepository.searchActiveListings(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), isNull()))
+        when(listingRepository.searchActiveListings(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), isNull(), any(org.springframework.data.domain.Pageable.class)))
                 .thenReturn(List.of(listing));
 
         List<TicketSearchResultDto> results = listingService.searchTickets(
@@ -305,7 +305,7 @@ class ListingServiceTest {
     @DisplayName("searchTickets - given listing with seller - includes seller display name")
     void searchTickets_givenListingWithSeller_includesSellerDisplayName() {
         Listing listing = createFullListing(false, true);
-        when(listingRepository.searchActiveListings(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), isNull()))
+        when(listingRepository.searchActiveListings(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), isNull(), any(org.springframework.data.domain.Pageable.class)))
                 .thenReturn(List.of(listing));
 
         List<TicketSearchResultDto> results = listingService.searchTickets(
@@ -318,7 +318,7 @@ class ListingServiceTest {
     @DisplayName("searchTickets - given listing without seat or seller - returns nulls for optional fields")
     void searchTickets_givenListingWithoutSeatOrSeller_returnsNullsForOptionalFields() {
         Listing listing = createFullListing(false, false);
-        when(listingRepository.searchActiveListings(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), isNull()))
+        when(listingRepository.searchActiveListings(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), isNull(), any(org.springframework.data.domain.Pageable.class)))
                 .thenReturn(List.of(listing));
 
         List<TicketSearchResultDto> results = listingService.searchTickets(
@@ -330,37 +330,37 @@ class ListingServiceTest {
     }
 
     @Test
-    @DisplayName("searchTickets - given limit - caps results")
-    void searchTickets_givenLimit_capsResults() {
-        Listing listing1 = createFullListing(false, false);
-        Listing listing2 = createFullListing(false, false);
-        listing2.setId(2L);
-        when(listingRepository.searchActiveListings(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), isNull()))
-                .thenReturn(List.of(listing1, listing2));
+    @DisplayName("searchTickets - given limit - passes limit to database query via Pageable")
+    void searchTickets_givenLimit_passesLimitToQuery() {
+        when(listingRepository.searchActiveListings(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), isNull(), any(org.springframework.data.domain.Pageable.class)))
+                .thenReturn(List.of());
 
-        List<TicketSearchResultDto> results = listingService.searchTickets(
-                null, null, null, null, null, null, null, null, 1);
+        listingService.searchTickets(null, null, null, null, null, null, null, null, 5);
 
-        assertEquals(1, results.size());
+        org.mockito.ArgumentCaptor<org.springframework.data.domain.Pageable> pageableCaptor =
+                org.mockito.ArgumentCaptor.forClass(org.springframework.data.domain.Pageable.class);
+        verify(listingRepository).searchActiveListings(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), isNull(), pageableCaptor.capture());
+        assertEquals(5, pageableCaptor.getValue().getPageSize(), "Should pass limit as page size");
+        assertEquals(0, pageableCaptor.getValue().getPageNumber(), "Should request first page");
     }
 
     @Test
     @DisplayName("searchTickets - given blank params - normalizes to null")
     void searchTickets_givenBlankParams_normalizesToNull() {
-        when(listingRepository.searchActiveListings(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), isNull()))
+        when(listingRepository.searchActiveListings(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), isNull(), any(org.springframework.data.domain.Pageable.class)))
                 .thenReturn(List.of());
 
         List<TicketSearchResultDto> results = listingService.searchTickets(
                 "  ", "  ", "  ", null, null, "  ", null, null, 10);
 
         assertEquals(0, results.size());
-        verify(listingRepository).searchActiveListings(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), isNull());
+        verify(listingRepository).searchActiveListings(isNull(), isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), isNull(), any(org.springframework.data.domain.Pageable.class));
     }
 
     @Test
     @DisplayName("searchTickets - given no results - returns empty list")
     void searchTickets_givenNoResults_returnsEmptyList() {
-        when(listingRepository.searchActiveListings(eq("nonexistent"), isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), isNull()))
+        when(listingRepository.searchActiveListings(eq("nonexistent"), isNull(), isNull(), isNull(), isNull(), isNull(), any(Instant.class), isNull(), any(org.springframework.data.domain.Pageable.class)))
                 .thenReturn(List.of());
 
         List<TicketSearchResultDto> results = listingService.searchTickets(


### PR DESCRIPTION
## Summary

The `findTickets` MCP tool was timing out on broad queries. Root cause: `searchActiveListings` fetched ALL matching listings (with 7 JOIN FETCHes across listing, ticket, section, seat, row, event, venue, category, seller) then applied the limit in Java via `stream().limit()`. With hundreds of thousands of seed listings, this loaded the entire result set into memory.

Fix: add a `Pageable` parameter to the repository query so PostgreSQL applies the `LIMIT` clause. The service passes `PageRequest.of(0, limit)`.

## Test plan

- [x] Updated `ListingServiceTest` — limit test now uses `ArgumentCaptor` to verify the correct `Pageable` is passed to the repository
- [x] All 8 `searchTickets` test stubs updated for new method signature
- [x] Full backend test suite passes
- [x] MCP protocol integration test passes (findTickets via JSON-RPC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)