### PR TITLE
Extend MCP OAuth2 token lifetimes to reduce mobile re-login

### DIFF
--- a/backend/src/main/java/com/mockhub/mcp/config/McpOAuth2SecurityConfig.java
+++ b/backend/src/main/java/com/mockhub/mcp/config/McpOAuth2SecurityConfig.java
@@ -172,11 +172,14 @@ public class McpOAuth2SecurityConfig {
                 .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
                 .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
                 .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+                .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
                 .redirectUri("https://claude.ai/api/mcp/auth_callback")
                 .redirectUri("http://localhost:6274/oauth/callback")
                 .redirectUri("http://127.0.0.1:6274/oauth/callback")
                 .tokenSettings(TokenSettings.builder()
-                        .accessTokenTimeToLive(Duration.ofHours(1))
+                        .accessTokenTimeToLive(Duration.ofHours(8))
+                        .refreshTokenTimeToLive(Duration.ofDays(30))
+                        .reuseRefreshTokens(false)
                         .build())
                 .build();
         return new InMemoryRegisteredClientRepository(claudeClient);

--- a/backend/src/test/java/com/mockhub/mcp/config/McpOAuth2SecurityConfigTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/config/McpOAuth2SecurityConfigTest.java
@@ -15,9 +15,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
 
+import java.time.Duration;
+
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class McpOAuth2SecurityConfigTest {
 
@@ -78,6 +83,47 @@ class McpOAuth2SecurityConfigTest {
         AuthorizationServerSettings settings = config.authorizationServerSettings(issuerUri);
 
         assertEquals(issuerUri, settings.getIssuer());
+    }
+
+    @Test
+    void registeredClientRepository_claudeClientHasRefreshTokenGrant() {
+        RegisteredClientRepository repository = config.registeredClientRepository();
+
+        var client = repository.findByClientId("claude-mcp-client");
+        assertNotNull(client);
+        assertTrue(client.getAuthorizationGrantTypes()
+                        .contains(AuthorizationGrantType.REFRESH_TOKEN),
+                "Client must support refresh_token grant type");
+    }
+
+    @Test
+    void registeredClientRepository_claudeClientHasEightHourAccessToken() {
+        RegisteredClientRepository repository = config.registeredClientRepository();
+
+        var client = repository.findByClientId("claude-mcp-client");
+        assertNotNull(client);
+        Duration accessTokenTtl = client.getTokenSettings().getAccessTokenTimeToLive();
+        assertEquals(Duration.ofHours(8), accessTokenTtl);
+    }
+
+    @Test
+    void registeredClientRepository_claudeClientHasThirtyDayRefreshToken() {
+        RegisteredClientRepository repository = config.registeredClientRepository();
+
+        var client = repository.findByClientId("claude-mcp-client");
+        assertNotNull(client);
+        Duration refreshTokenTtl = client.getTokenSettings().getRefreshTokenTimeToLive();
+        assertEquals(Duration.ofDays(30), refreshTokenTtl);
+    }
+
+    @Test
+    void registeredClientRepository_claudeClientDoesNotReuseRefreshTokens() {
+        RegisteredClientRepository repository = config.registeredClientRepository();
+
+        var client = repository.findByClientId("claude-mcp-client");
+        assertNotNull(client);
+        assertFalse(client.getTokenSettings().isReuseRefreshTokens(),
+                "Refresh tokens should rotate on each use");
     }
 
     @Test


### PR DESCRIPTION
Access token TTL increased from 1 hour to 8 hours and refresh token
grant enabled with 30-day TTL and token rotation. This keeps mobile
MCP sessions alive longer and allows silent renewal when the client
supports refresh_token grants.

https://claude.ai/code/session_014ZpXCRkN9RcBqHPWTtsK9L