### PR TITLE
Show agent attribution on orders purchased via MCP

### DIFF
--- a/backend/src/main/java/com/mockhub/admin/service/AdminOrderService.java
+++ b/backend/src/main/java/com/mockhub/admin/service/AdminOrderService.java
@@ -98,7 +98,8 @@ public class AdminOrderService {
                 order.getCreatedAt(),
                 eventName,
                 eventDate,
-                venueName
+                venueName,
+                order.getAgentId()
         );
     }
 }

--- a/backend/src/main/java/com/mockhub/order/dto/OrderDto.java
+++ b/backend/src/main/java/com/mockhub/order/dto/OrderDto.java
@@ -14,6 +14,8 @@ public record OrderDto(
         String paymentMethod,
         Instant confirmedAt,
         Instant createdAt,
-        List<OrderItemDto> items
+        List<OrderItemDto> items,
+        String agentId,
+        String mandateId
 ) {
 }

--- a/backend/src/main/java/com/mockhub/order/dto/OrderSummaryDto.java
+++ b/backend/src/main/java/com/mockhub/order/dto/OrderSummaryDto.java
@@ -12,6 +12,7 @@ public record OrderSummaryDto(
         Instant createdAt,
         String eventName,
         Instant eventDate,
-        String venueName
+        String venueName,
+        String agentId
 ) {
 }

--- a/backend/src/main/java/com/mockhub/order/service/OrderService.java
+++ b/backend/src/main/java/com/mockhub/order/service/OrderService.java
@@ -229,7 +229,8 @@ public class OrderService {
                             order.getCreatedAt(),
                             eventName,
                             eventDate,
-                            venueName
+                            venueName,
+                            order.getAgentId()
                     );
                 })
                 .toList();
@@ -436,7 +437,9 @@ public class OrderService {
                 order.getPaymentMethod(),
                 order.getConfirmedAt(),
                 order.getCreatedAt(),
-                itemDtos
+                itemDtos,
+                order.getAgentId(),
+                order.getMandateId()
         );
     }
 }

--- a/backend/src/test/java/com/mockhub/acp/service/AcpCheckoutServiceTest.java
+++ b/backend/src/test/java/com/mockhub/acp/service/AcpCheckoutServiceTest.java
@@ -99,7 +99,9 @@ class AcpCheckoutServiceTest {
                 "mock",
                 null,
                 Instant.now(),
-                orderItems
+                orderItems,
+                null,
+                null
         );
 
         lenient().when(evalRunner.evaluate(any())).thenReturn(new EvalSummary(List.of(EvalResult.pass("ok"))));
@@ -236,7 +238,9 @@ class AcpCheckoutServiceTest {
                 "mock",
                 Instant.now(),
                 Instant.now(),
-                testOrderDto.items()
+                testOrderDto.items(),
+                null,
+                null
         );
 
         when(userRepository.findByEmail("buyer@test.com")).thenReturn(Optional.of(testUser));
@@ -307,7 +311,9 @@ class AcpCheckoutServiceTest {
                 "mock",
                 Instant.now(),
                 Instant.now(),
-                testOrderDto.items()
+                testOrderDto.items(),
+                null,
+                null
         );
 
         when(userRepository.findByEmail("buyer@test.com")).thenReturn(Optional.of(testUser));
@@ -346,7 +352,7 @@ class AcpCheckoutServiceTest {
         OrderDto pendingOrder = new OrderDto(
                 1L, "MH-20260323-0001", "PENDING",
                 new BigDecimal("110.00"), new BigDecimal("11.00"), new BigDecimal("121.00"),
-                "mock", null, Instant.now(), existingItems);
+                "mock", null, Instant.now(), existingItems, null, null);
 
         OrderDto newOrder = new OrderDto(
                 2L, "MH-20260323-0002", "PENDING",
@@ -356,7 +362,7 @@ class AcpCheckoutServiceTest {
                         "Floor", "A", "1", "GENERAL", new BigDecimal("50.00")),
                 new OrderItemDto(3L, 30L, 300L, "Concert C", "concert-c",
                         "VIP", "C", "3", "GENERAL", new BigDecimal("30.00"))
-        ));
+        ), null, null);
 
         AcpUpdateRequest updateRequest = createUpdateRequest(List.of(new AcpLineItem(30L, 1)), List.of(20L));
 
