### PR TITLE
Run smoke E2E on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    # Nightly full E2E browser matrix.
+    - cron: '0 8 * * *'
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -88,13 +91,107 @@ jobs:
           name: frontend-coverage
           path: frontend/coverage/
 
-  e2e-test:
-    name: E2E Tests (Playwright) - Shard ${{ matrix.shard }}
+  e2e-smoke:
+    name: E2E Smoke (Playwright Chromium)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [backend-test, frontend-test]
+    if: github.event_name == 'pull_request'
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_DB: mockhub
+          POSTGRES_USER: mockhub
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 25
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Start backend
+        working-directory: backend
+        run: |
+          ./gradlew bootRun > bootRun.log 2>&1 &
+          echo "Waiting for backend to start..."
+          for i in $(seq 1 60); do
+            if curl -s http://localhost:8080/actuator/health > /dev/null 2>&1; then
+              echo "Backend is ready!"
+              break
+            fi
+            if [ $i -eq 60 ]; then
+              echo "Backend failed to start. Last 50 lines of log:"
+              tail -50 bootRun.log
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}
+          restore-keys: |
+            playwright-chromium-${{ runner.os }}-
+
+      - name: Install Playwright browsers
+        working-directory: frontend
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E smoke tests
+        working-directory: frontend
+        run: npx playwright test --project=chromium --grep @smoke
+
+      - name: Upload backend log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-bootrun-log-smoke
+          path: backend/bootRun.log
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-smoke-report
+          path: frontend/playwright-report/
+
+  e2e-test:
+    name: E2E Tests (Playwright Full) - Shard ${{ matrix.shard }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [backend-test, frontend-test]
+    if: github.event_name != 'pull_request'
     # Runs the full Playwright project matrix from frontend/playwright.config.ts
-    # on both pushes to main and PRs. Shards split the same matrix by test file.
+    # on pushes to main and the nightly schedule. Shards split the same matrix by test file.
     strategy:
       fail-fast: false
       matrix:

--- a/frontend/e2e/auth.spec.ts
+++ b/frontend/e2e/auth.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Authentication flows', () => {
-  test('login page renders correctly', async ({ page }) => {
+  test('login page renders correctly @smoke', async ({ page }) => {
     await page.goto('/login');
 
     await expect(page.getByText('Welcome back')).toBeVisible();
@@ -10,10 +10,12 @@ test.describe('Authentication flows', () => {
     await expect(page.getByRole('button', { name: 'Log in' })).toBeVisible();
   });
 
-  test('register page renders correctly', async ({ page }) => {
+  test('register page renders correctly @smoke', async ({ page }) => {
     await page.goto('/register');
 
-    await expect(page.locator('[data-slot="card-title"]', { hasText: 'Create an account' })).toBeVisible();
+    await expect(
+      page.locator('[data-slot="card-title"]', { hasText: 'Create an account' }),
+    ).toBeVisible();
     await expect(page.getByLabel('Email')).toBeVisible();
     await expect(page.getByLabel('Password', { exact: true })).toBeVisible();
     await expect(page.getByLabel('Confirm password')).toBeVisible();

--- a/frontend/e2e/browsing.spec.ts
+++ b/frontend/e2e/browsing.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Event browsing', () => {
-  test('home page loads', async ({ page }) => {
+  test('home page loads @smoke', async ({ page }) => {
     await page.goto('/');
 
     await expect(page.getByRole('banner').getByRole('link', { name: 'MockHub' })).toBeVisible();
@@ -13,7 +13,7 @@ test.describe('Event browsing', () => {
     await expect(page.getByRole('heading', { name: /browse events/i })).toBeVisible();
   });
 
-  test('events page has search input', async ({ page }) => {
+  test('events page has search input @smoke', async ({ page }) => {
     await page.goto('/events');
 
     const searchInput = page.getByPlaceholder(/search/i);
@@ -43,7 +43,7 @@ test.describe('Event browsing', () => {
     await expect(page.getByRole('combobox', { name: 'Sort by' })).toBeVisible();
   });
 
-  test('event cards are clickable and navigate to detail page', async ({ page }) => {
+  test('event cards are clickable and navigate to detail page @smoke', async ({ page }) => {
     const mockEventsList = {
       content: [
         {

--- a/frontend/e2e/cart-checkout.spec.ts
+++ b/frontend/e2e/cart-checkout.spec.ts
@@ -62,14 +62,14 @@ async function authenticateUser(page: Page) {
 }
 
 test.describe('Cart and checkout', () => {
-  test('cart page is protected', async ({ page }) => {
+  test('cart page is protected @smoke', async ({ page }) => {
     await page.goto('/cart');
 
     // Unauthenticated user should be redirected
     await expect(page).not.toHaveURL('/cart');
   });
 
-  test('checkout page is protected', async ({ page }) => {
+  test('checkout page is protected @smoke', async ({ page }) => {
     await page.goto('/checkout');
 
     // Unauthenticated user should be redirected
@@ -84,8 +84,14 @@ test.describe('Cart and checkout', () => {
     await expect(page.getByRole('banner').getByRole('link', { name: 'MockHub' })).toBeVisible();
   });
 
-  test('cart icon shows badge count when authenticated with items in cart', async ({ page, isMobile }) => {
-    test.skip(!!isMobile, 'Cart button in header is not visible on mobile — mobile nav tested separately');
+  test('cart icon shows badge count when authenticated with items in cart', async ({
+    page,
+    isMobile,
+  }) => {
+    test.skip(
+      !!isMobile,
+      'Cart button in header is not visible on mobile — mobile nav tested separately',
+    );
     await authenticateUser(page);
 
     // Mock cart endpoint to return a cart with one item

--- a/frontend/e2e/event-detail.spec.ts
+++ b/frontend/e2e/event-detail.spec.ts
@@ -180,7 +180,7 @@ async function mockEventDetailEndpoints(page: Page, event = MOCK_EVENT) {
 // -- Tests --
 
 test.describe('Event Detail Page', () => {
-  test('event detail page loads with event name heading', async ({ page }) => {
+  test('event detail page loads with event name heading @smoke', async ({ page }) => {
     await mockEventDetailEndpoints(page);
     await page.goto('/events');
 


### PR DESCRIPTION
## Summary
- Run a Chromium-only @smoke Playwright suite for pull requests
- Keep the full Playwright browser matrix and two shards on pushes to main
- Add a nightly scheduled full E2E run

## Smoke coverage
The PR smoke suite currently covers:
- home page loads
- events page search input
- event card navigation to detail
- login and register render paths
- protected cart and checkout redirects
- event detail page heading render

## Validation
- ruby YAML parse: OK
- git diff --check: OK
- npm run format:check -- e2e/auth.spec.ts e2e/browsing.spec.ts e2e/cart-checkout.spec.ts e2e/event-detail.spec.ts
- npx playwright test --project=chromium --grep @smoke

Refs #220