### PR TITLE
Fix Ticketmaster API date format

### DIFF
--- a/backend/src/main/java/com/mockhub/ticketmaster/service/TicketmasterSyncService.java
+++ b/backend/src/main/java/com/mockhub/ticketmaster/service/TicketmasterSyncService.java
@@ -1,6 +1,8 @@
 package com.mockhub.ticketmaster.service;
 
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
@@ -60,8 +62,11 @@ public class TicketmasterSyncService {
     public void syncEvents() {
         log.info("Starting Ticketmaster event sync");
 
-        String startDateTime = Instant.now().toString();
-        String endDateTime = Instant.now().plus(180, ChronoUnit.DAYS).toString();
+        // Ticketmaster requires YYYY-MM-DDTHH:mm:ssZ format (no fractional seconds)
+        DateTimeFormatter tmFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'")
+                .withZone(ZoneOffset.UTC);
+        String startDateTime = tmFormat.format(Instant.now());
+        String endDateTime = tmFormat.format(Instant.now().plus(180, ChronoUnit.DAYS));
 
         int newEvents = 0;
         int updatedEvents = 0;


### PR DESCRIPTION
## Summary

- Fix date format for Ticketmaster Discovery API — requires `YYYY-MM-DDTHH:mm:ssZ` without fractional seconds
- `Instant.toString()` produces `2026-04-01T17:05:58.429123Z` which Ticketmaster rejects (DIS1015)
- Use `DateTimeFormatter` to produce exact required format

## Test plan

- [x] All tests pass
- [ ] Re-trigger sync after deploy to verify events import

🤖 Generated with [Claude Code](https://claude.com/claude-code)