@@ -389,7 +395,7 @@ class AcpCheckoutServiceTest {
         OrderDto newOrder = new OrderDto(
                 2L, "MH-20260323-0002", "PENDING",
                 new BigDecimal("100.00"), new BigDecimal("10.00"), new BigDecimal("110.00"),
-                "mock", null, Instant.now(), testOrderDto.items());
+                "mock", null, Instant.now(), testOrderDto.items(), null, null);
 
         when(userRepository.findByEmail("buyer@test.com")).thenReturn(Optional.of(testUser));
         when(orderService.getOrder(testUser, "MH-20260323-0001")).thenReturn(testOrderDto);
@@ -418,7 +424,7 @@ class AcpCheckoutServiceTest {
         OrderDto newOrder = new OrderDto(
                 2L, "MH-20260323-0002", "PENDING",
                 new BigDecimal("50.00"), new BigDecimal("5.00"), new BigDecimal("55.00"),
-                "mock", null, Instant.now(), testOrderDto.items());
+                "mock", null, Instant.now(), testOrderDto.items(), null, null);
 
         when(userRepository.findByEmail("buyer@test.com")).thenReturn(Optional.of(testUser));
         when(orderService.getOrder(testUser, "MH-20260323-0001")).thenReturn(testOrderDto);
@@ -490,7 +496,7 @@ class AcpCheckoutServiceTest {
         OrderDto confirmedOrder = new OrderDto(
                 1L, "MH-20260323-0001", "CONFIRMED",
                 new BigDecimal("50.00"), new BigDecimal("5.00"), new BigDecimal("55.00"),
-                "mock", Instant.now(), Instant.now(), testOrderDto.items());
+                "mock", Instant.now(), Instant.now(), testOrderDto.items(), null, null);
 
         when(userRepository.findByEmail("buyer@test.com")).thenReturn(Optional.of(testUser));
         when(orderService.getOrder(testUser, "MH-20260323-0001"))
@@ -513,7 +519,7 @@ class AcpCheckoutServiceTest {
         OrderDto failedOrder = new OrderDto(
                 1L, "MH-20260323-0001", "FAILED",
                 new BigDecimal("50.00"), new BigDecimal("5.00"), new BigDecimal("55.00"),
-                "mock", null, Instant.now(), testOrderDto.items());
+                "mock", null, Instant.now(), testOrderDto.items(), null, null);
 
         when(userRepository.findByEmail("buyer@test.com")).thenReturn(Optional.of(testUser));
         when(orderService.getOrder(testUser, "MH-20260323-0001")).thenReturn(failedOrder);
@@ -559,7 +565,7 @@ class AcpCheckoutServiceTest {
         OrderDto unknownOrder = new OrderDto(
                 1L, "MH-20260323-0001", "PROCESSING",
                 new BigDecimal("50.00"), new BigDecimal("5.00"), new BigDecimal("55.00"),
-                "mock", null, Instant.now(), testOrderDto.items());
+                "mock", null, Instant.now(), testOrderDto.items(), null, null);
 
         when(userRepository.findByEmail("buyer@test.com")).thenReturn(Optional.of(testUser));
         when(orderService.getOrder(testUser, "MH-20260323-0001")).thenReturn(unknownOrder);

--- a/backend/src/test/java/com/mockhub/mcp/tools/OrderToolsTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/tools/OrderToolsTest.java
@@ -139,7 +139,7 @@ class OrderToolsTest {
             when(cartService.getCartDto(testUser)).thenReturn(new CartDto(null, 1L, List.of(), java.math.BigDecimal.TEN, 1, null));
             stubPassingEval();
             OrderDto orderDto = new OrderDto(
-                    null, null, null, null, null, null, null, null, null, null);
+                    null, null, null, null, null, null, null, null, null, null, null, null);
             when(orderService.checkout(eq(testUser), any(CheckoutRequest.class), any(), eq(AGENT_ID), eq(MANDATE_ID)))
                     .thenReturn(orderDto);
 
@@ -212,7 +212,7 @@ class OrderToolsTest {
             stubUserLookup("buyer@example.com");
             Order orderEntity = createAgentOrderEntity("MH-20260319-0001");
             OrderDto orderDto = new OrderDto(
-                    null, null, null, null, null, null, null, null, null, null);
+                    null, null, null, null, null, null, null, null, null, null, null, null);
             when(orderService.getOrder(testUser, "MH-20260319-0001")).thenReturn(orderDto);
             when(orderService.getOrderEntity("MH-20260319-0001")).thenReturn(orderEntity);
             stubPassingEval();
