### PR TITLE
Add deterministic demo reset for video recordings

### DIFF
--- a/backend/src/main/java/com/mockhub/admin/controller/AdminController.java
+++ b/backend/src/main/java/com/mockhub/admin/controller/AdminController.java
@@ -23,7 +23,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.mockhub.admin.dto.AdminEventDto;
 import com.mockhub.admin.dto.DashboardStatsDto;
+import com.mockhub.admin.dto.DemoResetResultDto;
 import com.mockhub.admin.service.AdminDashboardService;
+import com.mockhub.admin.service.DemoResetService;
 import com.mockhub.admin.service.AdminEventService;
 import com.mockhub.admin.service.AdminOrderService;
 import com.mockhub.admin.service.AdminUserService;
@@ -49,17 +51,20 @@ public class AdminController {
     private final AdminUserService adminUserService;
     private final AdminOrderService adminOrderService;
     private final Optional<TicketmasterSyncService> ticketmasterSyncService;
+    private final DemoResetService demoResetService;
 
     public AdminController(AdminDashboardService adminDashboardService,
                            AdminEventService adminEventService,
                            AdminUserService adminUserService,
                            AdminOrderService adminOrderService,
-                           Optional<TicketmasterSyncService> ticketmasterSyncService) {
+                           Optional<TicketmasterSyncService> ticketmasterSyncService,
+                           DemoResetService demoResetService) {
         this.adminDashboardService = adminDashboardService;
         this.adminEventService = adminEventService;
         this.adminUserService = adminUserService;
         this.adminOrderService = adminOrderService;
         this.ticketmasterSyncService = ticketmasterSyncService;
+        this.demoResetService = demoResetService;
     }
 
     @GetMapping("/dashboard")
@@ -208,5 +213,20 @@ public class AdminController {
     @ApiResponse(responseCode = "200", description = "Activation complete")
     public ResponseEntity<Map<String, Integer>> activateTicketmasterEvents() {
         return ResponseEntity.ok(adminEventService.activateTicketmasterEvents());
+    }
+
+    @PostMapping("/demo/reset")
+    @Operation(summary = "Reset demo user state (admin)",
+            description = "Clear cart, cancel orders, revoke mandates for a user. For repeatable demo recordings.")
+    @ApiResponse(responseCode = "200", description = "Demo state reset")
+    @ApiResponse(responseCode = "404", description = "User not found")
+    public ResponseEntity<DemoResetResultDto> resetDemoUser(
+            @RequestBody Map<String, String> body) {
+        String userEmail = body.get("userEmail");
+        if (userEmail == null || userEmail.isBlank()) {
+            return ResponseEntity.badRequest().build();
+        }
+        DemoResetResultDto result = demoResetService.resetUser(userEmail);
+        return ResponseEntity.ok(result);
     }
 }

--- a/backend/src/main/java/com/mockhub/admin/dto/DemoResetResultDto.java
+++ b/backend/src/main/java/com/mockhub/admin/dto/DemoResetResultDto.java
@@ -1,0 +1,10 @@
+package com.mockhub.admin.dto;
+
+import java.util.List;
+
+public record DemoResetResultDto(
+        String userEmail,
+        boolean cartCleared,
+        List<String> cancelledOrders,
+        List<String> revokedMandates
+) {}

--- a/backend/src/main/java/com/mockhub/admin/service/DemoResetService.java
+++ b/backend/src/main/java/com/mockhub/admin/service/DemoResetService.java
@@ -1,0 +1,99 @@
+package com.mockhub.admin.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mockhub.admin.dto.DemoResetResultDto;
+import com.mockhub.auth.entity.User;
+import com.mockhub.auth.repository.UserRepository;
+import com.mockhub.cart.service.CartService;
+import com.mockhub.common.exception.ResourceNotFoundException;
+import com.mockhub.mandate.entity.Mandate;
+import com.mockhub.mandate.repository.MandateRepository;
+import com.mockhub.mandate.service.MandateService;
+import com.mockhub.order.entity.Order;
+import com.mockhub.order.entity.OrderStatus;
+import com.mockhub.order.repository.OrderRepository;
+import com.mockhub.order.service.OrderService;
+
+@Service
+public class DemoResetService {
+
+    private static final Logger log = LoggerFactory.getLogger(DemoResetService.class);
+
+    private final UserRepository userRepository;
+    private final CartService cartService;
+    private final OrderService orderService;
+    private final OrderRepository orderRepository;
+    private final MandateService mandateService;
+    private final MandateRepository mandateRepository;
+
+    public DemoResetService(UserRepository userRepository,
+                            CartService cartService,
+                            OrderService orderService,
+                            OrderRepository orderRepository,
+                            MandateService mandateService,
+                            MandateRepository mandateRepository) {
+        this.userRepository = userRepository;
+        this.cartService = cartService;
+        this.orderService = orderService;
+        this.orderRepository = orderRepository;
+        this.mandateService = mandateService;
+        this.mandateRepository = mandateRepository;
+    }
+
+    @Transactional
+    public DemoResetResultDto resetUser(String userEmail) {
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new ResourceNotFoundException("User", "email", userEmail));
+
+        // 1. Clear cart
+        cartService.clearCart(user);
+        boolean cartCleared = true;
+
+        // 2. Cancel/fail active orders (catch per-order so one failure doesn't abort the reset)
+        List<String> cancelledOrders = new ArrayList<>();
+        Page<Order> orders = orderRepository.findByUserIdOrderByCreatedAtDesc(
+                user.getId(), PageRequest.of(0, 1000));
+        for (Order order : orders) {
+            try {
+                if (order.getStatus() == OrderStatus.PENDING) {
+                    orderService.failOrder(order.getOrderNumber());
+                    cancelledOrders.add(order.getOrderNumber());
+                } else if (order.getStatus() == OrderStatus.CONFIRMED) {
+                    orderService.cancelOrder(order.getOrderNumber());
+                    cancelledOrders.add(order.getOrderNumber());
+                }
+            } catch (RuntimeException ex) {
+                log.warn("Failed to reset order {}: {}", order.getOrderNumber(), ex.getMessage());
+            }
+        }
+
+        // 3. Revoke all active mandates
+        List<String> revokedMandates = new ArrayList<>();
+        List<Mandate> mandates = mandateRepository.findByUserEmail(userEmail);
+        for (Mandate mandate : mandates) {
+            if ("ACTIVE".equals(mandate.getStatus())) {
+                mandateService.revokeMandate(mandate.getMandateId());
+                revokedMandates.add(mandate.getMandateId());
+            }
+        }
+
+        log.info("Demo reset for user '{}': cart cleared, {} orders cancelled/failed, {} mandates revoked",
+                userEmail, cancelledOrders.size(), revokedMandates.size());
+
+        return new DemoResetResultDto(
+                userEmail,
+                cartCleared,
+                cancelledOrders,
+                revokedMandates
+        );
+    }
+}

