### PR TITLE
Add owned tickets to sell page and VenueMap integration

### DIFF
--- a/backend/src/main/java/com/mockhub/order/repository/OrderItemRepository.java
+++ b/backend/src/main/java/com/mockhub/order/repository/OrderItemRepository.java
@@ -67,4 +67,21 @@ public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
             WHERE l.seller.id = :sellerId AND o.status = 'COMPLETED'
             """)
     BigDecimal sumEarningsBySellerId(@Param("sellerId") Long sellerId);
+
+    @Query("""
+            SELECT oi FROM OrderItem oi
+            JOIN FETCH oi.order o
+            JOIN FETCH oi.ticket t
+            JOIN FETCH oi.listing l
+            JOIN FETCH l.event e
+            JOIN FETCH e.venue v
+            JOIN FETCH t.section s
+            LEFT JOIN FETCH t.seat seat
+            LEFT JOIN FETCH seat.row r
+            WHERE o.user.id = :userId
+              AND o.status IN ('CONFIRMED', 'COMPLETED')
+              AND t.status = 'SOLD'
+            ORDER BY e.eventDate ASC
+            """)
+    List<OrderItem> findOwnedAvailableTicketsByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/mockhub/ticket/controller/SellerController.java
+++ b/backend/src/main/java/com/mockhub/ticket/controller/SellerController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.mockhub.auth.security.SecurityUser;
 import com.mockhub.ticket.dto.EarningsSummaryDto;
+import com.mockhub.ticket.dto.OwnedTicketDto;
 import com.mockhub.ticket.dto.SellListingRequest;
 import com.mockhub.ticket.dto.SellerListingDto;
 import com.mockhub.ticket.dto.UpdatePriceRequest;
@@ -91,6 +92,17 @@ public class SellerController {
             @PathVariable Long id) {
         listingService.deactivateListing(id, securityUser.getEmail());
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/my/owned-tickets")
+    @Operation(summary = "Get owned tickets",
+            description = "Return tickets from confirmed orders that are available to sell")
+    @ApiResponse(responseCode = "200", description = "Owned tickets returned")
+    public ResponseEntity<List<OwnedTicketDto>> getOwnedTickets(
+            @AuthenticationPrincipal SecurityUser securityUser) {
+        List<OwnedTicketDto> tickets = listingService.getOwnedTickets(
+                securityUser.getEmail());
+        return ResponseEntity.ok(tickets);
     }
 
     @GetMapping("/my/earnings")

--- a/backend/src/main/java/com/mockhub/ticket/dto/OwnedTicketDto.java
+++ b/backend/src/main/java/com/mockhub/ticket/dto/OwnedTicketDto.java
@@ -1,0 +1,18 @@
+package com.mockhub.ticket.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+public record OwnedTicketDto(
+        Long ticketId,
+        String eventSlug,
+        String eventName,
+        Instant eventDate,
+        String venueName,
+        String sectionName,
+        String rowLabel,
+        String seatNumber,
+        String ticketType,
+        BigDecimal faceValue
+) {
+}

--- a/backend/src/main/java/com/mockhub/ticket/service/ListingService.java
+++ b/backend/src/main/java/com/mockhub/ticket/service/ListingService.java
@@ -23,6 +23,7 @@ import com.mockhub.order.entity.OrderItem;
 import com.mockhub.order.repository.OrderItemRepository;
 import com.mockhub.ticket.dto.EarningsSummaryDto;
 import com.mockhub.ticket.dto.ListingCreateRequest;
+import com.mockhub.ticket.dto.OwnedTicketDto;
 import com.mockhub.ticket.dto.ListingDto;
 import com.mockhub.ticket.dto.SaleDto;
 import com.mockhub.ticket.dto.SellListingRequest;
@@ -324,6 +325,15 @@ public class ListingService {
     }
 
     @Transactional(readOnly = true)
+    public List<OwnedTicketDto> getOwnedTickets(String userEmail) {
+        User user = resolveUser(userEmail);
+        List<OrderItem> items = orderItemRepository.findOwnedAvailableTicketsByUserId(user.getId());
+        return items.stream()
+                .map(this::toOwnedTicketDto)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
     public List<TicketSearchResultDto> searchTickets(ListingSearchCriteria criteria) {
         Specification<Listing> spec = ListingSearchSpecification.fromCriteria(criteria);
 
@@ -427,6 +437,31 @@ public class ListingService {
                 listing.getStatus(),
                 listing.getListedAt(),
                 listing.getCreatedAt());
+    }
+
+    private OwnedTicketDto toOwnedTicketDto(OrderItem orderItem) {
+        Ticket ticket = orderItem.getTicket();
+        Event event = orderItem.getListing().getEvent();
+        String sectionName = ticket.getSection().getName();
+        String rowLabel = null;
+        String seatNumber = null;
+
+        if (ticket.getSeat() != null) {
+            rowLabel = ticket.getSeat().getRow().getRowLabel();
+            seatNumber = ticket.getSeat().getSeatNumber();
+        }
+
+        return new OwnedTicketDto(
+                ticket.getId(),
+                event.getSlug(),
+                event.getName(),
+                event.getEventDate(),
+                event.getVenue().getName(),
+                sectionName,
+                rowLabel,
+                seatNumber,
+                ticket.getTicketType(),
+                ticket.getFaceValue());
     }
 
     private SaleDto toSaleDto(OrderItem orderItem) {

--- a/backend/src/test/java/com/mockhub/ticket/controller/SellerControllerTest.java
+++ b/backend/src/test/java/com/mockhub/ticket/controller/SellerControllerTest.java
@@ -23,6 +23,7 @@ import com.mockhub.auth.security.SecurityUser;
 import com.mockhub.auth.security.UserDetailsServiceImpl;
 import com.mockhub.config.SecurityConfig;
 import com.mockhub.ticket.dto.EarningsSummaryDto;
+import com.mockhub.ticket.dto.OwnedTicketDto;
 import com.mockhub.ticket.dto.SaleDto;
 import com.mockhub.ticket.dto.SellerListingDto;
 import com.mockhub.ticket.service.ListingService;
@@ -225,6 +226,57 @@ class SellerControllerTest {
                 .andExpect(status().isNoContent());
 
         verify(listingService).deactivateListing(1L, "seller@example.com");
+    }
+
+    // -- GET /api/v1/my/owned-tickets (unauthenticated) --
+
+    @Test
+    @DisplayName("GET /api/v1/my/owned-tickets - unauthenticated - returns 401")
+    void getOwnedTickets_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(get("/api/v1/my/owned-tickets"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // -- GET /api/v1/my/owned-tickets (authenticated) --
+
+    @Test
+    @DisplayName("GET /api/v1/my/owned-tickets - authenticated - returns 200 with tickets")
+    void getOwnedTickets_authenticated_returns200() throws Exception {
+        authenticateAs(securityUser);
+
+        OwnedTicketDto dto = new OwnedTicketDto(
+                1L, "test-concert", "Test Concert",
+                Instant.parse("2026-06-15T20:00:00Z"),
+                "Madison Square Garden",
+                "Floor", "A", "1", "RESERVED",
+                new BigDecimal("50.00"));
+
+        when(listingService.getOwnedTickets("seller@example.com"))
+                .thenReturn(List.of(dto));
+
+        mockMvc.perform(get("/api/v1/my/owned-tickets"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].ticketId").value(1))
+                .andExpect(jsonPath("$[0].eventSlug").value("test-concert"))
+                .andExpect(jsonPath("$[0].sectionName").value("Floor"))
+                .andExpect(jsonPath("$[0].rowLabel").value("A"))
+                .andExpect(jsonPath("$[0].seatNumber").value("1"));
+
+        verify(listingService).getOwnedTickets("seller@example.com");
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/my/owned-tickets - authenticated with no tickets - returns empty list")
+    void getOwnedTickets_authenticated_noTickets_returnsEmptyList() throws Exception {
+        authenticateAs(securityUser);
+
+        when(listingService.getOwnedTickets("seller@example.com"))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/my/owned-tickets"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
     }
 
     // -- GET /api/v1/my/earnings (unauthenticated) --

--- a/backend/src/test/java/com/mockhub/ticket/service/ListingServiceTest.java
+++ b/backend/src/test/java/com/mockhub/ticket/service/ListingServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.mockhub.auth.repository.UserRepository;
+import com.mockhub.order.entity.OrderItem;
 import com.mockhub.common.exception.ConflictException;
 import com.mockhub.common.exception.ResourceNotFoundException;
 import com.mockhub.event.entity.Event;
@@ -24,6 +25,7 @@ import com.mockhub.event.entity.Category;
 import com.mockhub.ticket.dto.ListingCreateRequest;
 import com.mockhub.ticket.dto.ListingDto;
 import com.mockhub.ticket.dto.ListingSearchCriteria;
+import com.mockhub.ticket.dto.OwnedTicketDto;
 import com.mockhub.ticket.dto.TicketSearchResultDto;
 import com.mockhub.auth.entity.User;
 import com.mockhub.ticket.entity.Listing;
@@ -463,5 +465,97 @@ class ListingServiceTest {
         }
 
         return listing;
+    }
+
+    // -- getOwnedTickets --
+
+    @Test
+    @DisplayName("getOwnedTickets - given user with available tickets - returns owned ticket DTOs")
+    void getOwnedTickets_givenUserWithTickets_returnsOwnedTicketDtos() {
+        User user = new User();
+        user.setId(1L);
+        user.setEmail("buyer@example.com");
+
+        Venue venue = new Venue();
+        venue.setName("Madison Square Garden");
+        testEvent.setVenue(venue);
+
+        SeatRow row = new SeatRow();
+        row.setRowLabel("A");
+        Seat seat = new Seat();
+        seat.setSeatNumber("5");
+        seat.setRow(row);
+        testTicket.setSeat(seat);
+
+        Listing listing = new Listing();
+        listing.setEvent(testEvent);
+
+        OrderItem orderItem = new OrderItem();
+        orderItem.setTicket(testTicket);
+        orderItem.setListing(listing);
+
+        when(userRepository.findByEmail("buyer@example.com"))
+                .thenReturn(Optional.of(user));
+        when(orderItemRepository.findOwnedAvailableTicketsByUserId(1L))
+                .thenReturn(List.of(orderItem));
+
+        List<OwnedTicketDto> result = listingService.getOwnedTickets("buyer@example.com");
+
+        assertEquals(1, result.size());
+        OwnedTicketDto dto = result.get(0);
+        assertEquals(1L, dto.ticketId());
+        assertEquals("test-event", dto.eventSlug());
+        assertEquals("Floor", dto.sectionName());
+        assertEquals("A", dto.rowLabel());
+        assertEquals("5", dto.seatNumber());
+    }
+
+    @Test
+    @DisplayName("getOwnedTickets - given user with no tickets - returns empty list")
+    void getOwnedTickets_givenUserWithNoTickets_returnsEmptyList() {
+        User user = new User();
+        user.setId(2L);
+        user.setEmail("notickets@example.com");
+
+        when(userRepository.findByEmail("notickets@example.com"))
+                .thenReturn(Optional.of(user));
+        when(orderItemRepository.findOwnedAvailableTicketsByUserId(2L))
+                .thenReturn(List.of());
+
+        List<OwnedTicketDto> result = listingService.getOwnedTickets("notickets@example.com");
+
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    @DisplayName("getOwnedTickets - given ticket without seat - returns null row and seat")
+    void getOwnedTickets_givenTicketWithoutSeat_returnsNullRowAndSeat() {
+        User user = new User();
+        user.setId(1L);
+        user.setEmail("buyer@example.com");
+
+        Venue venue = new Venue();
+        venue.setName("Open Air Venue");
+        testEvent.setVenue(venue);
+
+        testTicket.setSeat(null);
+
+        Listing listing = new Listing();
+        listing.setEvent(testEvent);
+
+        OrderItem orderItem = new OrderItem();
+        orderItem.setTicket(testTicket);
+        orderItem.setListing(listing);
+
+        when(userRepository.findByEmail("buyer@example.com"))
+                .thenReturn(Optional.of(user));
+        when(orderItemRepository.findOwnedAvailableTicketsByUserId(1L))
+                .thenReturn(List.of(orderItem));
+
+        List<OwnedTicketDto> result = listingService.getOwnedTickets("buyer@example.com");
+
+        assertEquals(1, result.size());
+        assertNull(result.get(0).rowLabel());
+        assertNull(result.get(0).seatNumber());
     }
 }

--- a/frontend/src/api/seller.ts
+++ b/frontend/src/api/seller.ts
@@ -4,7 +4,13 @@ import type {
   SellListingRequest,
   UpdatePriceRequest,
   EarningsSummary,
+  OwnedTicket,
 } from '@/types/seller';
+
+export async function getMyOwnedTickets(): Promise<OwnedTicket[]> {
+  const response = await apiClient.get<OwnedTicket[]>('/my/owned-tickets');
+  return response.data;
+}
 
 export async function getMyListings(status?: string): Promise<SellerListing[]> {
   const response = await apiClient.get<SellerListing[]>('/my/listings', {

--- a/frontend/src/hooks/use-seller.ts
+++ b/frontend/src/hooks/use-seller.ts
@@ -1,6 +1,21 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import * as sellerApi from '@/api/seller';
 import type { SellListingRequest, UpdatePriceRequest } from '@/types/seller';
+import { useAuthStore } from '@/stores/auth-store';
+
+/**
+ * Hook for fetching the current user's owned tickets that are available to sell.
+ * Only fetches when the user is authenticated.
+ */
+export function useMyOwnedTickets() {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+
+  return useQuery({
+    queryKey: ['my-owned-tickets'],
+    queryFn: () => sellerApi.getMyOwnedTickets(),
+    enabled: isAuthenticated,
+  });
+}
 
 /**
  * Hook for fetching the current user's listings.

--- a/frontend/src/pages/SellPage.test.tsx
+++ b/frontend/src/pages/SellPage.test.tsx
@@ -4,6 +4,7 @@ import { SellPage } from './SellPage';
 import type { EventSummary } from '@/types/event';
 import type { PageResponse } from '@/types/common';
 import type { SectionAvailability } from '@/types/ticket';
+import type { OwnedTicket } from '@/types/seller';
 
 vi.mock('@/hooks/use-events', () => ({
   useEvents: vi.fn(() => ({
@@ -21,10 +22,14 @@ vi.mock('@/hooks/use-seller', () => ({
     mutate: vi.fn(),
     isPending: false,
   })),
+  useMyOwnedTickets: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+  })),
 }));
 
 import { useEvents, useEventSections } from '@/hooks/use-events';
-import { useCreateListing } from '@/hooks/use-seller';
+import { useCreateListing, useMyOwnedTickets } from '@/hooks/use-seller';
 
 const mockSections: SectionAvailability[] = [
   {
@@ -105,6 +110,40 @@ function setEvents(data: PageResponse<EventSummary> | undefined, isLoading = fal
     data,
     isLoading,
   } as unknown as ReturnType<typeof useEvents>);
+}
+
+const mockOwnedTickets: OwnedTicket[] = [
+  {
+    ticketId: 101,
+    eventSlug: 'taylor-swift-eras-tour',
+    eventName: 'Taylor Swift - Eras Tour',
+    eventDate: '2026-06-15T20:00:00',
+    venueName: 'SoFi Stadium',
+    sectionName: 'Floor',
+    rowLabel: 'A',
+    seatNumber: '5',
+    ticketType: 'RESERVED',
+    faceValue: 150.0,
+  },
+  {
+    ticketId: 102,
+    eventSlug: 'kendrick-lamar',
+    eventName: 'Kendrick Lamar',
+    eventDate: '2026-07-20T19:30:00',
+    venueName: 'Madison Square Garden',
+    sectionName: 'Section 101',
+    rowLabel: 'C',
+    seatNumber: '12',
+    ticketType: 'RESERVED',
+    faceValue: 85.0,
+  },
+];
+
+function setOwnedTickets(data: OwnedTicket[] | undefined, isLoading = false) {
+  vi.mocked(useMyOwnedTickets).mockReturnValue({
+    data,
+    isLoading,
+  } as unknown as ReturnType<typeof useMyOwnedTickets>);
 }
 
 function setSections(data: SectionAvailability[] | undefined, isLoading = false) {
@@ -319,5 +358,93 @@ describe('SellPage', () => {
     expect(screen.getByText('1')).toBeDefined();
     expect(screen.getByText('2')).toBeDefined();
     expect(screen.getByText('3')).toBeDefined();
+  });
+
+  // -- Owned Tickets (#81) --
+
+  it('shows owned tickets when user has available tickets', () => {
+    setOwnedTickets(mockOwnedTickets);
+    setEvents(undefined);
+
+    renderWithProviders(<SellPage />);
+
+    expect(screen.getByText('Your Tickets')).toBeDefined();
+    expect(screen.getByText('Taylor Swift - Eras Tour')).toBeDefined();
+    expect(screen.getByText('Kendrick Lamar')).toBeDefined();
+    expect(screen.getByText('$150.00')).toBeDefined();
+    expect(screen.getByText('Or Search for a Different Event')).toBeDefined();
+  });
+
+  it('skips to price step when an owned ticket is selected', async () => {
+    setOwnedTickets(mockOwnedTickets);
+    setEvents(undefined);
+    setSections(undefined);
+
+    const user = userEvent.setup();
+    renderWithProviders(<SellPage />);
+
+    // Click the first owned ticket
+    const ticketButtons = screen.getAllByRole('button');
+    const taylorButton = ticketButtons.find((btn) =>
+      btn.textContent?.includes('Taylor Swift - Eras Tour'),
+    );
+    expect(taylorButton).toBeDefined();
+    await user.click(taylorButton!);
+
+    // Should jump directly to step 3 (price)
+    expect(screen.getByText('Set Your Price')).toBeDefined();
+    expect(screen.getByText('Floor · Row A · Seat 5')).toBeDefined();
+  });
+
+  it('shows loading state while owned tickets load', () => {
+    setOwnedTickets(undefined, true);
+    setEvents(undefined);
+
+    renderWithProviders(<SellPage />);
+
+    const spinner = document.querySelector('.animate-spin');
+    expect(spinner).not.toBeNull();
+  });
+
+  it('goes to seat step when owned ticket has no row/seat (GA)', async () => {
+    const gaTickets: OwnedTicket[] = [
+      {
+        ticketId: 201,
+        eventSlug: 'outdoor-festival',
+        eventName: 'Outdoor Festival',
+        eventDate: '2026-08-01T14:00:00',
+        venueName: 'Central Park',
+        sectionName: 'General Admission',
+        rowLabel: null,
+        seatNumber: null,
+        ticketType: 'GENERAL_ADMISSION',
+        faceValue: 50.0,
+      },
+    ];
+    setOwnedTickets(gaTickets);
+    setEvents(undefined);
+    setSections([]);
+
+    const user = userEvent.setup();
+    renderWithProviders(<SellPage />);
+
+    const ticketButton = screen.getByText('Outdoor Festival').closest('button')!;
+    await user.click(ticketButton);
+
+    // Should go to step 2 (seat details) since row/seat are null
+    expect(screen.getAllByText('Seat Details').length).toBeGreaterThan(0);
+    // Section should be pre-filled
+    const sectionInput = screen.getByLabelText('Section') as HTMLInputElement;
+    expect(sectionInput.value).toBe('General Admission');
+  });
+
+  it('shows only search when user has no owned tickets', () => {
+    setOwnedTickets([]);
+    setEvents(undefined);
+
+    renderWithProviders(<SellPage />);
+
+    expect(screen.getByText('Select an Event')).toBeDefined();
+    expect(screen.queryByText('Your Tickets')).toBeNull();
   });
 });

--- a/frontend/src/pages/SellPage.tsx
+++ b/frontend/src/pages/SellPage.tsx
@@ -14,16 +14,19 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { useEvents, useEventSections } from '@/hooks/use-events';
-import { useCreateListing } from '@/hooks/use-seller';
+import { useCreateListing, useMyOwnedTickets } from '@/hooks/use-seller';
+import { VenueMap } from '@/components/tickets/VenueMap';
 import type { EventSummary } from '@/types/event';
+import type { OwnedTicket } from '@/types/seller';
 import type { SellListingRequest } from '@/types/seller';
 
 type Step = 'event' | 'seat' | 'price';
 
 /**
  * Multi-step form for creating a new ticket listing.
- * Step 1: Search and select an event
- * Step 2: Enter seat details (section, row, seat number)
+ * Shows owned tickets first for quick listing, with fallback to event search.
+ * Step 1: Select from owned tickets or search for an event
+ * Step 2: Enter seat details (section, row, seat number) with optional VenueMap
  * Step 3: Set the listing price
  */
 export function SellPage() {
@@ -37,6 +40,8 @@ export function SellPage() {
   const [rowLabel, setRowLabel] = useState('');
   const [seatNumber, setSeatNumber] = useState('');
   const [listedPrice, setListedPrice] = useState('');
+
+  const { data: ownedTickets, isLoading: ownedTicketsLoading } = useMyOwnedTickets();
 
   const { data: sections, isLoading: sectionsLoading } = useEventSections(
     selectedEvent?.slug ?? '',
@@ -52,7 +57,37 @@ export function SellPage() {
   const handleSelectEvent = useCallback((event: EventSummary) => {
     setSelectedEvent(event);
     setSectionName('');
+    setRowLabel('');
+    setSeatNumber('');
     setStep('seat');
+  }, []);
+
+  const handleSelectOwnedTicket = useCallback((ticket: OwnedTicket) => {
+    const eventSummary: EventSummary = {
+      id: 0,
+      name: ticket.eventName,
+      slug: ticket.eventSlug,
+      artistName: null,
+      venueName: ticket.venueName,
+      city: '',
+      eventDate: ticket.eventDate,
+      categoryName: '',
+      primaryImageUrl: null,
+      minPrice: null,
+      availableTickets: 0,
+      isFeatured: false,
+    };
+    setSelectedEvent(eventSummary);
+    setSectionName(ticket.sectionName);
+    setRowLabel(ticket.rowLabel ?? '');
+    setSeatNumber(ticket.seatNumber ?? '');
+
+    // Skip to price only if we have complete seat info; otherwise go to seat step
+    if (ticket.rowLabel && ticket.seatNumber) {
+      setStep('price');
+    } else {
+      setStep('seat');
+    }
   }, []);
 
   const handleSeatSubmit = useCallback(
@@ -109,6 +144,20 @@ export function SellPage() {
     [selectedEvent, sectionName, rowLabel, seatNumber, listedPrice, createListing, navigate],
   );
 
+  const handleSectionSelect = useCallback(
+    (sectionId: number | null) => {
+      if (sectionId === null || !sections) {
+        setSectionName('');
+        return;
+      }
+      const section = sections.find((s) => s.sectionId === sectionId);
+      if (section) {
+        setSectionName(section.sectionName);
+      }
+    },
+    [sections],
+  );
+
   const renderSectionInput = () => {
     if (sectionsLoading) {
       return (
@@ -144,6 +193,10 @@ export function SellPage() {
       />
     );
   };
+
+  const selectedSectionId = sections?.find((s) => s.sectionName === sectionName)?.sectionId ?? null;
+
+  const hasSvgSections = sections?.some((s) => s.svgX !== null) ?? false;
 
   return (
     <div className="mx-auto max-w-2xl px-4 py-6 sm:px-6 lg:px-8">
@@ -183,72 +236,133 @@ export function SellPage() {
 
       {/* Step 1: Select Event */}
       {step === 'event' && (
-        <Card>
-          <CardHeader>
-            <CardTitle>Select an Event</CardTitle>
-            <CardDescription>Search for the event you have tickets for.</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <div className="relative mb-4">
-              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-              <Input
-                placeholder="Search events..."
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                className="pl-9"
-              />
-            </div>
-
-            {eventsLoading && (
-              <div className="flex items-center justify-center py-8">
+        <div className="space-y-6">
+          {/* Owned Tickets Section */}
+          {ownedTicketsLoading && (
+            <Card>
+              <CardContent className="flex items-center justify-center py-8">
                 <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-              </div>
-            )}
+              </CardContent>
+            </Card>
+          )}
 
-            {!eventsLoading && searchQuery.length >= 2 && events.length === 0 && (
-              <p className="py-8 text-center text-sm text-muted-foreground">
-                No events found. Try a different search term.
-              </p>
-            )}
-
-            {!eventsLoading && searchQuery.length < 2 && (
-              <p className="py-8 text-center text-sm text-muted-foreground">
-                Type at least 2 characters to search for events.
-              </p>
-            )}
-
-            <div className="space-y-2">
-              {events.map((event) => (
-                <button
-                  key={event.id}
-                  onClick={() => handleSelectEvent(event)}
-                  className="w-full rounded-lg border p-4 text-left transition-colors hover:bg-accent"
-                >
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0 flex-1">
-                      <p className="font-medium">{event.name}</p>
-                      <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
-                        <span className="flex items-center gap-1">
-                          <Calendar className="h-3.5 w-3.5" />
-                          {new Date(event.eventDate).toLocaleDateString()}
-                        </span>
-                        <span className="flex items-center gap-1">
-                          <MapPin className="h-3.5 w-3.5" />
-                          {event.venueName}, {event.city}
+          {ownedTickets && ownedTickets.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle>Your Tickets</CardTitle>
+                <CardDescription>Select a ticket you own to list it for sale.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-2">
+                  {ownedTickets.map((ticket) => (
+                    <button
+                      key={ticket.ticketId}
+                      onClick={() => handleSelectOwnedTicket(ticket)}
+                      className="w-full rounded-lg border p-4 text-left transition-colors hover:bg-accent"
+                    >
+                      <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0 flex-1">
+                          <p className="font-medium">{ticket.eventName}</p>
+                          <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+                            <span className="flex items-center gap-1">
+                              <Calendar className="h-3.5 w-3.5" />
+                              {new Date(ticket.eventDate).toLocaleDateString()}
+                            </span>
+                            <span className="flex items-center gap-1">
+                              <MapPin className="h-3.5 w-3.5" />
+                              {ticket.venueName}
+                            </span>
+                            <span className="flex items-center gap-1">
+                              <Ticket className="h-3.5 w-3.5" />
+                              {ticket.sectionName}
+                              {ticket.rowLabel && `, Row ${ticket.rowLabel}`}
+                              {ticket.seatNumber && `, Seat ${ticket.seatNumber}`}
+                            </span>
+                          </div>
+                        </div>
+                        <span className="shrink-0 text-sm text-muted-foreground">
+                          ${ticket.faceValue.toFixed(2)}
                         </span>
                       </div>
+                    </button>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Event Search */}
+          <Card>
+            <CardHeader>
+              <CardTitle>
+                {ownedTickets && ownedTickets.length > 0
+                  ? 'Or Search for a Different Event'
+                  : 'Select an Event'}
+              </CardTitle>
+              <CardDescription>Search for the event you have tickets for.</CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="relative mb-4">
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  placeholder="Search events..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="pl-9"
+                />
+              </div>
+
+              {eventsLoading && (
+                <div className="flex items-center justify-center py-8">
+                  <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                </div>
+              )}
+
+              {!eventsLoading && searchQuery.length >= 2 && events.length === 0 && (
+                <p className="py-8 text-center text-sm text-muted-foreground">
+                  No events found. Try a different search term.
+                </p>
+              )}
+
+              {!eventsLoading && searchQuery.length < 2 && (
+                <p className="py-8 text-center text-sm text-muted-foreground">
+                  Type at least 2 characters to search for events.
+                </p>
+              )}
+
+              <div className="space-y-2">
+                {events.map((event) => (
+                  <button
+                    key={event.id}
+                    onClick={() => handleSelectEvent(event)}
+                    className="w-full rounded-lg border p-4 text-left transition-colors hover:bg-accent"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0 flex-1">
+                        <p className="font-medium">{event.name}</p>
+                        <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-muted-foreground">
+                          <span className="flex items-center gap-1">
+                            <Calendar className="h-3.5 w-3.5" />
+                            {new Date(event.eventDate).toLocaleDateString()}
+                          </span>
+                          <span className="flex items-center gap-1">
+                            <MapPin className="h-3.5 w-3.5" />
+                            {event.venueName}, {event.city}
+                          </span>
+                        </div>
+                      </div>
+                      {event.minPrice !== null && (
+                        <span className="shrink-0 text-sm text-muted-foreground">
+                          from ${event.minPrice.toFixed(2)}
+                        </span>
+                      )}
                     </div>
-                    {event.minPrice !== null && (
-                      <span className="shrink-0 text-sm text-muted-foreground">
-                        from ${event.minPrice.toFixed(2)}
-                      </span>
-                    )}
-                  </div>
-                </button>
-              ))}
-            </div>
-          </CardContent>
-        </Card>
+                  </button>
+                ))}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
       )}
 
       {/* Step 2: Enter Seat Details */}
@@ -262,6 +376,18 @@ export function SellPage() {
             </CardDescription>
           </CardHeader>
           <CardContent>
+            {/* VenueMap for visual section selection */}
+            {hasSvgSections && sections && (
+              <div className="mb-6">
+                <Label className="mb-2 block">Select a section on the map</Label>
+                <VenueMap
+                  sections={sections}
+                  selectedSectionId={selectedSectionId}
+                  onSectionSelect={handleSectionSelect}
+                />
+              </div>
+            )}
+
             <form onSubmit={handleSeatSubmit} className="space-y-4">
               <div className="space-y-2">
                 <Label htmlFor="section">Section</Label>

--- a/frontend/src/types/seller.ts
+++ b/frontend/src/types/seller.ts
@@ -17,6 +17,19 @@ export interface SellerListing {
   createdAt: string;
 }
 
+export interface OwnedTicket {
+  ticketId: number;
+  eventSlug: string;
+  eventName: string;
+  eventDate: string;
+  venueName: string;
+  sectionName: string;
+  rowLabel: string | null;
+  seatNumber: string | null;
+  ticketType: string;
+  faceValue: number;
+}
+
 export interface SellListingRequest {
   eventSlug: string;
   sectionName: string;


### PR DESCRIPTION
## Summary
- **#81**: SellPage step 1 now shows the user's owned tickets (from confirmed orders) as selectable cards. Clicking one pre-fills event/section/row/seat and skips to the price step. GA tickets without row/seat go to the seat details step instead.
- **#38**: VenueMap renders in step 2 when SVG section data is available. Clicking a section auto-fills the section dropdown.
- New `GET /api/v1/my/owned-tickets` backend endpoint queries `OrderItem → Ticket` (status `SOLD`) with eager joins for event/venue/section/seat data.

Closes #81, closes #38

## Test plan
- [ ] Backend: 3 new unit tests (service) + 3 new controller tests for owned-tickets endpoint
- [ ] Frontend: 5 new SellPage tests (owned tickets display, selection skip, GA fallback, loading, empty state)
- [ ] Verify SonarCloud quality gate passes (80%+ coverage on new code)
- [ ] Manual: login → /sell → verify owned tickets appear → click one → verify skip to price
- [ ] Manual: step 2 with SVG venue → verify VenueMap renders and section click fills dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)