@@ -252,7 +252,7 @@ class OrderToolsTest {
             stubUserLookup("buyer@example.com");
             Order orderEntity = createAgentOrderEntity("MH-20260319-0001");
             OrderDto orderDto = new OrderDto(
-                    null, null, null, null, null, null, null, null, null, null);
+                    null, null, null, null, null, null, null, null, null, null, null, null);
             when(orderService.getOrder(testUser, "MH-20260319-0001")).thenReturn(orderDto);
             when(orderService.getOrderEntity("MH-20260319-0001")).thenReturn(orderEntity);
             stubPassingEval();
@@ -290,7 +290,7 @@ class OrderToolsTest {
             stubUserLookup("buyer@example.com");
             Order orderEntity = createAgentOrderEntity("MH-INVALID");
             when(orderService.getOrder(testUser, "MH-INVALID")).thenReturn(
-                    new OrderDto(null, null, null, null, null, null, null, null, null, null));
+                    new OrderDto(null, null, null, null, null, null, null, null, null, null, null, null));
             when(orderService.getOrderEntity("MH-INVALID")).thenReturn(orderEntity);
             stubPassingEval();
             when(paymentService.createPaymentIntent(orderEntity))
@@ -310,7 +310,7 @@ class OrderToolsTest {
             Order orderEntity = createAgentOrderEntity("MH-20260319-0001");
             orderEntity.setPaymentIntentId("pi_existing");
             OrderDto orderDto = new OrderDto(
-                    null, null, null, null, null, null, null, null, null, null);
+                    null, null, null, null, null, null, null, null, null, null, null, null);
             when(orderService.getOrder(testUser, "MH-20260319-0001")).thenReturn(orderDto);
             when(orderService.getOrderEntity("MH-20260319-0001")).thenReturn(orderEntity);
             stubPassingEval();
@@ -331,7 +331,7 @@ class OrderToolsTest {
             orderEntity.setPaymentMethod("stripe");
             orderEntity.setPaymentIntentId(null);
             OrderDto orderDto = new OrderDto(
-                    null, null, null, null, null, null, null, null, null, null);
+                    null, null, null, null, null, null, null, null, null, null, null, null);
             when(orderService.getOrder(testUser, "MH-20260319-0001")).thenReturn(orderDto);
             when(orderService.getOrderEntity("MH-20260319-0001")).thenReturn(orderEntity);
             stubPassingEval();