--- a/backend/src/test/java/com/mockhub/admin/controller/AdminControllerSyncTest.java
+++ b/backend/src/test/java/com/mockhub/admin/controller/AdminControllerSyncTest.java
@@ -20,7 +20,8 @@ class AdminControllerSyncTest {
                 mock(com.mockhub.admin.service.AdminEventService.class),
                 mock(com.mockhub.admin.service.AdminUserService.class),
                 mock(com.mockhub.admin.service.AdminOrderService.class),
-                Optional.empty());
+                Optional.empty(),
+                mock(com.mockhub.admin.service.DemoResetService.class));
 
         ResponseEntity<Map<String, String>> response = controller.triggerTicketmasterSync();
 
@@ -37,7 +38,8 @@ class AdminControllerSyncTest {
                 mock(com.mockhub.admin.service.AdminEventService.class),
                 mock(com.mockhub.admin.service.AdminUserService.class),
                 mock(com.mockhub.admin.service.AdminOrderService.class),
-                Optional.of(syncService));
+                Optional.of(syncService),
+                mock(com.mockhub.admin.service.DemoResetService.class));
 
         ResponseEntity<Map<String, String>> response = controller.triggerTicketmasterSync();
 

--- a/backend/src/test/java/com/mockhub/admin/controller/AdminControllerTest.java
+++ b/backend/src/test/java/com/mockhub/admin/controller/AdminControllerTest.java
@@ -8,15 +8,19 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.mockhub.admin.dto.DashboardStatsDto;
+import com.mockhub.admin.dto.DemoResetResultDto;
 import com.mockhub.admin.service.AdminDashboardService;
 import com.mockhub.admin.service.AdminEventService;
 import com.mockhub.admin.service.AdminOrderService;
 import com.mockhub.admin.service.AdminUserService;
