### PR TITLE
Cache Playwright browsers in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,13 +160,13 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}
+          key: playwright-chromium-webkit-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}
           restore-keys: |
-            playwright-${{ runner.os }}-
+            playwright-chromium-webkit-${{ runner.os }}-
 
       - name: Install Playwright browsers
         working-directory: frontend
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps chromium webkit
 
       - name: Run E2E tests
         working-directory: frontend

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [backend-test, frontend-test]
+    # Runs the full Playwright project matrix from frontend/playwright.config.ts
+    # on both pushes to main and PRs. Shards split the same matrix by test file.
     strategy:
       fail-fast: false
       matrix:
@@ -153,6 +155,14 @@ jobs:
       - name: Install frontend dependencies
         working-directory: frontend
         run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            playwright-${{ runner.os }}-
 
       - name: Install Playwright browsers
         working-directory: frontend


### PR DESCRIPTION
## Summary
- Cache Playwright browser binaries in the E2E workflow
- Limit the CI browser install to Chromium and WebKit, matching the configured Playwright projects
- Document that the current E2E job still runs the full Playwright project matrix on pushes and PRs

## Timing comparison
Baseline main run: https://github.com/kousen/mockhub/actions/runs/25342022661
- Shard 1: browser install 58s; E2E execution 2m07s; job wall time 4m34s
- Shard 2: browser install 64s; E2E execution 2m03s; job wall time 4m44s

Final warm-cache PR run: https://github.com/kousen/mockhub/actions/runs/25343151517
- Shard 1: cache restore 4s; browser install 39s; E2E execution 1m36s; job wall time 3m31s
- Shard 2: cache restore 5s; browser install 33s; E2E execution 2m06s; job wall time 3m58s

Result:
- Shard 1 improved by 63s wall time
- Shard 2 improved by 46s wall time
- GitHub runner queue delay was visible during reruns, but it is separate from job duration and not addressed by this PR

## Validation
- ruby YAML parse: OK
- git diff --check: OK
- PR checks passed: backend, frontend, Docker smoke, SonarCloud, GitGuardian, and both Playwright shards
- Claude ultrareview completed successfully with no findings

Refs #220