### PR TITLE
Extract notification logic from OrderService

### DIFF
--- a/backend/src/main/java/com/mockhub/order/service/OrderNotificationService.java
+++ b/backend/src/main/java/com/mockhub/order/service/OrderNotificationService.java
@@ -1,0 +1,129 @@
+package com.mockhub.order.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import com.mockhub.notification.entity.NotificationType;
+import com.mockhub.notification.service.EmailDeliveryService;
+import com.mockhub.notification.service.NotificationService;
+import com.mockhub.notification.service.SmsDeliveryService;
+import com.mockhub.order.entity.Order;
+import com.mockhub.ticket.service.TicketSigningService;
+
+/**
+ * Handles all confirmation notifications for completed orders:
+ * in-app notifications, SMS, and email delivery.
+ *
+ * Extracted from OrderService to honor the Single Responsibility Principle —
+ * OrderService owns order lifecycle; this service owns notification dispatch.
+ */
+@Service
+public class OrderNotificationService {
+
+    private static final Logger log = LoggerFactory.getLogger(OrderNotificationService.class);
+
+    private final NotificationService notificationService;
+    private final SmsDeliveryService smsDeliveryService;
+    private final EmailDeliveryService emailDeliveryService;
+    private final TicketSigningService ticketSigningService;
+    private final String orderBaseUrl;
+
+    public OrderNotificationService(NotificationService notificationService,
+                                    SmsDeliveryService smsDeliveryService,
+                                    EmailDeliveryService emailDeliveryService,
+                                    TicketSigningService ticketSigningService,
+                                    @Value("${mockhub.sms.order-base-url}") String orderBaseUrl) {
+        this.notificationService = notificationService;
+        this.smsDeliveryService = smsDeliveryService;
+        this.emailDeliveryService = emailDeliveryService;
+        this.ticketSigningService = ticketSigningService;
+        this.orderBaseUrl = orderBaseUrl;
+    }
+
+    /**
+     * Sends all confirmation notifications for a confirmed order:
+     * in-app notification, SMS (if phone available), and email (if email available).
+     */
+    public void sendConfirmationNotifications(Order order) {
+        String orderNumber = order.getOrderNumber();
+
+        notificationService.createNotification(
+                order.getUser().getId(),
+                NotificationType.ORDER_CONFIRMED,
+                "Order Confirmed",
+                String.format("Your order %s has been confirmed. Total: $%s",
+                        orderNumber, order.getTotal().toPlainString()),
+                "/orders/" + orderNumber + "/confirmation"
+        );
+
+        sendSmsConfirmation(order);
+        sendEmailConfirmation(order);
+    }
+
+    private void sendSmsConfirmation(Order order) {
+        String phone = order.getUser().getPhone();
+        if (phone == null || phone.isBlank()) {
+            return;
+        }
+
+        String eventName = order.getItems().stream()
+                .findFirst()
+                .map(item -> item.getListing().getEvent().getName())
+                .orElse("your event");
+        String orderViewToken = ticketSigningService.generateOrderViewToken(order.getOrderNumber());
+        String orderUrl = orderBaseUrl + "/tickets/view?token=" + orderViewToken;
+        String smsMessage = String.format(
+                "MockHub: Your tickets for %s are confirmed! View your tickets: %s",
+                eventName, orderUrl);
+        smsDeliveryService.sendSms(phone, smsMessage);
+    }
+
+    private void sendEmailConfirmation(Order order) {
+        String email = order.getUser().getEmail();
+        if (email == null || email.isBlank()) {
+            return;
+        }
+
+        try {
+            String eventName = order.getItems().stream()
+                    .findFirst()
+                    .map(item -> item.getListing().getEvent().getName())
+                    .orElse("your event");
+            String emailToken = ticketSigningService.generateOrderViewToken(order.getOrderNumber());
+            String ticketUrl = orderBaseUrl + "/tickets/view?token=" + emailToken;
+
+            String htmlBody = buildConfirmationEmail(order.getOrderNumber(), eventName,
+                    order.getTotal().toPlainString(), order.getItems().size(), ticketUrl);
+            emailDeliveryService.sendEmail(email,
+                    "Your MockHub tickets for " + eventName, htmlBody);
+        } catch (Exception exception) {
+            log.error("Failed to send confirmation email for order {}: {}",
+                    order.getOrderNumber(), exception.getMessage());
+        }
+    }
+
+    private String buildConfirmationEmail(String orderNumber, String eventName,
+                                           String total, int ticketCount, String ticketUrl) {
+        return String.format("""
+                <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; \
+                max-width: 600px; margin: 0 auto; padding: 24px;">
+                  <h1 style="font-size: 24px; margin-bottom: 8px;">Your tickets are confirmed!</h1>
+                  <p style="color: #666; margin-bottom: 24px;">Order %s</p>
+                  <div style="background: #f9fafb; border-radius: 8px; padding: 20px; margin-bottom: 24px;">
+                    <h2 style="font-size: 18px; margin: 0 0 8px 0;">%s</h2>
+                    <p style="color: #666; margin: 0;">%d ticket%s &middot; Total: $%s</p>
+                  </div>
+                  <a href="%s" style="display: inline-block; background: #18181b; color: #fff; \
+                padding: 12px 24px; border-radius: 6px; text-decoration: none; font-weight: 500;">
+                    View Your Tickets
+                  </a>
+                  <p style="color: #999; font-size: 12px; margin-top: 24px;">
+                    Tap the button above to see your scannable QR code tickets. No login required.
+                  </p>
+                </div>
+                """, orderNumber, eventName, ticketCount,
+                ticketCount == 1 ? "" : "s", total, ticketUrl);
+    }
+}