@@ -351,7 +351,7 @@ class OrderToolsTest {
             stubUserLookup("buyer@example.com");
             Order orderEntity = createAgentOrderEntity("MH-20260319-0001");
             OrderDto orderDto = new OrderDto(
-                    null, null, null, null, null, null, null, null, null, null);
+                    null, null, null, null, null, null, null, null, null, null, null, null);
             when(orderService.getOrder(testUser, "MH-20260319-0001")).thenReturn(orderDto);
             when(orderService.getOrderEntity("MH-20260319-0001")).thenReturn(orderEntity);
             when(evalRunner.evaluate(any())).thenReturn(new EvalSummary(List.of(
@@ -376,7 +376,7 @@ class OrderToolsTest {
         void givenValidEmailAndOrderNumber_returnsOrderJson() {
             stubUserLookup("buyer@example.com");
             OrderDto orderDto = new OrderDto(
-                    null, null, null, null, null, null, null, null, null, null);
+                    null, null, null, null, null, null, null, null, null, null, null, null);
             when(orderService.getOrder(testUser, "MH-20260319-0001")).thenReturn(orderDto);
 
             String result = orderTools.getOrder("buyer@example.com", "MH-20260319-0001");
@@ -408,7 +408,7 @@ class OrderToolsTest {
         void givenOrderNumberWithWhitespace_stripsWhitespace() {
             stubUserLookup("buyer@example.com");
             OrderDto orderDto = new OrderDto(
-                    null, null, null, null, null, null, null, null, null, null);
+                    null, null, null, null, null, null, null, null, null, null, null, null);
             when(orderService.getOrder(testUser, "MH-20260319-0001")).thenReturn(orderDto);
 
             orderTools.getOrder("buyer@example.com", "  MH-20260319-0001  ");
@@ -519,7 +519,7 @@ class OrderToolsTest {
         void givenValidOrder_returnsIcsContent() {
             stubUserLookup("buyer@example.com");
             OrderDto orderDto = new OrderDto(
-                    null, "MH-20260326-0001", null, null, null, null, null, null, null, null);
+                    null, "MH-20260326-0001", null, null, null, null, null, null, null, null, null, null);
             when(orderService.getOrder(testUser, "MH-20260326-0001")).thenReturn(orderDto);
             Order order = new Order();
             order.setOrderNumber("MH-20260326-0001");
@@ -574,7 +574,7 @@ class OrderToolsTest {
             CartDto cartDto = new CartDto(null, null, null, java.math.BigDecimal.TEN, 1, null);
             when(cartService.getCartDto(realUser)).thenReturn(cartDto);
             when(evalRunner.evaluate(any())).thenReturn(new EvalSummary(List.of(EvalResult.pass("test"))));
-            OrderDto orderDto = new OrderDto(1L, "MH-001", null, null, null, null, null, null, null, null);
+            OrderDto orderDto = new OrderDto(1L, "MH-001", null, null, null, null, null, null, null, null, null, null);
             when(orderService.checkout(eq(realUser), any(CheckoutRequest.class), any(), eq(AGENT_ID), eq(MANDATE_ID)))
                     .thenReturn(orderDto);
 
@@ -592,7 +592,7 @@ class OrderToolsTest {
             realUser.setId(2L);
             realUser.setEmail("real@example.com");
             when(userRepository.findByEmail("real@example.com")).thenReturn(Optional.of(realUser));
-            OrderDto orderDto = new OrderDto(1L, "MH-001", null, null, null, null, null, null, null, null);
+            OrderDto orderDto = new OrderDto(1L, "MH-001", null, null, null, null, null, null, null, null, null, null);
             when(orderService.getOrder(realUser, "MH-001")).thenReturn(orderDto);
 
             orderTools.getOrder("attacker@example.com", "MH-001");
@@ -605,7 +605,7 @@ class OrderToolsTest {
         @DisplayName("given no ChatContext - uses parameter email (external MCP)")
         void givenNoChatContext_usesParameterEmail() {
             stubUserLookup("buyer@example.com");
-            OrderDto orderDto = new OrderDto(1L, "MH-001", null, null, null, null, null, null, null, null);
+            OrderDto orderDto = new OrderDto(1L, "MH-001", null, null, null, null, null, null, null, null, null, null);
             when(orderService.getOrder(testUser, "MH-001")).thenReturn(orderDto);
 
             orderTools.getOrder("buyer@example.com", "MH-001");

--- a/frontend/src/components/orders/OrderCard.tsx
+++ b/frontend/src/components/orders/OrderCard.tsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router';
-import { ChevronRight } from 'lucide-react';
+import { Bot, ChevronRight } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { formatCurrency, formatShortDate } from '@/lib/formatters';
@@ -58,6 +58,14 @@ export function OrderCard({ order }: Readonly<OrderCardProps>) {
               <Badge variant={statusVariant} className={getStatusColor(order.status)}>
                 {order.status}
               </Badge>
+              {order.agentId && (
+                <span
+                  className="flex items-center gap-0.5 text-xs text-blue-600 dark:text-blue-400"
+                  title={`Purchased by agent: ${order.agentId}`}
+                >
+                  <Bot className="h-3 w-3" />
+                </span>
+              )}
             </div>
             <p className="text-xs text-muted-foreground">
               {order.eventDate

--- a/frontend/src/pages/OrderConfirmationPage.test.tsx
+++ b/frontend/src/pages/OrderConfirmationPage.test.tsx
@@ -34,6 +34,8 @@ const mockOrder: Order = {
   paymentMethod: 'MOCK',
   confirmedAt: '2026-03-20T10:05:00',
   createdAt: '2026-03-20T10:00:00',
+  agentId: null,
+  mandateId: null,
   items: [
     {
       id: 201,
@@ -107,5 +109,29 @@ describe('OrderConfirmationPage', () => {
 
     expect(screen.getByText('View Order History')).toBeDefined();
     expect(screen.getByText('Continue Browsing')).toBeDefined();
+  });
+
+  it('shows agent attribution badge for agent-initiated orders', () => {
+    setOrderState({
+      ...mockOrder,
+      agentId: 'claude-desktop',
+      mandateId: 'mandate-001',
+    });
+
+    renderWithProviders(<OrderConfirmationPage />);
+
+    expect(screen.getByText(/claude-desktop/)).toBeDefined();
+  });
+
+  it('does not show agent badge for human orders', () => {
+    setOrderState({
+      ...mockOrder,
+      agentId: null,
+      mandateId: null,
+    });
+
+    renderWithProviders(<OrderConfirmationPage />);
+
+    expect(screen.queryByText(/Purchased by agent/)).toBeNull();
   });
 });

--- a/frontend/src/pages/OrderConfirmationPage.tsx
+++ b/frontend/src/pages/OrderConfirmationPage.tsx
@@ -1,5 +1,5 @@
 import { Link, useParams } from 'react-router';
-import { CalendarPlus, CheckCircle } from 'lucide-react';
+import { Bot, CalendarPlus, CheckCircle } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import { Badge } from '@/components/ui/badge';
@@ -83,6 +83,12 @@ export function OrderConfirmationPage() {
         >
           {order.status}
         </Badge>
+        {order.agentId && (
+          <div className="mt-3 inline-flex items-center gap-1.5 rounded-full border border-blue-200 bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-950/50 dark:text-blue-300">
+            <Bot className="h-3.5 w-3.5" />
+            Purchased by agent: {order.agentId}
+          </div>
+        )}
       </div>
 
       {/* Order Details */}

--- a/frontend/src/pages/OrderHistoryPage.test.tsx
+++ b/frontend/src/pages/OrderHistoryPage.test.tsx
@@ -24,6 +24,7 @@ const mockOrders: OrderSummary[] = [
     eventName: 'Taylor Swift - Eras Tour',
     eventDate: '2026-09-15T20:00:00Z',
     venueName: 'Madison Square Garden',
+    agentId: null,
   },
   {
     id: 2,
@@ -35,6 +36,7 @@ const mockOrders: OrderSummary[] = [
     eventName: null,
     eventDate: null,
     venueName: null,
+    agentId: null,
   },
 ];
 
@@ -129,5 +131,22 @@ describe('OrderHistoryPage', () => {
     expect(screen.getByText('Previous')).toBeDefined();
     expect(screen.getByText('Next')).toBeDefined();
     expect(screen.getByText('Page 1 of 2')).toBeDefined();
+  });
+
+  it('shows bot icon for agent-initiated orders', () => {
+    setOrdersState({
+      content: [{ ...mockOrders[0], agentId: 'claude-desktop' }],
+      totalElements: 1,
+      totalPages: 1,
+      size: 20,
+      number: 0,
+      first: true,
+      last: true,
+    });
+
+    renderWithProviders(<OrderHistoryPage />);
+
+    const agentIndicator = screen.getByTitle('Purchased by agent: claude-desktop');
+    expect(agentIndicator).toBeDefined();
   });
 });

--- a/frontend/src/types/order.ts
+++ b/frontend/src/types/order.ts
@@ -21,6 +21,8 @@ export interface Order {
   confirmedAt: string | null;
   createdAt: string;
   items: OrderItem[];
+  agentId: string | null;
+  mandateId: string | null;
 }
 
 export interface OrderSummary {
@@ -33,6 +35,7 @@ export interface OrderSummary {
   eventName: string | null;
   eventDate: string | null;
   venueName: string | null;
+  agentId: string | null;
 }
 
 export interface CheckoutRequest {


### PR DESCRIPTION
## Summary
- Exposes `agentId` and `mandateId` on `OrderDto`, `agentId` on `OrderSummaryDto`
- Shows a blue bot badge on the order confirmation page for agent-initiated purchases
- Shows a bot icon with tooltip in order history cards for agent orders
- Human-initiated orders show no agent attribution (clean conditional rendering)

## Details
- **Backend**: Added fields to `OrderDto` (agentId + mandateId) and `OrderSummaryDto` (agentId), updated mapping in `OrderService` and `AdminOrderService`
- **Frontend**: `Bot` icon from lucide-react, blue pill badge on `OrderConfirmationPage`, small icon on `OrderCard`, updated `Order`/`OrderSummary` types
- **Tests**: 3 new frontend tests (badge shown for agent orders, hidden for human orders, bot icon in history list), updated all existing test fixtures for new required fields

## Test plan
- [x] Full backend suite passes (no regressions from DTO changes)
- [x] Full frontend suite passes (446 tests, 67 files)
- [x] TypeScript compiles with zero errors
- [x] Prettier formatting verified
- [x] Codex review findings addressed (test fixtures, attribution tests)

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)