+import com.mockhub.admin.service.DemoResetService;
+import com.mockhub.common.exception.ResourceNotFoundException;
 import com.mockhub.auth.security.JwtAuthenticationFilter;
 import com.mockhub.auth.security.JwtTokenProvider;
 import com.mockhub.auth.security.UserDetailsServiceImpl;
@@ -57,6 +61,9 @@ class AdminControllerTest {
 
     @MockitoBean
     private TicketmasterSyncService ticketmasterSyncService;
+
+    @MockitoBean
+    private DemoResetService demoResetService;
 
     @Test
     @DisplayName("GET /api/v1/admin/dashboard - unauthenticated - returns 401")
@@ -151,5 +158,79 @@ class AdminControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.seedEventsDeactivated").value(100))
                 .andExpect(jsonPath("$.ticketmasterEventsFeatured").value(83));
+    }
+
+    // -- POST /api/v1/admin/demo/reset (unauthenticated) --
+
+    @Test
+    @DisplayName("POST /api/v1/admin/demo/reset - unauthenticated - returns 401")
+    void resetDemoUser_unauthenticated_returns401() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/demo/reset")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userEmail\": \"buyer@mockhub.com\"}"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    // -- POST /api/v1/admin/demo/reset (non-admin) --
+
+    @Test
+    @DisplayName("POST /api/v1/admin/demo/reset - non-admin - returns 403")
+    @WithMockUser(roles = "BUYER")
+    void resetDemoUser_nonAdmin_returns403() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/demo/reset")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userEmail\": \"buyer@mockhub.com\"}"))
+                .andExpect(status().isForbidden());
+    }
+
+    // -- POST /api/v1/admin/demo/reset (admin, valid) --
+
+    @Test
+    @DisplayName("POST /api/v1/admin/demo/reset - admin - returns 200 with summary")
+    @WithMockUser(authorities = "ROLE_ADMIN")
+    void resetDemoUser_admin_returns200WithSummary() throws Exception {
+        DemoResetResultDto result = new DemoResetResultDto(
+                "buyer@mockhub.com", true,
+                List.of("MH-20260408-0001"), List.of("mandate-001"));
+
+        when(demoResetService.resetUser("buyer@mockhub.com")).thenReturn(result);
+
+        mockMvc.perform(post("/api/v1/admin/demo/reset")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userEmail\": \"buyer@mockhub.com\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.userEmail").value("buyer@mockhub.com"))
+                .andExpect(jsonPath("$.cartCleared").value(true))
+                .andExpect(jsonPath("$.cancelledOrders[0]").value("MH-20260408-0001"))
+                .andExpect(jsonPath("$.revokedMandates[0]").value("mandate-001"));
+
+        verify(demoResetService).resetUser("buyer@mockhub.com");
+    }
+
+    // -- POST /api/v1/admin/demo/reset (missing email) --
+
+    @Test
+    @DisplayName("POST /api/v1/admin/demo/reset - missing email - returns 400")
+    @WithMockUser(authorities = "ROLE_ADMIN")
+    void resetDemoUser_missingEmail_returns400() throws Exception {
+        mockMvc.perform(post("/api/v1/admin/demo/reset")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userEmail\": \"\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    // -- POST /api/v1/admin/demo/reset (user not found) --
+
+    @Test
+    @DisplayName("POST /api/v1/admin/demo/reset - user not found - returns 404")
+    @WithMockUser(authorities = "ROLE_ADMIN")
+    void resetDemoUser_userNotFound_returns404() throws Exception {
+        when(demoResetService.resetUser("unknown@example.com"))
+                .thenThrow(new ResourceNotFoundException("User", "email", "unknown@example.com"));
+
+        mockMvc.perform(post("/api/v1/admin/demo/reset")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"userEmail\": \"unknown@example.com\"}"))
+                .andExpect(status().isNotFound());
     }
 }

