### PR TITLE
Fix missing SVG fields in SellPage test mock sections

### DIFF
--- a/frontend/src/pages/SellPage.test.tsx
+++ b/frontend/src/pages/SellPage.test.tsx
@@ -36,6 +36,11 @@ const mockSections: SectionAvailability[] = [
     minPrice: 150.0,
     maxPrice: 300.0,
     colorHex: '#FF0000',
+    svgPathId: null,
+    svgX: null,
+    svgY: null,
+    svgWidth: null,
+    svgHeight: null,
   },
   {
     sectionId: 2,
@@ -46,6 +51,11 @@ const mockSections: SectionAvailability[] = [
     minPrice: 85.0,
     maxPrice: 150.0,
     colorHex: '#00FF00',
+    svgPathId: null,
+    svgX: null,
+    svgY: null,
+    svgWidth: null,
+    svgHeight: null,
   },
 ];
 


### PR DESCRIPTION
## Summary

- Adds missing `svgPathId`, `svgX`, `svgY`, `svgWidth`, `svgHeight` fields to `SectionAvailability` mock data in `SellPage.test.tsx`
- Fixes the Frontend Tests CI failure from #184

## Test plan

- [x] TypeScript type check passes
- [x] All 12 SellPage tests pass
- [ ] CI Frontend Tests pass

https://claude.ai/code/session_014ZpXCRkN9RcBqHPWTtsK9L