--- a/backend/src/main/java/com/mockhub/order/service/OrderService.java
+++ b/backend/src/main/java/com/mockhub/order/service/OrderService.java
@@ -29,22 +29,17 @@ import com.mockhub.common.exception.ResourceNotFoundException;
 import com.mockhub.common.exception.UnauthorizedException;
 import com.mockhub.event.entity.Event;
 import com.mockhub.event.repository.EventRepository;
+import com.mockhub.mandate.service.MandateService;
 import com.mockhub.order.dto.CheckoutRequest;
 import com.mockhub.order.dto.OrderDto;
 import com.mockhub.order.dto.OrderItemDto;
 import com.mockhub.order.dto.OrderSummaryDto;
-import com.mockhub.notification.entity.NotificationType;
-import com.mockhub.notification.service.NotificationService;
-import com.mockhub.notification.service.EmailDeliveryService;
-import com.mockhub.notification.service.SmsDeliveryService;
-import com.mockhub.mandate.service.MandateService;
 import com.mockhub.order.entity.Order;
 import com.mockhub.order.entity.OrderItem;
 import com.mockhub.order.repository.OrderRepository;
 import com.mockhub.ticket.entity.Listing;
 import com.mockhub.ticket.entity.Ticket;
 import com.mockhub.ticket.service.TicketService;
