### PR TITLE
Add manual Ticketmaster sync trigger for admin

### DIFF
--- a/backend/src/main/java/com/mockhub/admin/controller/AdminController.java
+++ b/backend/src/main/java/com/mockhub/admin/controller/AdminController.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -148,14 +149,18 @@ public class AdminController {
     @PostMapping("/ticketmaster/sync")
     @Operation(summary = "Trigger Ticketmaster sync (admin)",
             description = "Manually trigger a Ticketmaster event sync. Requires the ticketmaster profile to be active.")
-    @ApiResponse(responseCode = "200", description = "Sync triggered")
+    @ApiResponse(responseCode = "202", description = "Sync triggered")
     @ApiResponse(responseCode = "503", description = "Ticketmaster integration not active")
     public ResponseEntity<Map<String, String>> triggerTicketmasterSync() {
         if (ticketmasterSyncService.isEmpty()) {
+            ProblemDetail problem = ProblemDetail.forStatusAndDetail(
+                    HttpStatus.SERVICE_UNAVAILABLE,
+                    "Ticketmaster integration is not active. Enable the 'ticketmaster' profile.");
+            problem.setTitle("Ticketmaster Not Available");
             return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
-                    .body(Map.of("error", "Ticketmaster integration is not active. Enable the 'ticketmaster' profile."));
+                    .body(Map.of("detail", problem.getDetail(), "title", problem.getTitle()));
         }
         ticketmasterSyncService.get().syncEvents();
-        return ResponseEntity.ok(Map.of("status", "Sync completed"));
+        return ResponseEntity.accepted().body(Map.of("status", "Sync triggered successfully"));
     }
 }

--- a/backend/src/test/java/com/mockhub/admin/controller/AdminControllerSyncTest.java
+++ b/backend/src/test/java/com/mockhub/admin/controller/AdminControllerSyncTest.java
@@ -22,7 +22,7 @@ class AdminControllerSyncTest {
         ResponseEntity<Map<String, String>> response = controller.triggerTicketmasterSync();
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
-        assertThat(response.getBody()).containsKey("error");
+        assertThat(response.getBody()).containsKey("detail");
     }
 
     @Test
@@ -35,8 +35,8 @@ class AdminControllerSyncTest {
 
         ResponseEntity<Map<String, String>> response = controller.triggerTicketmasterSync();
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).containsEntry("status", "Sync completed");
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.ACCEPTED);
+        assertThat(response.getBody()).containsEntry("status", "Sync triggered successfully");
         verify(syncService).syncEvents();
     }
 }

--- a/backend/src/test/java/com/mockhub/admin/controller/AdminControllerTest.java
+++ b/backend/src/test/java/com/mockhub/admin/controller/AdminControllerTest.java
@@ -104,8 +104,8 @@ class AdminControllerTest {
     @WithMockUser(authorities = "ROLE_ADMIN")
     void triggerTicketmasterSync_admin_returns200() throws Exception {
         mockMvc.perform(post("/api/v1/admin/ticketmaster/sync"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.status").value("Sync completed"));
+                .andExpect(status().isAccepted())
+                .andExpect(jsonPath("$.status").value("Sync triggered successfully"));
 
         verify(ticketmasterSyncService).syncEvents();
     }


### PR DESCRIPTION
## Summary

- Adds `POST /api/v1/admin/ticketmaster/sync` endpoint for on-demand Ticketmaster event sync
- Returns 202 Accepted (sync may partially fail internally)
- Returns 503 with ProblemDetail-style error if `ticketmaster` profile is not active
- Uses `Optional<TicketmasterSyncService>` for profile-conditional injection

## Test plan

- [x] Admin auth: 202 on success, 401 unauthenticated, 403 non-admin
- [x] Unit tests: Optional.empty() returns 503, Optional.present() calls sync
- [x] Full test suite passes
- [ ] After merge: add `ticketmaster` to Railway `SPRING_PROFILES_ACTIVE`, then trigger sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)