--- a/backend/src/test/java/com/mockhub/admin/service/DemoResetServiceTest.java
+++ b/backend/src/test/java/com/mockhub/admin/service/DemoResetServiceTest.java
@@ -1,0 +1,198 @@
+package com.mockhub.admin.service;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+
+import com.mockhub.admin.dto.DemoResetResultDto;
+import com.mockhub.auth.entity.User;
+import com.mockhub.auth.repository.UserRepository;
+import com.mockhub.cart.service.CartService;
+import com.mockhub.common.exception.ResourceNotFoundException;
+import com.mockhub.mandate.entity.Mandate;
+import com.mockhub.mandate.repository.MandateRepository;
+import com.mockhub.mandate.service.MandateService;
+import com.mockhub.order.entity.Order;
+import com.mockhub.order.entity.OrderStatus;
+import com.mockhub.order.repository.OrderRepository;
+import com.mockhub.order.service.OrderService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class DemoResetServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private CartService cartService;
+
+    @Mock
+    private OrderService orderService;
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private MandateService mandateService;
+
+    @Mock
+    private MandateRepository mandateRepository;
+
+    @InjectMocks
+    private DemoResetService demoResetService;
+
+    private User testUser;
+
+    @BeforeEach
+    void setUp() {
+        testUser = new User();
+        testUser.setId(1L);
+        testUser.setEmail("buyer@mockhub.com");
+        testUser.setFirstName("Jane");
+        testUser.setLastName("Buyer");
+        testUser.setEnabled(true);
+    }
+
+    @Test
+    @DisplayName("resetUser - user not found - throws ResourceNotFoundException")
+    void resetUser_userNotFound_throwsResourceNotFoundException() {
+        when(userRepository.findByEmail("unknown@mockhub.com")).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> demoResetService.resetUser("unknown@mockhub.com"));
+    }
+
+    @Test
+    @DisplayName("resetUser - clears cart for the user")
+    void resetUser_clearsCart() {
+        when(userRepository.findByEmail("buyer@mockhub.com")).thenReturn(Optional.of(testUser));
+        when(orderRepository.findByUserIdOrderByCreatedAtDesc(eq(1L), any()))
+                .thenReturn(new PageImpl<>(Collections.emptyList()));
+        when(mandateRepository.findByUserEmail("buyer@mockhub.com"))
+                .thenReturn(Collections.emptyList());
+
+        demoResetService.resetUser("buyer@mockhub.com");
+
+        verify(cartService).clearCart(testUser);
+    }
+
+    @Test
+    @DisplayName("resetUser - fails pending orders via orderService")
+    void resetUser_failsPendingOrders() {
+        when(userRepository.findByEmail("buyer@mockhub.com")).thenReturn(Optional.of(testUser));
+
+        Order pendingOrder = mock(Order.class);
+        when(pendingOrder.getStatus()).thenReturn(OrderStatus.PENDING);
+        when(pendingOrder.getOrderNumber()).thenReturn("MH-20260408-0001");
+
+        when(orderRepository.findByUserIdOrderByCreatedAtDesc(eq(1L), any()))
+                .thenReturn(new PageImpl<>(List.of(pendingOrder)));
+        when(mandateRepository.findByUserEmail("buyer@mockhub.com"))
+                .thenReturn(Collections.emptyList());
+
+        demoResetService.resetUser("buyer@mockhub.com");
+
+        verify(orderService).failOrder("MH-20260408-0001");
+    }
+
+    @Test
+    @DisplayName("resetUser - cancels confirmed orders via orderService")
+    void resetUser_cancelsConfirmedOrders() {
+        when(userRepository.findByEmail("buyer@mockhub.com")).thenReturn(Optional.of(testUser));
+
+        Order confirmedOrder = mock(Order.class);
+        when(confirmedOrder.getStatus()).thenReturn(OrderStatus.CONFIRMED);
+        when(confirmedOrder.getOrderNumber()).thenReturn("MH-20260408-0002");
+
+        when(orderRepository.findByUserIdOrderByCreatedAtDesc(eq(1L), any()))
+                .thenReturn(new PageImpl<>(List.of(confirmedOrder)));
+        when(mandateRepository.findByUserEmail("buyer@mockhub.com"))
+                .thenReturn(Collections.emptyList());
+
+        demoResetService.resetUser("buyer@mockhub.com");
+
+        verify(orderService).cancelOrder("MH-20260408-0002");
+    }
+
+    @Test
+    @DisplayName("resetUser - revokes active mandates via mandateService")
+    void resetUser_revokesActiveMandates() {
+        when(userRepository.findByEmail("buyer@mockhub.com")).thenReturn(Optional.of(testUser));
+        when(orderRepository.findByUserIdOrderByCreatedAtDesc(eq(1L), any()))
+                .thenReturn(new PageImpl<>(Collections.emptyList()));
+
+        Mandate activeMandate = new Mandate();
+        activeMandate.setMandateId("mandate-001");
+        activeMandate.setStatus("ACTIVE");
+
+        when(mandateRepository.findByUserEmail("buyer@mockhub.com"))
+                .thenReturn(List.of(activeMandate));
+
+        demoResetService.resetUser("buyer@mockhub.com");
+
+        verify(mandateService).revokeMandate("mandate-001");
+    }
+
+    @Test
+    @DisplayName("resetUser - full reset - returns summary with correct counts")
+    void resetUser_fullReset_returnsSummary() {
+        when(userRepository.findByEmail("buyer@mockhub.com")).thenReturn(Optional.of(testUser));
+
+        Order pendingOrder = mock(Order.class);
+        when(pendingOrder.getStatus()).thenReturn(OrderStatus.PENDING);
+        when(pendingOrder.getOrderNumber()).thenReturn("MH-20260408-0001");
+
+        Order confirmedOrder = mock(Order.class);
+        when(confirmedOrder.getStatus()).thenReturn(OrderStatus.CONFIRMED);
+        when(confirmedOrder.getOrderNumber()).thenReturn("MH-20260408-0002");
+
+        when(orderRepository.findByUserIdOrderByCreatedAtDesc(eq(1L), any()))
+                .thenReturn(new PageImpl<>(List.of(pendingOrder, confirmedOrder)));
+
+        Mandate activeMandate = new Mandate();
+        activeMandate.setMandateId("mandate-001");
+        activeMandate.setStatus("ACTIVE");
+
+        Mandate revokedMandate = new Mandate();
+        revokedMandate.setMandateId("mandate-002");
+        revokedMandate.setStatus("REVOKED");
+
+        when(mandateRepository.findByUserEmail("buyer@mockhub.com"))
+                .thenReturn(List.of(activeMandate, revokedMandate));
+
+        DemoResetResultDto result = demoResetService.resetUser("buyer@mockhub.com");
+
+        assertNotNull(result, "Result should not be null");
+        assertEquals("buyer@mockhub.com", result.userEmail(), "Email should match");
+        assertTrue(result.cartCleared(), "Cart should be marked as cleared");
+        assertEquals(2, result.cancelledOrders().size(),
+                "Should have 2 cancelled/failed orders");
+        assertTrue(result.cancelledOrders().contains("MH-20260408-0001"),
+                "Should contain the pending order number");
+        assertTrue(result.cancelledOrders().contains("MH-20260408-0002"),
+                "Should contain the confirmed order number");
+        assertEquals(1, result.revokedMandates().size(),
+                "Should have 1 revoked mandate (the already-revoked one is skipped)");
+        assertTrue(result.revokedMandates().contains("mandate-001"),
+                "Should contain the active mandate ID");
+    }
+}