-import com.mockhub.ticket.service.TicketSigningService;
 
 @Service
 public class OrderService {
@@ -64,35 +59,23 @@ public class OrderService {
     private final CartService cartService;
     private final TicketService ticketService;
     private final EventRepository eventRepository;
-    private final NotificationService notificationService;
-    private final SmsDeliveryService smsDeliveryService;
-    private final EmailDeliveryService emailDeliveryService;
-    private final TicketSigningService ticketSigningService;
+    private final OrderNotificationService orderNotificationService;
     private final MandateService mandateService;
-    private final String smsOrderBaseUrl;
 
     public OrderService(OrderRepository orderRepository,
                         CartRepository cartRepository,
                         CartService cartService,
                         TicketService ticketService,
                         EventRepository eventRepository,
-                        NotificationService notificationService,
-                        SmsDeliveryService smsDeliveryService,
-                        EmailDeliveryService emailDeliveryService,
-                        TicketSigningService ticketSigningService,
-                        MandateService mandateService,
-                        @org.springframework.beans.factory.annotation.Value("${mockhub.sms.order-base-url}") String smsOrderBaseUrl) {
+                        OrderNotificationService orderNotificationService,
+                        MandateService mandateService) {
         this.orderRepository = orderRepository;
         this.cartRepository = cartRepository;
         this.cartService = cartService;
         this.ticketService = ticketService;
         this.eventRepository = eventRepository;
-        this.notificationService = notificationService;
-        this.smsDeliveryService = smsDeliveryService;
-        this.emailDeliveryService = emailDeliveryService;
-        this.ticketSigningService = ticketSigningService;
+        this.orderNotificationService = orderNotificationService;
         this.mandateService = mandateService;
-        this.smsOrderBaseUrl = smsOrderBaseUrl;
     }
 
     @Transactional
@@ -150,7 +133,7 @@ public class OrderService {
             mandateService.recordSpend(order.getMandateId(), order.getTotal());
         }
 
-        sendConfirmationNotifications(order);
+        orderNotificationService.sendConfirmationNotifications(order);
     }
 
     @Transactional
@@ -360,8 +343,6 @@ public class OrderService {
         return order;
     }
 
-    // ── Confirmation helpers ───────────────────────────────────────────
-
     private void markTicketsAsSold(Order order) {
         for (OrderItem item : order.getItems()) {
             item.getTicket().setStatus("SOLD");
@@ -371,87 +352,6 @@ public class OrderService {
             event.setAvailableTickets(Math.max(0, event.getAvailableTickets() - 1));
             eventRepository.save(event);
         }
-    }
-
-    private void sendConfirmationNotifications(Order order) {
-        String orderNumber = order.getOrderNumber();
-
-        notificationService.createNotification(
-                order.getUser().getId(),
-                NotificationType.ORDER_CONFIRMED,
-                "Order Confirmed",
-                String.format("Your order %s has been confirmed. Total: $%s",
-                        orderNumber, order.getTotal().toPlainString()),
-                "/orders/" + orderNumber + "/confirmation"
-        );
-
-        sendSmsConfirmation(order);
-        sendEmailConfirmation(order);
-    }
-
-    private void sendSmsConfirmation(Order order) {
-        String phone = order.getUser().getPhone();
-        if (phone == null || phone.isBlank()) {
-            return;
-        }
-
-        String eventName = order.getItems().stream()
-                .findFirst()
-                .map(item -> item.getListing().getEvent().getName())
-                .orElse("your event");
-        String orderViewToken = ticketSigningService.generateOrderViewToken(order.getOrderNumber());
-        String orderUrl = smsOrderBaseUrl + "/tickets/view?token=" + orderViewToken;
-        String smsMessage = String.format(
-                "MockHub: Your tickets for %s are confirmed! View your tickets: %s",
-                eventName, orderUrl);
-        smsDeliveryService.sendSms(phone, smsMessage);
-    }
-
-    private void sendEmailConfirmation(Order order) {
-        String email = order.getUser().getEmail();
-        if (email == null || email.isBlank()) {
-            return;
-        }
-
-        try {
-            String eventName = order.getItems().stream()
-                    .findFirst()
-                    .map(item -> item.getListing().getEvent().getName())
-                    .orElse("your event");
-            String emailToken = ticketSigningService.generateOrderViewToken(order.getOrderNumber());
-            String ticketUrl = smsOrderBaseUrl + "/tickets/view?token=" + emailToken;
-
-            String htmlBody = buildConfirmationEmail(order.getOrderNumber(), eventName,
-                    order.getTotal().toPlainString(), order.getItems().size(), ticketUrl);
-            emailDeliveryService.sendEmail(email,
-                    "Your MockHub tickets for " + eventName, htmlBody);
-        } catch (Exception exception) {
-            log.error("Failed to send confirmation email for order {}: {}",
-                    order.getOrderNumber(), exception.getMessage());
-        }
-    }
-
-    private String buildConfirmationEmail(String orderNumber, String eventName,
-                                           String total, int ticketCount, String ticketUrl) {
-        return String.format("""
-                <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; \
-                max-width: 600px; margin: 0 auto; padding: 24px;">
-                  <h1 style="font-size: 24px; margin-bottom: 8px;">Your tickets are confirmed!</h1>
-                  <p style="color: #666; margin-bottom: 24px;">Order %s</p>
-                  <div style="background: #f9fafb; border-radius: 8px; padding: 20px; margin-bottom: 24px;">
-                    <h2 style="font-size: 18px; margin: 0 0 8px 0;">%s</h2>
-                    <p style="color: #666; margin: 0;">%d ticket%s &middot; Total: $%s</p>
-                  </div>
-                  <a href="%s" style="display: inline-block; background: #18181b; color: #fff; \
-                padding: 12px 24px; border-radius: 6px; text-decoration: none; font-weight: 500;">
-                    View Your Tickets
-                  </a>
-                  <p style="color: #999; font-size: 12px; margin-top: 24px;">
-                    Tap the button above to see your scannable QR code tickets. No login required.
-                  </p>
-                </div>
-                """, orderNumber, eventName, ticketCount,
-                ticketCount == 1 ? "" : "s", total, ticketUrl);
     }
 
     // ── Shared helpers ─────────────────────────────────────────────────

--- a/backend/src/test/java/com/mockhub/order/service/OrderNotificationServiceTest.java
+++ b/backend/src/test/java/com/mockhub/order/service/OrderNotificationServiceTest.java
@@ -1,0 +1,240 @@
+package com.mockhub.order.service;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.mockhub.auth.entity.User;
+import com.mockhub.event.entity.Event;
+import com.mockhub.notification.entity.NotificationType;
+import com.mockhub.notification.service.EmailDeliveryService;
+import com.mockhub.notification.service.NotificationService;
+import com.mockhub.notification.service.SmsDeliveryService;
+import com.mockhub.order.entity.Order;
+import com.mockhub.order.entity.OrderItem;
+import com.mockhub.ticket.entity.Listing;
+import com.mockhub.ticket.entity.Ticket;
+import com.mockhub.ticket.service.TicketSigningService;
+import com.mockhub.venue.entity.Section;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OrderNotificationServiceTest {
+
+    @Mock
+    private NotificationService notificationService;
+
+    @Mock
+    private SmsDeliveryService smsDeliveryService;
+
+    @Mock
+    private EmailDeliveryService emailDeliveryService;
+
+    @Mock
+    private TicketSigningService ticketSigningService;
+
+    private OrderNotificationService orderNotificationService;
+
+    private Order testOrder;
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        orderNotificationService = new OrderNotificationService(
+                notificationService, smsDeliveryService, emailDeliveryService,
+                ticketSigningService, "http://localhost:5173");
+
+        testUser = new User();
+        testUser.setId(1L);
+        testUser.setEmail("buyer@example.com");
+        testUser.setPhone("+15551234567");
+
+        Event testEvent = new Event();
+        testEvent.setId(1L);
+        testEvent.setName("Test Event");
+        testEvent.setSlug("test-event");
+
+        Section testSection = new Section();
+        testSection.setId(1L);
+        testSection.setName("Floor");
+
+        Ticket testTicket = new Ticket();
+        testTicket.setId(1L);
+        testTicket.setEvent(testEvent);
+        testTicket.setSection(testSection);
+        testTicket.setTicketType("GENERAL_ADMISSION");
+        testTicket.setFaceValue(new BigDecimal("50.00"));
+        testTicket.setStatus("SOLD");
+
+        Listing testListing = new Listing();
+        testListing.setId(1L);
+        testListing.setTicket(testTicket);
+        testListing.setEvent(testEvent);
+        testListing.setListedPrice(new BigDecimal("75.00"));
+        testListing.setComputedPrice(new BigDecimal("75.00"));
+        testListing.setPriceMultiplier(BigDecimal.ONE);
+        testListing.setStatus("SOLD");
+        testListing.setListedAt(Instant.now());
+
+        OrderItem orderItem = new OrderItem();
+        orderItem.setId(1L);
+        orderItem.setListing(testListing);
+        orderItem.setTicket(testTicket);
+        orderItem.setPricePaid(new BigDecimal("75.00"));
+
+        testOrder = new Order();
+        testOrder.setId(1L);
+        testOrder.setUser(testUser);
+        testOrder.setOrderNumber("MH-20260317-0001");
+        testOrder.setStatus("CONFIRMED");
+        testOrder.setSubtotal(new BigDecimal("75.00"));
+        testOrder.setServiceFee(new BigDecimal("7.50"));
+        testOrder.setTotal(new BigDecimal("82.50"));
+        testOrder.setPaymentMethod("mock");
+        testOrder.setCreatedAt(Instant.now());
+        testOrder.setItems(List.of(orderItem));
+        orderItem.setOrder(testOrder);
+    }
+
+    @Test
+    @DisplayName("sendConfirmationNotifications - given confirmed order - creates in-app notification")
+    void sendConfirmationNotifications_givenConfirmedOrder_createsInAppNotification() {
+        orderNotificationService.sendConfirmationNotifications(testOrder);
+
+        verify(notificationService).createNotification(
+                eq(1L),
+                eq(NotificationType.ORDER_CONFIRMED),
+                eq("Order Confirmed"),
+                contains("MH-20260317-0001"),
+                eq("/orders/MH-20260317-0001/confirmation"));
+    }
+
+    @Test
+    @DisplayName("sendConfirmationNotifications - given user with phone - sends SMS")
+    void sendConfirmationNotifications_givenUserWithPhone_sendsSms() {
+        when(ticketSigningService.generateOrderViewToken("MH-20260317-0001"))
+                .thenReturn("test-token");
+
+        orderNotificationService.sendConfirmationNotifications(testOrder);
+
+        verify(smsDeliveryService).sendSms(
+                eq("+15551234567"),
+                contains("Test Event"));
+    }
+
+    @Test
+    @DisplayName("sendConfirmationNotifications - given user without phone - skips SMS")
+    void sendConfirmationNotifications_givenUserWithoutPhone_skipsSms() {
+        testUser.setPhone(null);
+
+        orderNotificationService.sendConfirmationNotifications(testOrder);
+
+        verify(smsDeliveryService, never()).sendSms(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("sendConfirmationNotifications - given user with blank phone - skips SMS")
+    void sendConfirmationNotifications_givenUserWithBlankPhone_skipsSms() {
+        testUser.setPhone("   ");
+
+        orderNotificationService.sendConfirmationNotifications(testOrder);
+
+        verify(smsDeliveryService, never()).sendSms(anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("sendConfirmationNotifications - given user with email - sends email")
+    void sendConfirmationNotifications_givenUserWithEmail_sendsEmail() {
+        when(ticketSigningService.generateOrderViewToken("MH-20260317-0001"))
+                .thenReturn("email-token");
+
+        orderNotificationService.sendConfirmationNotifications(testOrder);
+
+        verify(emailDeliveryService).sendEmail(
+                eq("buyer@example.com"),
+                contains("Test Event"),
+                contains("MH-20260317-0001"));
+    }
+
+    @Test
+    @DisplayName("sendConfirmationNotifications - given user without email - skips email")
+    void sendConfirmationNotifications_givenUserWithoutEmail_skipsEmail() {
+        testUser.setEmail(null);
+
+        orderNotificationService.sendConfirmationNotifications(testOrder);
+
+        verify(emailDeliveryService, never()).sendEmail(anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("sendConfirmationNotifications - given email delivery failure - does not throw")
+    void sendConfirmationNotifications_givenEmailDeliveryFailure_doesNotThrow() {
+        when(ticketSigningService.generateOrderViewToken("MH-20260317-0001"))
+                .thenReturn("test-token");
+        when(emailDeliveryService.sendEmail(anyString(), anyString(), anyString()))
+                .thenThrow(new RuntimeException("SMTP connection refused"));
+
+        // Should not throw - email failures are caught and logged
+        orderNotificationService.sendConfirmationNotifications(testOrder);
+
+        verify(notificationService).createNotification(
+                anyLong(), eq(NotificationType.ORDER_CONFIRMED),
+                anyString(), anyString(), anyString());
+    }
+
+    @Test
+    @DisplayName("sendConfirmationNotifications - given SMS token - includes ticket view URL")
+    void sendConfirmationNotifications_givenSmsToken_includesTicketViewUrl() {
+        when(ticketSigningService.generateOrderViewToken("MH-20260317-0001"))
+                .thenReturn("sms-view-token");
+
+        orderNotificationService.sendConfirmationNotifications(testOrder);
+
+        verify(smsDeliveryService).sendSms(
+                eq("+15551234567"),
+                contains("http://localhost:5173/tickets/view?token=sms-view-token"));
+    }
+
+    @Test
+    @DisplayName("sendConfirmationNotifications - given email token - includes ticket view URL in HTML")
+    void sendConfirmationNotifications_givenEmailToken_includesTicketViewUrlInHtml() {
+        when(ticketSigningService.generateOrderViewToken("MH-20260317-0001"))
+                .thenReturn("email-view-token");
+
+        orderNotificationService.sendConfirmationNotifications(testOrder);
+
+        verify(emailDeliveryService).sendEmail(
+                eq("buyer@example.com"),
+                anyString(),
+                contains("http://localhost:5173/tickets/view?token=email-view-token"));
+    }
+
+    @Test
+    @DisplayName("sendConfirmationNotifications - given order with no items - uses fallback event name")
+    void sendConfirmationNotifications_givenOrderWithNoItems_usesFallbackEventName() {
+        testOrder.setItems(List.of());
+
+        orderNotificationService.sendConfirmationNotifications(testOrder);
+
+        verify(notificationService).createNotification(
+                eq(1L),
+                eq(NotificationType.ORDER_CONFIRMED),
+                eq("Order Confirmed"),
+                contains("82.50"),
+                anyString());
+    }
+}

--- a/backend/src/test/java/com/mockhub/order/service/OrderServiceTest.java
+++ b/backend/src/test/java/com/mockhub/order/service/OrderServiceTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
@@ -32,11 +31,6 @@ import com.mockhub.common.exception.UnauthorizedException;
 import com.mockhub.event.entity.Event;
 import com.mockhub.event.repository.EventRepository;
 import com.mockhub.mandate.service.MandateService;
-import com.mockhub.notification.service.EmailDeliveryService;
-import com.mockhub.notification.entity.NotificationType;
-import com.mockhub.notification.service.NotificationService;
-import com.mockhub.notification.service.SmsDeliveryService;
-import com.mockhub.ticket.service.TicketSigningService;
 import com.mockhub.order.dto.CheckoutRequest;
 import com.mockhub.order.dto.OrderDto;
 import com.mockhub.order.dto.OrderSummaryDto;
@@ -80,16 +74,7 @@ class OrderServiceTest {
     private EventRepository eventRepository;
 
     @Mock
-    private NotificationService notificationService;
-
-    @Mock
-    private SmsDeliveryService smsDeliveryService;
-
-    @Mock
-    private EmailDeliveryService emailDeliveryService;
-
-    @Mock
-    private TicketSigningService ticketSigningService;
+    private OrderNotificationService orderNotificationService;
 
     @Mock
     private MandateService mandateService;
@@ -106,9 +91,7 @@ class OrderServiceTest {
     @BeforeEach
     void setUp() {
         orderService = new OrderService(orderRepository, cartRepository, cartService,
-                ticketService, eventRepository, notificationService,
-                smsDeliveryService, emailDeliveryService, ticketSigningService, mandateService,
-                "http://localhost:5173");
+                ticketService, eventRepository, orderNotificationService, mandateService);
 
         Role buyerRole = new Role("ROLE_BUYER");
         buyerRole.setId(1L);
@@ -298,12 +281,7 @@ class OrderServiceTest {
 
         assertEquals("CONFIRMED", testOrder.getStatus());
         assertNotNull(testOrder.getConfirmedAt());
-        verify(notificationService, times(1)).createNotification(
-                anyLong(),
-                org.mockito.ArgumentMatchers.eq(NotificationType.ORDER_CONFIRMED),
-                anyString(),
-                anyString(),
-                anyString());
+        verify(orderNotificationService, times(1)).sendConfirmationNotifications(any(Order.class));
         verify(eventRepository, times(1)).save(any(Event.class));
         verify(mandateService, times(1)).recordSpend("mandate-123", new BigDecimal("82.50"));
     }
@@ -346,9 +324,8 @@ class OrderServiceTest {
         assertThrows(ConflictException.class,
                 () -> orderService.confirmOrder("MH-20260317-0001"));
 
-        verify(notificationService, org.mockito.Mockito.never())
-                .createNotification(anyLong(), org.mockito.ArgumentMatchers.any(NotificationType.class),
-                        anyString(), anyString(), anyString());
+        verify(orderNotificationService, org.mockito.Mockito.never())
+                .sendConfirmationNotifications(any(Order.class));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Extracted order notification dispatching (in-app, SMS, email) from `OrderService` into a new `OrderNotificationService` in the `order/service` package
- `OrderService` constructor simplified from 11 parameters to 7 -- no longer depends on `NotificationService`, `SmsDeliveryService`, `EmailDeliveryService`, `TicketSigningService`, or the `smsOrderBaseUrl` config value
- Added 10 unit tests for `OrderNotificationService` covering all notification channels, edge cases (null/blank phone/email), error handling (email failures don't throw), and URL generation

## Motivation
Addresses #151 (Single Responsibility Principle). `OrderService` previously handled both order lifecycle management AND notification dispatching. These are separate concerns with different change drivers.

Closes #151

## Test plan
- [x] All 10 `OrderNotificationServiceTest` tests pass (in-app notification, SMS with/without phone, email with/without address, email failure resilience, URL generation, fallback event name)
- [x] All 17 `OrderServiceTest` tests pass (updated to mock `OrderNotificationService` instead of individual notification services)
- [x] Full backend test suite passes (`./gradlew test` -- 53s, BUILD SUCCESSFUL)
- [x] JaCoCo coverage report generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)