### PR TITLE
Stabilize accessibility E2E checks

### DIFF
--- a/frontend/e2e/accessibility.spec.ts
+++ b/frontend/e2e/accessibility.spec.ts
@@ -2,6 +2,8 @@ import { test, expect } from '@playwright/test';
 import AxeBuilder from '@axe-core/playwright';
 
 test.describe('Accessibility checks', () => {
+  test.describe.configure({ mode: 'serial', timeout: 30_000 });
+
   test('home page has no critical accessibility violations', async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');


### PR DESCRIPTION
## Summary
- Run the accessibility E2E spec serially so axe scans do not compete with each other under WebKit
- Increase the accessibility spec timeout to 30 seconds for heavier axe analysis

## Context
The post-merge main run for #222 failed in E2E Shard 1/2. The failure was WebKit accessibility checks timing out while creating pages or running AxeBuilder.analyze, with several related retries recovering.

## Validation
- git diff --check
- npm run format:check -- e2e/accessibility.spec.ts
- npx playwright test e2e/accessibility.spec.ts --project=webkit

Note: the targeted local Playwright run passed, with expected Vite proxy ECONNREFUSED warnings because the backend was not started for this frontend-only verification.