### PR TITLE
Add mandate management UI for agent authorization

### DIFF
--- a/backend/src/main/java/com/mockhub/mandate/controller/MandateController.java
+++ b/backend/src/main/java/com/mockhub/mandate/controller/MandateController.java
@@ -1,0 +1,82 @@
+package com.mockhub.mandate.controller;
+
+import java.util.List;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.mockhub.auth.security.SecurityUser;
+import com.mockhub.mandate.dto.CreateMandateRequest;
+import com.mockhub.mandate.dto.MandateDto;
+import com.mockhub.mandate.dto.WebCreateMandateRequest;
+import com.mockhub.mandate.service.MandateService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@RequestMapping("/api/v1/my/mandates")
+@Tag(name = "Mandates", description = "Agent mandate management")
+public class MandateController {
+
+    private final MandateService mandateService;
+
+    public MandateController(MandateService mandateService) {
+        this.mandateService = mandateService;
+    }
+
+    @PostMapping
+    @Operation(summary = "Create mandate",
+            description = "Create a new agent mandate for the authenticated user")
+    @ApiResponse(responseCode = "201", description = "Mandate created")
+    public ResponseEntity<MandateDto> createMandate(
+            @AuthenticationPrincipal SecurityUser securityUser,
+            @Valid @RequestBody WebCreateMandateRequest request) {
+        CreateMandateRequest serviceRequest = new CreateMandateRequest(
+                request.agentId(),
+                securityUser.getEmail(),
+                request.scope(),
+                request.maxSpendPerTransaction(),
+                request.maxSpendTotal(),
+                request.allowedCategories(),
+                request.allowedEvents(),
+                request.expiresAt()
+        );
+        MandateDto mandate = mandateService.createMandate(serviceRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(mandate);
+    }
+
+    @GetMapping
+    @Operation(summary = "List my mandates",
+            description = "Return all mandates for the authenticated user (active, expired, and revoked)")
+    @ApiResponse(responseCode = "200", description = "Mandates returned")
+    public ResponseEntity<List<MandateDto>> listMandates(
+            @AuthenticationPrincipal SecurityUser securityUser) {
+        List<MandateDto> mandates = mandateService.listAllMandates(securityUser.getEmail());
+        return ResponseEntity.ok(mandates);
+    }
+
+    @DeleteMapping("/{mandateId}")
+    @Operation(summary = "Revoke mandate",
+            description = "Revoke an agent mandate owned by the authenticated user")
+    @ApiResponse(responseCode = "204", description = "Mandate revoked")
+    @ApiResponse(responseCode = "404", description = "Mandate not found")
+    @ApiResponse(responseCode = "401", description = "Not the mandate owner")
+    public ResponseEntity<Void> revokeMandate(
+            @AuthenticationPrincipal SecurityUser securityUser,
+            @PathVariable String mandateId) {
+        mandateService.revokeMandate(mandateId, securityUser.getEmail());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/src/main/java/com/mockhub/mandate/dto/WebCreateMandateRequest.java
+++ b/backend/src/main/java/com/mockhub/mandate/dto/WebCreateMandateRequest.java
@@ -1,0 +1,16 @@
+package com.mockhub.mandate.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record WebCreateMandateRequest(
+        @NotBlank String agentId,
+        @NotBlank String scope,
+        BigDecimal maxSpendPerTransaction,
+        BigDecimal maxSpendTotal,
+        String allowedCategories,
+        String allowedEvents,
+        Instant expiresAt
+) {}

--- a/backend/src/main/java/com/mockhub/mandate/repository/MandateRepository.java
+++ b/backend/src/main/java/com/mockhub/mandate/repository/MandateRepository.java
@@ -17,6 +17,8 @@ public interface MandateRepository extends JpaRepository<Mandate, Long> {
 
     List<Mandate> findByUserEmailAndStatus(String userEmail, String status);
 
+    List<Mandate> findByUserEmail(String userEmail);
+
     Optional<Mandate> findByMandateId(String mandateId);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/backend/src/main/java/com/mockhub/mandate/service/MandateService.java
+++ b/backend/src/main/java/com/mockhub/mandate/service/MandateService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.mockhub.common.exception.ResourceNotFoundException;
+import com.mockhub.common.exception.UnauthorizedException;
 import com.mockhub.mandate.dto.CreateMandateRequest;
 import com.mockhub.mandate.dto.MandateDto;
 import com.mockhub.mandate.entity.Mandate;
@@ -72,6 +73,27 @@ public class MandateService {
         return mandates.stream()
                 .map(this::toDto)
                 .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<MandateDto> listAllMandates(String userEmail) {
+        List<Mandate> mandates = mandateRepository.findByUserEmail(userEmail);
+        return mandates.stream()
+                .map(this::toDto)
+                .toList();
+    }
+
+    @Transactional
+    public void revokeMandate(String mandateId, String userEmail) {
+        Mandate mandate = mandateRepository.findByMandateId(mandateId)
+                .orElseThrow(() -> new ResourceNotFoundException(MANDATE_RESOURCE, MANDATE_ID_FIELD, mandateId));
+        if (!mandate.getUserEmail().equals(userEmail)) {
+            throw new UnauthorizedException("You do not own this mandate");
+        }
+        mandate.setStatus("REVOKED");
+        mandate.setRevokedAt(Instant.now());
+        mandateRepository.save(mandate);
+        log.info("Revoked mandate {} by user {}", mandateId, userEmail);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/test/java/com/mockhub/mandate/controller/MandateControllerTest.java
+++ b/backend/src/test/java/com/mockhub/mandate/controller/MandateControllerTest.java
@@ -1,0 +1,263 @@
+package com.mockhub.mandate.controller;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.mockhub.auth.entity.User;
+import com.mockhub.auth.security.JwtAuthenticationFilter;
+import com.mockhub.auth.security.JwtTokenProvider;
+import com.mockhub.auth.security.SecurityUser;
+import com.mockhub.auth.security.UserDetailsServiceImpl;
+import com.mockhub.common.exception.ResourceNotFoundException;
+import com.mockhub.common.exception.UnauthorizedException;
+import com.mockhub.config.SecurityConfig;
+import com.mockhub.mandate.dto.MandateDto;
+import com.mockhub.mandate.service.MandateService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(MandateController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class MandateControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private MandateService mandateService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private UserDetailsServiceImpl userDetailsService;
+
+    private SecurityUser securityUser;
+
+    @BeforeEach
+    void setUp() {
+        User user = new User();
+        user.setId(1L);
+        user.setEmail("user@example.com");
+        user.setPasswordHash("hashed");
+        user.setFirstName("Test");
+        user.setLastName("User");
+        user.setEnabled(true);
+        securityUser = new SecurityUser(user);
+    }
+
+    private void authenticateAs(SecurityUser principal) {
+        UsernamePasswordAuthenticationToken auth =
+                new UsernamePasswordAuthenticationToken(
+                        principal, null, principal.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+
+    private MandateDto sampleMandateDto() {
+        return new MandateDto(
+                1L,
+                "test-mandate-123",
+                "claude-desktop",
+                "user@example.com",
+                "PURCHASE",
+                new BigDecimal("200.00"),
+                new BigDecimal("1000.00"),
+                BigDecimal.ZERO,
+                new BigDecimal("1000.00"),
+                "jazz,classical",
+                null,
+                "ACTIVE",
+                Instant.now().plus(7, ChronoUnit.DAYS),
+                Instant.now()
+        );
+    }
+
+    // -- POST /api/v1/my/mandates (unauthenticated) --
+
+    @Test
+    @DisplayName("POST /api/v1/my/mandates - unauthenticated - returns 401")
+    void createMandate_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(post("/api/v1/my/mandates")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "agentId": "claude-desktop",
+                                    "scope": "PURCHASE"
+                                }
+                                """))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // -- POST /api/v1/my/mandates (authenticated, real frontend payload without userEmail) --
+
+    @Test
+    @DisplayName("POST /api/v1/my/mandates - authenticated - returns 201 with authenticated user's email")
+    void createMandate_authenticated_returns201() throws Exception {
+        authenticateAs(securityUser);
+
+        MandateDto dto = sampleMandateDto();
+        when(mandateService.createMandate(argThat(req ->
+                "user@example.com".equals(req.userEmail()))))
+                .thenReturn(dto);
+
+        mockMvc.perform(post("/api/v1/my/mandates")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "agentId": "claude-desktop",
+                                    "scope": "PURCHASE",
+                                    "maxSpendPerTransaction": 200.00,
+                                    "maxSpendTotal": 1000.00,
+                                    "allowedCategories": "jazz,classical"
+                                }
+                                """))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.mandateId").value("test-mandate-123"))
+                .andExpect(jsonPath("$.agentId").value("claude-desktop"))
+                .andExpect(jsonPath("$.userEmail").value("user@example.com"));
+
+        verify(mandateService).createMandate(argThat(req ->
+                "user@example.com".equals(req.userEmail())));
+    }
+
+    // -- POST /api/v1/my/mandates (missing agentId) --
+
+    @Test
+    @DisplayName("POST /api/v1/my/mandates - missing agentId - returns 400")
+    void createMandate_missingAgentId_returns400() throws Exception {
+        authenticateAs(securityUser);
+
+        mockMvc.perform(post("/api/v1/my/mandates")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                    "agentId": "",
+                                    "scope": "PURCHASE"
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+
+    // -- GET /api/v1/my/mandates (unauthenticated) --
+
+    @Test
+    @DisplayName("GET /api/v1/my/mandates - unauthenticated - returns 401")
+    void listMandates_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(get("/api/v1/my/mandates"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // -- GET /api/v1/my/mandates (authenticated) --
+
+    @Test
+    @DisplayName("GET /api/v1/my/mandates - authenticated - returns 200 with mandates")
+    void listMandates_authenticated_returns200() throws Exception {
+        authenticateAs(securityUser);
+
+        MandateDto dto = sampleMandateDto();
+        when(mandateService.listAllMandates("user@example.com"))
+                .thenReturn(List.of(dto));
+
+        mockMvc.perform(get("/api/v1/my/mandates"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].mandateId").value("test-mandate-123"))
+                .andExpect(jsonPath("$[0].agentId").value("claude-desktop"))
+                .andExpect(jsonPath("$[0].scope").value("PURCHASE"));
+    }
+
+    // -- GET /api/v1/my/mandates (empty list) --
+
+    @Test
+    @DisplayName("GET /api/v1/my/mandates - no mandates - returns empty array")
+    void listMandates_emptyList_returns200() throws Exception {
+        authenticateAs(securityUser);
+
+        when(mandateService.listAllMandates("user@example.com"))
+                .thenReturn(List.of());
+
+        mockMvc.perform(get("/api/v1/my/mandates"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$").isEmpty());
+    }
+
+    // -- DELETE /api/v1/my/mandates/{mandateId} (unauthenticated) --
+
+    @Test
+    @DisplayName("DELETE /api/v1/my/mandates/{mandateId} - unauthenticated - returns 401")
+    void revokeMandate_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(delete("/api/v1/my/mandates/test-mandate-123"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // -- DELETE /api/v1/my/mandates/{mandateId} (authenticated) --
+
+    @Test
+    @DisplayName("DELETE /api/v1/my/mandates/{mandateId} - authenticated - returns 204")
+    void revokeMandate_authenticated_returns204() throws Exception {
+        authenticateAs(securityUser);
+
+        doNothing().when(mandateService)
+                .revokeMandate("test-mandate-123", "user@example.com");
+
+        mockMvc.perform(delete("/api/v1/my/mandates/test-mandate-123"))
+                .andExpect(status().isNoContent());
+
+        verify(mandateService).revokeMandate("test-mandate-123", "user@example.com");
+    }
+
+    // -- DELETE /api/v1/my/mandates/{mandateId} (not found) --
+
+    @Test
+    @DisplayName("DELETE /api/v1/my/mandates/{mandateId} - not found - returns 404")
+    void revokeMandate_notFound_returns404() throws Exception {
+        authenticateAs(securityUser);
+
+        doThrow(new ResourceNotFoundException("Mandate", "mandateId", "unknown-mandate"))
+                .when(mandateService)
+                .revokeMandate("unknown-mandate", "user@example.com");
+
+        mockMvc.perform(delete("/api/v1/my/mandates/unknown-mandate"))
+                .andExpect(status().isNotFound());
+    }
+
+    // -- DELETE /api/v1/my/mandates/{mandateId} (not owner) --
+
+    @Test
+    @DisplayName("DELETE /api/v1/my/mandates/{mandateId} - not owner - returns 401")
+    void revokeMandate_notOwner_returns401() throws Exception {
+        authenticateAs(securityUser);
+
+        doThrow(new UnauthorizedException("You do not own this mandate"))
+                .when(mandateService)
+                .revokeMandate("other-mandate", "user@example.com");
+
+        mockMvc.perform(delete("/api/v1/my/mandates/other-mandate"))
+                .andExpect(status().isUnauthorized());
+    }
+}

--- a/frontend/src/api/mandates.test.ts
+++ b/frontend/src/api/mandates.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from 'vitest';
+import { getMyMandates, createMandate, revokeMandate } from './mandates';
+
+vi.mock('./client', () => ({
+  default: {
+    get: vi.fn().mockResolvedValue({ data: 'mock' }),
+    post: vi.fn().mockResolvedValue({ data: 'mock' }),
+    delete: vi.fn().mockResolvedValue({}),
+  },
+}));
+
+describe('mandates API', () => {
+  it('getMyMandates calls /my/mandates', async () => {
+    const client = (await import('./client')).default;
+    await getMyMandates();
+    expect(client.get).toHaveBeenCalledWith('/my/mandates');
+  });
+
+  it('createMandate posts to /my/mandates', async () => {
+    const client = (await import('./client')).default;
+    await createMandate({
+      agentId: 'claude-desktop',
+      scope: 'PURCHASE',
+      maxSpendPerTransaction: 200,
+    });
+    expect(client.post).toHaveBeenCalledWith(
+      '/my/mandates',
+      expect.objectContaining({ agentId: 'claude-desktop' }),
+    );
+  });
+
+  it('revokeMandate deletes /my/mandates/{mandateId}', async () => {
+    const client = (await import('./client')).default;
+    await revokeMandate('mandate-123');
+    expect(client.delete).toHaveBeenCalledWith('/my/mandates/mandate-123');
+  });
+});

--- a/frontend/src/api/mandates.ts
+++ b/frontend/src/api/mandates.ts
@@ -1,0 +1,16 @@
+import apiClient from './client';
+import type { Mandate, CreateMandateRequest } from '@/types/mandate';
+
+export async function getMyMandates(): Promise<Mandate[]> {
+  const response = await apiClient.get<Mandate[]>('/my/mandates');
+  return response.data;
+}
+
+export async function createMandate(request: CreateMandateRequest): Promise<Mandate> {
+  const response = await apiClient.post<Mandate>('/my/mandates', request);
+  return response.data;
+}
+
+export async function revokeMandate(mandateId: string): Promise<void> {
+  await apiClient.delete(`/my/mandates/${mandateId}`);
+}

--- a/frontend/src/components/layout/Header.tsx
+++ b/frontend/src/components/layout/Header.tsx
@@ -9,6 +9,7 @@ import {
   Settings,
   Tag,
   DollarSign,
+  Shield,
 } from 'lucide-react';
 import { NotificationBell } from '@/components/notifications/NotificationBell';
 import { Button } from '@/components/ui/button';
@@ -136,6 +137,12 @@ export function Header() {
                   <Link to={ROUTES.EARNINGS}>
                     <DollarSign className="mr-2 h-4 w-4" />
                     Earnings
+                  </Link>
+                </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link to={ROUTES.MANDATES}>
+                    <Shield className="mr-2 h-4 w-4" />
+                    Mandates
                   </Link>
                 </DropdownMenuItem>
                 {user.roles?.includes('ROLE_ADMIN') && (

--- a/frontend/src/components/layout/MobileNav.tsx
+++ b/frontend/src/components/layout/MobileNav.tsx
@@ -3,6 +3,7 @@ import {
   Bell,
   DollarSign,
   Heart,
+  Shield,
   LogOut,
   Settings,
   ShoppingCart,
@@ -133,6 +134,14 @@ export function MobileNav() {
               >
                 <DollarSign className="h-4 w-4" />
                 Earnings
+              </Link>
+              <Link
+                to={ROUTES.MANDATES}
+                onClick={closeMobileNav}
+                className={navLinkClass(ROUTES.MANDATES)}
+              >
+                <Shield className="h-4 w-4" />
+                Mandates
               </Link>
               {isAdmin && (
                 <>

--- a/frontend/src/hooks/use-mandates.test.ts
+++ b/frontend/src/hooks/use-mandates.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+import { useMyMandates, useCreateMandate, useRevokeMandate } from './use-mandates';
+
+vi.mock('@/api/mandates', () => ({
+  getMyMandates: vi.fn().mockResolvedValue([]),
+  createMandate: vi.fn().mockResolvedValue({ mandateId: 'test-mandate' }),
+  revokeMandate: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/stores/auth-store', () => ({
+  useAuthStore: vi.fn((selector: (state: { isAuthenticated: boolean }) => boolean) =>
+    selector({ isAuthenticated: true }),
+  ),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  };
+}
+
+describe('use-mandates hooks', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('useMyMandates fetches mandates', async () => {
+    const { result } = renderHook(() => useMyMandates(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual([]);
+  });
+
+  it('useCreateMandate calls createMandate', async () => {
+    const mandatesApi = await import('@/api/mandates');
+    const { result } = renderHook(() => useCreateMandate(), { wrapper: createWrapper() });
+
+    result.current.mutate({
+      agentId: 'claude-desktop',
+      scope: 'PURCHASE',
+      maxSpendPerTransaction: 200,
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mandatesApi.createMandate).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: 'claude-desktop' }),
+    );
+  });
+
+  it('useRevokeMandate calls revokeMandate', async () => {
+    const mandatesApi = await import('@/api/mandates');
+    const { result } = renderHook(() => useRevokeMandate(), { wrapper: createWrapper() });
+
+    result.current.mutate('mandate-123');
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mandatesApi.revokeMandate).toHaveBeenCalledWith('mandate-123');
+  });
+});

--- a/frontend/src/hooks/use-mandates.ts
+++ b/frontend/src/hooks/use-mandates.ts
@@ -1,0 +1,36 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import * as mandatesApi from '@/api/mandates';
+import type { CreateMandateRequest } from '@/types/mandate';
+import { useAuthStore } from '@/stores/auth-store';
+
+export function useMyMandates() {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+
+  return useQuery({
+    queryKey: ['my-mandates'],
+    queryFn: () => mandatesApi.getMyMandates(),
+    enabled: isAuthenticated,
+  });
+}
+
+export function useCreateMandate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: CreateMandateRequest) => mandatesApi.createMandate(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['my-mandates'] });
+    },
+  });
+}
+
+export function useRevokeMandate() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (mandateId: string) => mandatesApi.revokeMandate(mandateId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['my-mandates'] });
+    },
+  });
+}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -16,6 +16,7 @@ export const ROUTES = {
   SELL: '/sell',
   MY_LISTINGS: '/my/listings',
   EARNINGS: '/my/earnings',
+  MANDATES: '/my/mandates',
   ADMIN: '/admin',
   ADMIN_DASHBOARD: '/admin',
   ADMIN_EVENTS: '/admin/events',

--- a/frontend/src/pages/MandatesPage.test.tsx
+++ b/frontend/src/pages/MandatesPage.test.tsx
@@ -1,0 +1,174 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderWithProviders, screen, userEvent } from '@/test/test-utils';
+import { MandatesPage } from './MandatesPage';
+import type { Mandate } from '@/types/mandate';
+
+vi.mock('@/hooks/use-mandates', () => ({
+  useMyMandates: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+  })),
+  useCreateMandate: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
+  useRevokeMandate: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
+}));
+
+import { useMyMandates } from '@/hooks/use-mandates';
+
+const mockMandates: Mandate[] = [
+  {
+    id: 1,
+    mandateId: 'mandate-001',
+    agentId: 'claude-desktop',
+    userEmail: 'user@example.com',
+    scope: 'PURCHASE',
+    maxSpendPerTransaction: 200,
+    maxSpendTotal: 1000,
+    totalSpent: 150,
+    remainingBudget: 850,
+    allowedCategories: 'jazz, classical',
+    allowedEvents: null,
+    status: 'ACTIVE',
+    expiresAt: '2027-12-31T23:59:59Z',
+    createdAt: '2026-03-01T10:00:00Z',
+  },
+  {
+    id: 2,
+    mandateId: 'mandate-002',
+    agentId: 'my-agent',
+    userEmail: 'user@example.com',
+    scope: 'BROWSE',
+    maxSpendPerTransaction: null,
+    maxSpendTotal: null,
+    totalSpent: 0,
+    remainingBudget: null,
+    allowedCategories: null,
+    allowedEvents: null,
+    status: 'REVOKED',
+    expiresAt: null,
+    createdAt: '2026-02-15T14:00:00Z',
+  },
+];
+
+function setMandates(data: Mandate[] | undefined, isLoading = false) {
+  vi.mocked(useMyMandates).mockReturnValue({
+    data,
+    isLoading,
+  } as unknown as ReturnType<typeof useMyMandates>);
+}
+
+describe('MandatesPage', () => {
+  it('renders mandate data when mandates exist', () => {
+    setMandates(mockMandates);
+
+    renderWithProviders(<MandatesPage />);
+
+    expect(screen.getByText('Agent Mandates')).toBeDefined();
+    // Active mandate agent ID appears in both mobile card and desktop table layouts
+    expect(screen.getAllByText('claude-desktop').length).toBeGreaterThan(0);
+  });
+
+  it('shows empty state when no mandates', () => {
+    setMandates([]);
+
+    renderWithProviders(<MandatesPage />);
+
+    expect(screen.getByText('No mandates')).toBeDefined();
+    expect(
+      screen.getByText('Create a mandate to authorize an AI agent to act on your behalf.'),
+    ).toBeDefined();
+  });
+
+  it('renders tab filters', () => {
+    setMandates(mockMandates);
+
+    renderWithProviders(<MandatesPage />);
+
+    expect(screen.getByRole('tab', { name: 'Active' })).toBeDefined();
+    expect(screen.getByRole('tab', { name: 'Expired' })).toBeDefined();
+    expect(screen.getByRole('tab', { name: 'Revoked' })).toBeDefined();
+  });
+
+  it('shows Revoked tab content when clicked', async () => {
+    setMandates(mockMandates);
+
+    const user = userEvent.setup();
+    renderWithProviders(<MandatesPage />);
+
+    const revokedTab = screen.getByRole('tab', { name: 'Revoked' });
+    await user.click(revokedTab);
+
+    // Revoked mandate agent ID appears in both mobile card and desktop table layouts
+    expect(screen.getAllByText('my-agent').length).toBeGreaterThan(0);
+  });
+
+  it('shows loading skeleton when loading', () => {
+    setMandates(undefined, true);
+
+    const { container } = renderWithProviders(<MandatesPage />);
+
+    // Skeleton components render with animate-pulse class
+    const skeletons = container.querySelectorAll('[class*="animate-pulse"]');
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it('shows "New Mandate" button', () => {
+    setMandates(mockMandates);
+
+    renderWithProviders(<MandatesPage />);
+
+    expect(screen.getByText('New Mandate')).toBeDefined();
+  });
+
+  it('shows create form when "New Mandate" clicked', async () => {
+    setMandates(mockMandates);
+
+    const user = userEvent.setup();
+    renderWithProviders(<MandatesPage />);
+
+    const newMandateButton = screen.getByText('New Mandate');
+    await user.click(newMandateButton);
+
+    expect(screen.getByLabelText(/Agent ID/)).toBeDefined();
+    expect(screen.getByLabelText(/Scope/)).toBeDefined();
+    expect(screen.getByLabelText(/Per-Transaction Limit/)).toBeDefined();
+    expect(screen.getByLabelText(/Total Budget/)).toBeDefined();
+  });
+
+  it('shows scope badge for active mandate', () => {
+    setMandates(mockMandates);
+
+    renderWithProviders(<MandatesPage />);
+
+    // PURCHASE badge appears in both mobile card and desktop table layouts
+    expect(screen.getAllByText('PURCHASE').length).toBeGreaterThan(0);
+  });
+
+  it('shows spending summary for mandate with budget', () => {
+    setMandates(mockMandates);
+
+    renderWithProviders(<MandatesPage />);
+
+    // Spending summary shows in both mobile card and desktop table layouts
+    expect(screen.getAllByText(/\$150\.00 spent/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/\$1000\.00 total/).length).toBeGreaterThan(0);
+  });
+
+  it('shows "No mandates" with filtered message for expired tab', async () => {
+    setMandates(mockMandates);
+
+    const user = userEvent.setup();
+    renderWithProviders(<MandatesPage />);
+
+    const expiredTab = screen.getByRole('tab', { name: 'Expired' });
+    await user.click(expiredTab);
+
+    expect(screen.getByText('No mandates')).toBeDefined();
+    expect(screen.getByText('You have no expired mandates.')).toBeDefined();
+  });
+});

--- a/frontend/src/pages/MandatesPage.tsx
+++ b/frontend/src/pages/MandatesPage.tsx
@@ -1,0 +1,537 @@
+import { useState, useCallback } from 'react';
+import { toast } from 'sonner';
+import { Shield, Plus, Loader2, Calendar, Ban, Clock } from 'lucide-react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { EmptyState } from '@/components/common/EmptyState';
+import { useMyMandates, useCreateMandate, useRevokeMandate } from '@/hooks/use-mandates';
+import type { Mandate, CreateMandateRequest } from '@/types/mandate';
+
+type StatusFilter = 'ACTIVE' | 'EXPIRED' | 'REVOKED';
+
+function filterMandates(mandates: Mandate[], filter: StatusFilter): Mandate[] {
+  const now = new Date().toISOString();
+  switch (filter) {
+    case 'ACTIVE':
+      return mandates.filter(
+        (m) => m.status === 'ACTIVE' && (m.expiresAt === null || m.expiresAt > now),
+      );
+    case 'EXPIRED':
+      return mandates.filter(
+        (m) => m.status === 'ACTIVE' && m.expiresAt !== null && m.expiresAt <= now,
+      );
+    case 'REVOKED':
+      return mandates.filter((m) => m.status === 'REVOKED');
+  }
+}
+
+function scopeBadgeVariant(scope: Mandate['scope']): 'default' | 'outline' {
+  return scope === 'PURCHASE' ? 'default' : 'outline';
+}
+
+function formatCurrency(amount: number): string {
+  return `$${amount.toFixed(2)}`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString();
+}
+
+/**
+ * Collapsible form for creating a new mandate.
+ */
+function CreateMandateForm({ onClose }: Readonly<{ onClose: () => void }>) {
+  const [agentId, setAgentId] = useState('');
+  const [scope, setScope] = useState<'BROWSE' | 'PURCHASE'>('BROWSE');
+  const [maxSpendPerTransaction, setMaxSpendPerTransaction] = useState('');
+  const [maxSpendTotal, setMaxSpendTotal] = useState('');
+  const [allowedCategories, setAllowedCategories] = useState('');
+  const [allowedEvents, setAllowedEvents] = useState('');
+  const [expiresAt, setExpiresAt] = useState('');
+  const createMandate = useCreateMandate();
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+
+      if (!agentId.trim()) {
+        toast.error('Agent ID is required.');
+        return;
+      }
+
+      const request: CreateMandateRequest = {
+        agentId: agentId.trim(),
+        scope,
+      };
+
+      if (maxSpendPerTransaction) {
+        const value = Number.parseFloat(maxSpendPerTransaction);
+        if (!Number.isNaN(value) && value > 0) {
+          request.maxSpendPerTransaction = value;
+        }
+      }
+      if (maxSpendTotal) {
+        const value = Number.parseFloat(maxSpendTotal);
+        if (!Number.isNaN(value) && value > 0) {
+          request.maxSpendTotal = value;
+        }
+      }
+      if (allowedCategories.trim()) {
+        request.allowedCategories = allowedCategories.trim();
+      }
+      if (allowedEvents.trim()) {
+        request.allowedEvents = allowedEvents.trim();
+      }
+      if (expiresAt) {
+        request.expiresAt = new Date(expiresAt).toISOString();
+      }
+
+      createMandate.mutate(request, {
+        onSuccess: () => {
+          toast.success('Mandate created.');
+          onClose();
+        },
+        onError: () => {
+          toast.error('Failed to create mandate.');
+        },
+      });
+    },
+    [
+      agentId,
+      scope,
+      maxSpendPerTransaction,
+      maxSpendTotal,
+      allowedCategories,
+      allowedEvents,
+      expiresAt,
+      createMandate,
+      onClose,
+    ],
+  );
+
+  return (
+    <Card className="mb-6">
+      <CardHeader>
+        <CardTitle>New Mandate</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <label htmlFor="agentId" className="text-sm font-medium">
+                Agent ID <span className="text-destructive">*</span>
+              </label>
+              <Input
+                id="agentId"
+                value={agentId}
+                onChange={(e) => setAgentId(e.target.value)}
+                placeholder="e.g., claude-desktop"
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="scope" className="text-sm font-medium">
+                Scope
+              </label>
+              <Select value={scope} onValueChange={(v) => setScope(v as 'BROWSE' | 'PURCHASE')}>
+                <SelectTrigger id="scope">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="BROWSE">Browse</SelectItem>
+                  <SelectItem value="PURCHASE">Purchase</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <label htmlFor="maxSpendPerTransaction" className="text-sm font-medium">
+                Per-Transaction Limit
+              </label>
+              <Input
+                id="maxSpendPerTransaction"
+                type="number"
+                min="0.01"
+                step="0.01"
+                value={maxSpendPerTransaction}
+                onChange={(e) => setMaxSpendPerTransaction(e.target.value)}
+                placeholder="$200.00"
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="maxSpendTotal" className="text-sm font-medium">
+                Total Budget
+              </label>
+              <Input
+                id="maxSpendTotal"
+                type="number"
+                min="0.01"
+                step="0.01"
+                value={maxSpendTotal}
+                onChange={(e) => setMaxSpendTotal(e.target.value)}
+                placeholder="$1,000.00"
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <label htmlFor="allowedCategories" className="text-sm font-medium">
+                Allowed Categories
+              </label>
+              <Input
+                id="allowedCategories"
+                value={allowedCategories}
+                onChange={(e) => setAllowedCategories(e.target.value)}
+                placeholder="e.g., jazz, classical"
+              />
+            </div>
+            <div className="space-y-2">
+              <label htmlFor="allowedEvents" className="text-sm font-medium">
+                Allowed Events
+              </label>
+              <Input
+                id="allowedEvents"
+                value={allowedEvents}
+                onChange={(e) => setAllowedEvents(e.target.value)}
+                placeholder="e.g., yo-yo-ma-bach-suites"
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <label htmlFor="expiresAt" className="text-sm font-medium">
+                Expires
+              </label>
+              <Input
+                id="expiresAt"
+                type="datetime-local"
+                value={expiresAt}
+                onChange={(e) => setExpiresAt(e.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2 pt-2">
+            <Button type="submit" disabled={createMandate.isPending}>
+              {createMandate.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Shield className="mr-2 h-4 w-4" />
+              )}
+              Create Mandate
+            </Button>
+            <Button type="button" variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+/**
+ * Spending summary line for a mandate.
+ */
+function SpendingSummary({ mandate }: Readonly<{ mandate: Mandate }>) {
+  return (
+    <div className="text-sm text-muted-foreground">
+      {mandate.maxSpendPerTransaction !== null && (
+        <span>{formatCurrency(mandate.maxSpendPerTransaction)} per transaction</span>
+      )}
+      {mandate.maxSpendPerTransaction !== null && mandate.maxSpendTotal !== null && (
+        <span> &middot; </span>
+      )}
+      {mandate.maxSpendTotal !== null && (
+        <span>
+          {formatCurrency(mandate.totalSpent)} spent of {formatCurrency(mandate.maxSpendTotal)}{' '}
+          total
+          {mandate.remainingBudget !== null && (
+            <span className="ml-1">({formatCurrency(mandate.remainingBudget)} remaining)</span>
+          )}
+        </span>
+      )}
+      {mandate.maxSpendPerTransaction === null && mandate.maxSpendTotal === null && (
+        <span>No spending limits</span>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Restrictions line for a mandate.
+ */
+function Restrictions({ mandate }: Readonly<{ mandate: Mandate }>) {
+  if (!mandate.allowedCategories && !mandate.allowedEvents) {
+    return null;
+  }
+  return (
+    <div className="text-sm text-muted-foreground">
+      {mandate.allowedCategories && <span>Categories: {mandate.allowedCategories}</span>}
+      {mandate.allowedCategories && mandate.allowedEvents && <span> &middot; </span>}
+      {mandate.allowedEvents && <span>Events: {mandate.allowedEvents}</span>}
+    </div>
+  );
+}
+
+/**
+ * Card view for a single mandate, used on mobile screens.
+ */
+function MandateCard({
+  mandate,
+  onRevoke,
+  isRevoking,
+}: Readonly<{
+  mandate: Mandate;
+  onRevoke: (mandateId: string) => void;
+  isRevoking: boolean;
+}>) {
+  const isActive =
+    mandate.status === 'ACTIVE' &&
+    (mandate.expiresAt === null || mandate.expiresAt > new Date().toISOString());
+
+  return (
+    <div className="rounded-lg border p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="font-medium">{mandate.agentId}</p>
+          <div className="mt-1 flex flex-wrap items-center gap-2">
+            <Badge variant={scopeBadgeVariant(mandate.scope)}>{mandate.scope}</Badge>
+            {mandate.status === 'REVOKED' && (
+              <Badge variant="destructive">
+                <Ban className="mr-1 h-3 w-3" />
+                Revoked
+              </Badge>
+            )}
+            {!isActive && mandate.status === 'ACTIVE' && (
+              <Badge variant="secondary">
+                <Clock className="mr-1 h-3 w-3" />
+                Expired
+              </Badge>
+            )}
+          </div>
+        </div>
+        {isActive && (
+          <Button
+            variant="destructive"
+            size="sm"
+            onClick={() => onRevoke(mandate.mandateId)}
+            disabled={isRevoking}
+          >
+            {isRevoking ? <Loader2 className="h-3 w-3 animate-spin" /> : 'Revoke'}
+          </Button>
+        )}
+      </div>
+
+      <div className="mt-3 space-y-1">
+        <SpendingSummary mandate={mandate} />
+        <Restrictions mandate={mandate} />
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-muted-foreground">
+        <span className="flex items-center gap-1">
+          <Calendar className="h-3 w-3" />
+          Created {formatDate(mandate.createdAt)}
+        </span>
+        {mandate.expiresAt && (
+          <span className="flex items-center gap-1">
+            <Clock className="h-3 w-3" />
+            Expires {formatDate(mandate.expiresAt)}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Mandates management page with tab filtering, create form, and responsive layout.
+ * Uses a table on desktop and card layout on mobile.
+ */
+export function MandatesPage() {
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('ACTIVE');
+  const [showCreateForm, setShowCreateForm] = useState(false);
+  const revokeMandate = useRevokeMandate();
+
+  const { data: mandates, isLoading } = useMyMandates();
+
+  const handleRevoke = useCallback(
+    (mandateId: string) => {
+      revokeMandate.mutate(mandateId, {
+        onSuccess: () => {
+          toast.success('Mandate revoked.');
+        },
+        onError: () => {
+          toast.error('Failed to revoke mandate.');
+        },
+      });
+    },
+    [revokeMandate],
+  );
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-5xl px-4 py-6 sm:px-6 lg:px-8">
+        <Skeleton className="mb-6 h-8 w-48" />
+        <Skeleton className="mb-4 h-10 w-80" />
+        <div className="space-y-3">
+          {Array.from({ length: 5 }, (_, i) => i).map((n) => (
+            <Skeleton key={`skeleton-${n}`} className="h-20 w-full" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  const allMandates = mandates ?? [];
+  const filtered = filterMandates(allMandates, statusFilter);
+
+  return (
+    <div className="mx-auto max-w-5xl px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Agent Mandates</h1>
+        {!showCreateForm && (
+          <Button onClick={() => setShowCreateForm(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            New Mandate
+          </Button>
+        )}
+      </div>
+
+      {showCreateForm && <CreateMandateForm onClose={() => setShowCreateForm(false)} />}
+
+      <Tabs value={statusFilter} onValueChange={(value) => setStatusFilter(value as StatusFilter)}>
+        <TabsList>
+          <TabsTrigger value="ACTIVE">Active</TabsTrigger>
+          <TabsTrigger value="EXPIRED">Expired</TabsTrigger>
+          <TabsTrigger value="REVOKED">Revoked</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value={statusFilter} className="mt-4">
+          {filtered.length === 0 ? (
+            <EmptyState
+              icon={Shield}
+              title="No mandates"
+              description={
+                statusFilter === 'ACTIVE'
+                  ? 'Create a mandate to authorize an AI agent to act on your behalf.'
+                  : `You have no ${statusFilter.toLowerCase()} mandates.`
+              }
+            />
+          ) : (
+            <>
+              {/* Mobile: Card layout */}
+              <div className="space-y-3 md:hidden">
+                {filtered.map((mandate) => (
+                  <MandateCard
+                    key={mandate.id}
+                    mandate={mandate}
+                    onRevoke={handleRevoke}
+                    isRevoking={revokeMandate.isPending}
+                  />
+                ))}
+              </div>
+
+              {/* Desktop: Table layout */}
+              <div className="hidden md:block">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Agent</TableHead>
+                      <TableHead>Scope</TableHead>
+                      <TableHead>Spending</TableHead>
+                      <TableHead>Restrictions</TableHead>
+                      <TableHead>Expires</TableHead>
+                      <TableHead>Created</TableHead>
+                      <TableHead className="text-right">Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {filtered.map((mandate) => {
+                      const isActive =
+                        mandate.status === 'ACTIVE' &&
+                        (mandate.expiresAt === null ||
+                          mandate.expiresAt > new Date().toISOString());
+                      return (
+                        <TableRow key={mandate.id}>
+                          <TableCell className="font-medium">{mandate.agentId}</TableCell>
+                          <TableCell>
+                            <Badge variant={scopeBadgeVariant(mandate.scope)}>
+                              {mandate.scope}
+                            </Badge>
+                          </TableCell>
+                          <TableCell>
+                            <SpendingSummary mandate={mandate} />
+                          </TableCell>
+                          <TableCell>
+                            {mandate.allowedCategories || mandate.allowedEvents ? (
+                              <div className="text-sm text-muted-foreground">
+                                {mandate.allowedCategories && (
+                                  <div>{mandate.allowedCategories}</div>
+                                )}
+                                {mandate.allowedEvents && <div>{mandate.allowedEvents}</div>}
+                              </div>
+                            ) : (
+                              <span className="text-sm text-muted-foreground">None</span>
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            {mandate.expiresAt ? (
+                              formatDate(mandate.expiresAt)
+                            ) : (
+                              <span className="text-muted-foreground">Never</span>
+                            )}
+                          </TableCell>
+                          <TableCell>{formatDate(mandate.createdAt)}</TableCell>
+                          <TableCell className="text-right">
+                            {isActive && (
+                              <Button
+                                variant="destructive"
+                                size="sm"
+                                onClick={() => handleRevoke(mandate.mandateId)}
+                                disabled={revokeMandate.isPending}
+                              >
+                                {revokeMandate.isPending ? (
+                                  <Loader2 className="h-3 w-3 animate-spin" />
+                                ) : (
+                                  'Revoke'
+                                )}
+                              </Button>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            </>
+          )}
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -19,6 +19,7 @@ import { FavoritesPage } from '@/pages/FavoritesPage';
 import { SellPage } from '@/pages/SellPage';
 import { MyListingsPage } from '@/pages/MyListingsPage';
 import { EarningsPage } from '@/pages/EarningsPage';
+import { MandatesPage } from '@/pages/MandatesPage';
 import { ProfilePage } from '@/pages/ProfilePage';
 import { AdminLayout } from '@/components/admin/AdminLayout';
 import { AdminDashboardPage } from '@/pages/admin/AdminDashboardPage';
@@ -56,6 +57,7 @@ export const router = createBrowserRouter([
           { path: 'sell', Component: SellPage },
           { path: 'my/listings', Component: MyListingsPage },
           { path: 'my/earnings', Component: EarningsPage },
+          { path: 'my/mandates', Component: MandatesPage },
         ],
       },
 

--- a/frontend/src/types/mandate.ts
+++ b/frontend/src/types/mandate.ts
@@ -1,0 +1,26 @@
+export interface Mandate {
+  id: number;
+  mandateId: string;
+  agentId: string;
+  userEmail: string;
+  scope: 'BROWSE' | 'PURCHASE';
+  maxSpendPerTransaction: number | null;
+  maxSpendTotal: number | null;
+  totalSpent: number;
+  remainingBudget: number | null;
+  allowedCategories: string | null;
+  allowedEvents: string | null;
+  status: 'ACTIVE' | 'REVOKED' | 'EXPIRED';
+  expiresAt: string | null;
+  createdAt: string;
+}
+
+export interface CreateMandateRequest {
+  agentId: string;
+  scope: 'BROWSE' | 'PURCHASE';
+  maxSpendPerTransaction?: number;
+  maxSpendTotal?: number;
+  allowedCategories?: string;
+  allowedEvents?: string;
+  expiresAt?: string;
+}


### PR DESCRIPTION
## Summary
- Adds REST endpoints (`POST/GET/DELETE /api/v1/my/mandates`) so users can create, view, and revoke agent mandates from the browser
- New React page at `/my/mandates` with Active/Expired/Revoked tabs, collapsible create form, and responsive card/table layout
- Navigation links added to Header dropdown and MobileNav
- Separate `WebCreateMandateRequest` DTO ensures the frontend never sends `userEmail` — it's always injected from the authenticated principal

## Details
- Backend: `MandateController`, `WebCreateMandateRequest` DTO, `listAllMandates()` service method, ownership-checked `revokeMandate(mandateId, userEmail)` overload
- Frontend: types, API module, React Query hooks, `MandatesPage` component with client-side expired/revoked filtering
- Tests: 10 backend `@WebMvcTest` tests (auth, validation, ownership), 10 frontend Vitest tests (tabs, form, empty states, rendering)

## Test plan
- [x] Backend: 10 `MandateControllerTest` tests pass (auth, create, list, revoke, validation, ownership)
- [x] Frontend: 10 `MandatesPage.test.tsx` tests pass (tabs, form, empty states, badges, spending)
- [x] Full backend suite passes (no regressions)
- [x] Full frontend suite passes (437 tests, 65 files)
- [x] TypeScript compiles with zero errors
- [x] Prettier formatting verified
- [x] Codex review findings addressed (WebCreateMandateRequest fix, status filter removal)

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)