--- a/backend/src/test/java/com/mockhub/auth/AuthorizationBypassTest.java
+++ b/backend/src/test/java/com/mockhub/auth/AuthorizationBypassTest.java
@@ -89,6 +89,9 @@ class AuthorizationBypassTest {
     @MockitoBean
     private com.mockhub.ticketmaster.service.TicketmasterSyncService ticketmasterSyncService;
 
+    @MockitoBean
+    private com.mockhub.admin.service.DemoResetService demoResetService;
+
     private SecurityUser userA;
     private User userAEntity;
 


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/admin/demo/reset` — admin-only endpoint that resets a user to a known state for repeatable demo recordings
- Clears cart, fails/cancels active orders (with per-order error handling), revokes active mandates
- Returns a `DemoResetResultDto` summary showing what was reset
- Reuses existing domain service methods — no raw SQL, all state transitions properly honored

## Details
- `DemoResetService` orchestrates reset via `CartService.clearCart()`, `OrderService.failOrder()`/`cancelOrder()`, `MandateService.revokeMandate()`
- Per-order try/catch prevents one failed order from aborting the entire reset
- `DemoResetResultDto` record: `userEmail`, `cartCleared`, `cancelledOrders`, `revokedMandates`
- Fixed `AuthorizationBypassTest` and `AdminControllerSyncTest` for new AdminController dependency

## Test plan
- [x] 6 `DemoResetServiceTest` unit tests (not found, cart clear, fail pending, cancel confirmed, revoke mandates, full summary)
- [x] 5 `AdminControllerTest` endpoint tests (401, 403, 200 happy path, 400 missing email, 404 unknown user)
- [x] Full backend suite passes (no regressions)
- [x] Full frontend suite passes (443 tests, 67 files)

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)