### PR TITLE
Add agent-readable commerce policies

### DIFF
--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -992,6 +992,63 @@ Replaced `X-API-Key` custom header auth on `/mcp/**` with OAuth 2.1 + DCR, elimi
 
 ---
 
-*Last updated: 2026-04-04*
-*Built with: Claude Opus 4.6 (1M context) via Claude Code*
+## Session 2026-05-05: PR Readiness Workflow Trial + Agent Commerce Policies
+
+### Workflow Trial
+
+Used issue **#213** as the first full test of the MockHub PR-readiness workflow in Codex:
+
+1. Created a feature branch: `feature/213-agent-readable-commerce-policies`
+2. Implemented the issue with tests before publication
+3. Ran local backend validation: `./gradlew test jacocoTestReport`
+4. Opened draft PR **#225**: "Add agent-readable commerce policies"
+5. Ran independent review with Gemini CLI
+6. Fixed valid review findings in a separate follow-up commit
+7. Re-ran local validation and re-checked GitHub Actions + SonarCloud
+
+Total elapsed time was roughly 35-40 minutes, including tool setup friction and CI wait time.
+
+### Issue #213: Agent-Readable Commerce Policies
+
+Added structured commerce policy metadata for agents before checkout:
+
+- REST endpoints under `/api/v1/commerce/policies/**`
+- MCP `getCommercePolicy(eventSlug)` tool
+- Policy context embedded in `getEventListings`
+- Policy URLs included in listing/search DTOs used by `findTickets` and listing detail responses
+- ACP catalog, listing, and checkout responses include `commercePolicy`
+- Documentation updated in `llms.txt`, `docs/agentic-commerce.md`, and `docs/acp-openapi.yaml`
+
+Gemini review found a useful contract issue: ACP checkout responses initially used the default policy even when all line items belonged to a single event. Fixed by resolving an event-scoped policy when the checkout response line items have exactly one event slug, with fallback to the default policy for mixed or unknown event sets.
+
+### Review Workflow Notes
+
+Gemini CLI is now the preferred lightweight independent review path for normal PRs:
+
+```bash
+gemini --skip-trust --approval-mode plan -p "Review the committed MockHub diff from origin/main to HEAD for issue #<issue>. Focus on correctness, regressions, missing tests, security/auth exposure, and REST/MCP/ACP contract mismatches. Return only actionable findings with file paths and line numbers; say No findings if none."
+```
+
+Observed tooling quirks:
+
+- Gemini may still ask the Codex shell to open an authentication page even after the project has been trusted from an interactive terminal.
+- Gemini extension warnings can appear before review output; they are usually noise unless they prevent completion.
+- Claude headless review timed out in this environment, likely due to project/plugin startup. Keep it as a bounded fallback rather than the default.
+- `claude ultrareview origin/main` should remain reserved for high-risk changes.
+
+The local `mockhub-pr-readiness` Codex skill was updated with these lessons.
+
+### Status at End of Session
+
+- PR #225 is open as a draft.
+- Commits:
+  - `b7d6220` — Add agent-readable commerce policies
+  - `ecf3494` — Address commerce policy review findings
+- PR checks were green after the review-fix commit: Backend, Frontend, E2E Smoke, Docker smoke, GitGuardian, SonarCloud Analysis, and SonarCloud Code Analysis.
+- Next session: try the workflow on another issue, preferably one issue per branch unless two issues are tightly coupled.
+
+---
+
+*Last updated: 2026-05-05*
+*Built with: Claude Opus 4.6 (1M context) via Claude Code; Codex GPT-5 for 2026-05-05 workflow trial*
 *Live at: https://mockhub.kousenit.com*

--- a/backend/src/main/java/com/mockhub/acp/dto/AcpCatalogItem.java
+++ b/backend/src/main/java/com/mockhub/acp/dto/AcpCatalogItem.java
@@ -3,6 +3,8 @@ package com.mockhub.acp.dto;
 import java.math.BigDecimal;
 import java.time.Instant;
 
+import com.mockhub.commerce.dto.CommercePolicyDto;
+
 public record AcpCatalogItem(
         String productId,
         String name,
@@ -14,6 +16,7 @@ public record AcpCatalogItem(
         BigDecimal minPrice,
         BigDecimal maxPrice,
         int availableTickets,
-        String url
+        String url,
+        CommercePolicyDto commercePolicy
 ) {
 }

--- a/backend/src/main/java/com/mockhub/acp/dto/AcpCheckoutResponse.java
+++ b/backend/src/main/java/com/mockhub/acp/dto/AcpCheckoutResponse.java
@@ -3,12 +3,15 @@ package com.mockhub.acp.dto;
 import java.time.Instant;
 import java.util.List;
 
+import com.mockhub.commerce.dto.CommercePolicyDto;
+
 public record AcpCheckoutResponse(
         String checkoutId,
         String status,
         String buyerEmail,
         List<AcpLineItemResponse> lineItems,
         AcpPricing pricing,
+        CommercePolicyDto commercePolicy,
         Instant createdAt,
         Instant completedAt
 ) {

--- a/backend/src/main/java/com/mockhub/acp/dto/AcpListingItem.java
+++ b/backend/src/main/java/com/mockhub/acp/dto/AcpListingItem.java
@@ -3,6 +3,8 @@ package com.mockhub.acp.dto;
 import java.math.BigDecimal;
 import java.time.Instant;
 
+import com.mockhub.commerce.dto.CommercePolicyDto;
+
 public record AcpListingItem(
         Long listingId,
         String productId,
@@ -17,6 +19,7 @@ public record AcpListingItem(
         String rowLabel,
         String seatNumber,
         BigDecimal price,
-        String url
+        String url,
+        CommercePolicyDto commercePolicy
 ) {
 }

--- a/backend/src/main/java/com/mockhub/acp/service/AcpCatalogService.java
+++ b/backend/src/main/java/com/mockhub/acp/service/AcpCatalogService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.mockhub.acp.dto.AcpCatalogItem;
 import com.mockhub.acp.dto.AcpListingItem;
+import com.mockhub.commerce.service.CommercePolicyService;
 import com.mockhub.common.dto.PagedResponse;
 import com.mockhub.event.dto.EventSearchRequest;
 import com.mockhub.event.dto.EventSummaryDto;
@@ -26,10 +27,14 @@ public class AcpCatalogService {
 
     private final EventService eventService;
     private final ListingRepository listingRepository;
+    private final CommercePolicyService commercePolicyService;
 
-    public AcpCatalogService(EventService eventService, ListingRepository listingRepository) {
+    public AcpCatalogService(EventService eventService,
+                             ListingRepository listingRepository,
+                             CommercePolicyService commercePolicyService) {
         this.eventService = eventService;
         this.listingRepository = listingRepository;
+        this.commercePolicyService = commercePolicyService;
     }
 
     @Transactional(readOnly = true)
@@ -53,7 +58,8 @@ public class AcpCatalogService {
                         event.minPrice(),
                         event.minPrice(),
                         event.availableTickets(),
-                        "/events/" + event.slug()
+                        "/events/" + event.slug(),
+                        commercePolicyService.getPolicyForEvent(event.slug())
                 ))
                 .toList();
 
@@ -116,7 +122,8 @@ public class AcpCatalogService {
                         rowLabel,
                         seatNumber,
                         listing.getComputedPrice(),
-                        "/events/" + event.slug()
+                        "/events/" + event.slug(),
+                        commercePolicyService.getPolicyForEvent(event.slug())
                 ));
             }
         }

--- a/backend/src/main/java/com/mockhub/acp/service/AcpCheckoutService.java
+++ b/backend/src/main/java/com/mockhub/acp/service/AcpCheckoutService.java
@@ -23,6 +23,7 @@ import com.mockhub.auth.entity.User;
 import com.mockhub.auth.repository.UserRepository;
 import com.mockhub.cart.service.CartService;
 import com.mockhub.cart.dto.CartDto;
+import com.mockhub.commerce.dto.CommercePolicyDto;
 import com.mockhub.commerce.service.CommercePolicyService;
 import com.mockhub.common.exception.ConflictException;
 import com.mockhub.common.exception.ResourceNotFoundException;
@@ -244,7 +245,7 @@ public class AcpCheckoutService {
                 buyerEmail,
                 lineItems,
                 pricing,
-                commercePolicyService.getDefaultPolicy(),
+                commercePolicyForLineItems(lineItems),
                 orderDto.createdAt(),
                 null
         );
@@ -358,10 +359,23 @@ public class AcpCheckoutService {
                 buyerEmail,
                 lineItems,
                 pricing,
-                commercePolicyService.getDefaultPolicy(),
+                commercePolicyForLineItems(lineItems),
                 orderDto.createdAt(),
                 orderDto.confirmedAt()
         );
+    }
+
+    private CommercePolicyDto commercePolicyForLineItems(List<AcpLineItemResponse> lineItems) {
+        Set<String> eventSlugs = lineItems.stream()
+                .map(AcpLineItemResponse::eventSlug)
+                .filter(slug -> slug != null && !slug.isBlank())
+                .collect(Collectors.toSet());
+
+        if (eventSlugs.size() == 1) {
+            return commercePolicyService.getPolicyForEvent(eventSlugs.iterator().next());
+        }
+
+        return commercePolicyService.getDefaultPolicy();
     }
 
     private String mapOrderStatusToAcpStatus(String orderStatus) {

--- a/backend/src/main/java/com/mockhub/acp/service/AcpCheckoutService.java
+++ b/backend/src/main/java/com/mockhub/acp/service/AcpCheckoutService.java
@@ -23,6 +23,7 @@ import com.mockhub.auth.entity.User;
 import com.mockhub.auth.repository.UserRepository;
 import com.mockhub.cart.service.CartService;
 import com.mockhub.cart.dto.CartDto;
+import com.mockhub.commerce.service.CommercePolicyService;
 import com.mockhub.common.exception.ConflictException;
 import com.mockhub.common.exception.ResourceNotFoundException;
 import com.mockhub.eval.dto.EvalContext;
@@ -53,19 +54,22 @@ public class AcpCheckoutService {
     private final ListingRepository listingRepository;
     private final EvalRunner evalRunner;
     private final PaymentService paymentService;
+    private final CommercePolicyService commercePolicyService;
 
     public AcpCheckoutService(UserRepository userRepository,
                               CartService cartService,
                               OrderService orderService,
                               ListingRepository listingRepository,
                               EvalRunner evalRunner,
-                              PaymentService paymentService) {
+                              PaymentService paymentService,
+                              CommercePolicyService commercePolicyService) {
         this.userRepository = userRepository;
         this.cartService = cartService;
         this.orderService = orderService;
         this.listingRepository = listingRepository;
         this.evalRunner = evalRunner;
         this.paymentService = paymentService;
+        this.commercePolicyService = commercePolicyService;
     }
 
     @Transactional
@@ -240,6 +244,7 @@ public class AcpCheckoutService {
                 buyerEmail,
                 lineItems,
                 pricing,
+                commercePolicyService.getDefaultPolicy(),
                 orderDto.createdAt(),
                 null
         );
@@ -353,6 +358,7 @@ public class AcpCheckoutService {
                 buyerEmail,
                 lineItems,
                 pricing,
+                commercePolicyService.getDefaultPolicy(),
                 orderDto.createdAt(),
                 orderDto.confirmedAt()
         );

--- a/backend/src/main/java/com/mockhub/commerce/controller/CommercePolicyController.java
+++ b/backend/src/main/java/com/mockhub/commerce/controller/CommercePolicyController.java
@@ -1,0 +1,31 @@
+package com.mockhub.commerce.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.mockhub.commerce.dto.CommercePolicyDto;
+import com.mockhub.commerce.service.CommercePolicyService;
+
+@RestController
+@RequestMapping("/api/v1/commerce/policies")
+public class CommercePolicyController {
+
+    private final CommercePolicyService commercePolicyService;
+
+    public CommercePolicyController(CommercePolicyService commercePolicyService) {
+        this.commercePolicyService = commercePolicyService;
+    }
+
+    @GetMapping("/default")
+    public ResponseEntity<CommercePolicyDto> getDefaultPolicy() {
+        return ResponseEntity.ok(commercePolicyService.getDefaultPolicy());
+    }
+
+    @GetMapping("/events/{eventSlug}")
+    public ResponseEntity<CommercePolicyDto> getEventPolicy(@PathVariable String eventSlug) {
+        return ResponseEntity.ok(commercePolicyService.getPolicyForEvent(eventSlug));
+    }
+}

--- a/backend/src/main/java/com/mockhub/commerce/dto/CommercePolicyDto.java
+++ b/backend/src/main/java/com/mockhub/commerce/dto/CommercePolicyDto.java
@@ -1,0 +1,17 @@
+package com.mockhub.commerce.dto;
+
+import java.time.Instant;
+import java.util.List;
+
+public record CommercePolicyDto(
+        String policyId,
+        String version,
+        String appliesTo,
+        String eventSlug,
+        List<CommercePolicySectionDto> sections,
+        String supportContact,
+        String supportUrl,
+        String policyUrl,
+        Instant updatedAt
+) {
+}

--- a/backend/src/main/java/com/mockhub/commerce/dto/CommercePolicySectionDto.java
+++ b/backend/src/main/java/com/mockhub/commerce/dto/CommercePolicySectionDto.java
@@ -1,0 +1,10 @@
+package com.mockhub.commerce.dto;
+
+public record CommercePolicySectionDto(
+        String code,
+        String title,
+        String summary,
+        String details,
+        String agentGuidance
+) {
+}

--- a/backend/src/main/java/com/mockhub/commerce/service/CommercePolicyService.java
+++ b/backend/src/main/java/com/mockhub/commerce/service/CommercePolicyService.java
@@ -1,0 +1,97 @@
+package com.mockhub.commerce.service;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.mockhub.commerce.dto.CommercePolicyDto;
+import com.mockhub.commerce.dto.CommercePolicySectionDto;
+
+@Service
+public class CommercePolicyService {
+
+    private static final String POLICY_ID = "mockhub-standard-commerce-policy";
+    private static final String VERSION = "2026-05-01";
+    private static final Instant UPDATED_AT = Instant.parse("2026-05-01T00:00:00Z");
+    private static final String DEFAULT_POLICY_URL = "/api/v1/commerce/policies/default";
+
+    public CommercePolicyDto getDefaultPolicy() {
+        return buildPolicy(null);
+    }
+
+    public CommercePolicyDto getPolicyForEvent(String eventSlug) {
+        if (eventSlug == null || eventSlug.isBlank()) {
+            return getDefaultPolicy();
+        }
+        return buildPolicy(eventSlug.strip());
+    }
+
+    public String getPolicyUrlForEvent(String eventSlug) {
+        if (eventSlug == null || eventSlug.isBlank()) {
+            return DEFAULT_POLICY_URL;
+        }
+        return "/api/v1/commerce/policies/events/" + eventSlug.strip();
+    }
+
+    private CommercePolicyDto buildPolicy(String eventSlug) {
+        return new CommercePolicyDto(
+                POLICY_ID,
+                VERSION,
+                eventSlug == null ? "all_mockhub_ticket_purchases" : "event:" + eventSlug,
+                eventSlug,
+                policySections(),
+                "support@mockhub.dev",
+                "/support",
+                eventSlug == null ? DEFAULT_POLICY_URL : getPolicyUrlForEvent(eventSlug),
+                UPDATED_AT
+        );
+    }
+
+    private List<CommercePolicySectionDto> policySections() {
+        return List.of(
+                new CommercePolicySectionDto(
+                        "refunds",
+                        "Refund policy",
+                        "Orders are final after confirmation except when MockHub cancels or cannot fulfill tickets.",
+                        "Pending orders can be cancelled before confirmation. Confirmed orders are generally final. "
+                                + "If MockHub cancels an event, cannot deliver tickets, or identifies invalid tickets, "
+                                + "the buyer is eligible for a refund or comparable replacement offer.",
+                        "Before checkout, tell the buyer that confirmed tickets are usually non-refundable unless "
+                                + "MockHub cannot fulfill the order."
+                ),
+                new CommercePolicySectionDto(
+                        "cancellations",
+                        "Cancellation policy",
+                        "Agents may cancel pending checkouts before completion; completed purchases cannot be cancelled.",
+                        "ACP checkouts and cart-based orders remain cancellable while they are PENDING. Once payment is "
+                                + "confirmed and tickets are issued, cancellation is not available through the checkout API.",
+                        "If the buyer asks to change seats or abandon a purchase, cancel before confirming payment."
+                ),
+                new CommercePolicySectionDto(
+                        "ticket_transfer",
+                        "Ticket transfer and delivery",
+                        "Confirmed tickets are delivered immediately through MockHub's public ticket view.",
+                        "Confirmed orders receive token-protected public ticket links with QR codes. Tickets are not "
+                                + "mailed, and transfer outside MockHub is not modeled in this teaching system.",
+                        "After purchase, use order/ticket links from MockHub instead of promising external transfer."
+                ),
+                new CommercePolicySectionDto(
+                        "fees",
+                        "Fee disclosure",
+                        "Checkout totals include ticket subtotal, service fee, and all-in total before confirmation.",
+                        "Agents must present the all-in total returned by checkout before confirming payment. Listing "
+                                + "prices alone are not the final buyer cost because service fees may apply.",
+                        "Use checkout pricing fields as the source of truth for final buyer cost."
+                ),
+                new CommercePolicySectionDto(
+                        "support_and_disputes",
+                        "Support and recourse",
+                        "Support is available through MockHub support when ticket delivery or validation fails.",
+                        "For invalid, missing, duplicate-scanned, or otherwise unusable tickets, the buyer should contact "
+                                + "MockHub support with the order number and ticket details.",
+                        "If fulfillment looks uncertain or a ticket verification problem appears, direct the buyer to support."
+                )
+        );
+    }
+}

--- a/backend/src/main/java/com/mockhub/config/SecurityConfig.java
+++ b/backend/src/main/java/com/mockhub/config/SecurityConfig.java
@@ -63,6 +63,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/categories").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/tags").permitAll()
                         .requestMatchers("/api/v1/search/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/commerce/policies/**").permitAll()
                         // Public Spotify metadata
                         .requestMatchers(HttpMethod.GET, "/api/v1/spotify/**").permitAll()
                         // Public AI endpoints

--- a/backend/src/main/java/com/mockhub/mcp/tools/EventTools.java
+++ b/backend/src/main/java/com/mockhub/mcp/tools/EventTools.java
@@ -12,6 +12,7 @@ import org.springframework.ai.tool.annotation.ToolParam;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mockhub.commerce.service.CommercePolicyService;
 import com.mockhub.common.dto.PagedResponse;
 import com.mockhub.event.dto.EventDto;
 import com.mockhub.event.dto.EventSearchRequest;
@@ -29,13 +30,16 @@ public class EventTools {
 
     private final EventService eventService;
     private final ListingService listingService;
+    private final CommercePolicyService commercePolicyService;
     private final ObjectMapper objectMapper;
 
     public EventTools(EventService eventService,
                       ListingService listingService,
+                      CommercePolicyService commercePolicyService,
                       ObjectMapper objectMapper) {
         this.eventService = eventService;
         this.listingService = listingService;
+        this.commercePolicyService = commercePolicyService;
         this.objectMapper = objectMapper;
     }
 
@@ -109,12 +113,27 @@ public class EventTools {
                     "listings", listings,
                     "page", pageNum,
                     "size", pageSize,
-                    "totalListings", totalListings
+                    "totalListings", totalListings,
+                    "commercePolicy", commercePolicyService.getPolicyForEvent(trimmedSlug)
             );
             return objectMapper.writeValueAsString(response);
         } catch (Exception e) {
             log.error("Error getting listings for slug '{}': {}", slug, e.getMessage(), e);
             return errorJson("Failed to get event listings: " + e.getMessage());
+        }
+    }
+
+    @Tool(description = "Get MockHub's structured commerce policy metadata for agent purchases. "
+            + "Call this before checkout when explaining refunds, cancellations, ticket delivery, fees, support, "
+            + "or buyer recourse. Optionally pass an event slug to get the policy URL scoped to that event.")
+    public String getCommercePolicy(
+            @ToolParam(description = "Optional event URL slug for event-scoped policy metadata",
+                    required = false) String eventSlug) {
+        try {
+            return objectMapper.writeValueAsString(commercePolicyService.getPolicyForEvent(eventSlug));
+        } catch (Exception e) {
+            log.error("Error getting commerce policy for slug '{}': {}", eventSlug, e.getMessage(), e);
+            return errorJson("Failed to get commerce policy: " + e.getMessage());
         }
     }
 

--- a/backend/src/main/java/com/mockhub/mcp/tools/EventTools.java
+++ b/backend/src/main/java/com/mockhub/mcp/tools/EventTools.java
@@ -125,7 +125,7 @@ public class EventTools {
 
     @Tool(description = "Get MockHub's structured commerce policy metadata for agent purchases. "
             + "Call this before checkout when explaining refunds, cancellations, ticket delivery, fees, support, "
-            + "or buyer recourse. Optionally pass an event slug to get the policy URL scoped to that event.")
+            + "or buyer recourse. Optionally pass an event slug to get a full policy object scoped to that event.")
     public String getCommercePolicy(
             @ToolParam(description = "Optional event URL slug for event-scoped policy metadata",
                     required = false) String eventSlug) {

--- a/backend/src/main/java/com/mockhub/ticket/dto/ListingDto.java
+++ b/backend/src/main/java/com/mockhub/ticket/dto/ListingDto.java
@@ -16,6 +16,7 @@ public record ListingDto(
         BigDecimal priceMultiplier,
         String status,
         Instant listedAt,
-        String sellerDisplayName
+        String sellerDisplayName,
+        String commercePolicyUrl
 ) {
 }

--- a/backend/src/main/java/com/mockhub/ticket/dto/TicketSearchResultDto.java
+++ b/backend/src/main/java/com/mockhub/ticket/dto/TicketSearchResultDto.java
@@ -18,6 +18,7 @@ public record TicketSearchResultDto(
         String seatNumber,
         String ticketType,
         BigDecimal price,
-        String sellerDisplayName
+        String sellerDisplayName,
+        String commercePolicyUrl
 ) {
 }

--- a/backend/src/main/java/com/mockhub/ticket/service/ListingService.java
+++ b/backend/src/main/java/com/mockhub/ticket/service/ListingService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.mockhub.auth.entity.User;
 import com.mockhub.auth.repository.UserRepository;
+import com.mockhub.commerce.service.CommercePolicyService;
 import com.mockhub.common.exception.ConflictException;
 import com.mockhub.common.exception.ResourceNotFoundException;
 import com.mockhub.common.exception.UnauthorizedException;
@@ -54,17 +55,20 @@ public class ListingService {
     private final EventRepository eventRepository;
     private final UserRepository userRepository;
     private final OrderItemRepository orderItemRepository;
+    private final CommercePolicyService commercePolicyService;
 
     public ListingService(ListingRepository listingRepository,
                           TicketRepository ticketRepository,
                           EventRepository eventRepository,
                           UserRepository userRepository,
-                          OrderItemRepository orderItemRepository) {
+                          OrderItemRepository orderItemRepository,
+                          CommercePolicyService commercePolicyService) {
         this.listingRepository = listingRepository;
         this.ticketRepository = ticketRepository;
         this.eventRepository = eventRepository;
         this.userRepository = userRepository;
         this.orderItemRepository = orderItemRepository;
+        this.commercePolicyService = commercePolicyService;
     }
 
     @Transactional(readOnly = true)
@@ -388,7 +392,8 @@ public class ListingService {
                 seatNumber,
                 ticket.getTicketType(),
                 listing.getComputedPrice(),
-                sellerDisplayName
+                sellerDisplayName,
+                commercePolicyService.getPolicyUrlForEvent(event.getSlug())
         );
     }
 
@@ -514,7 +519,8 @@ public class ListingService {
                 listing.getPriceMultiplier(),
                 listing.getStatus(),
                 listing.getListedAt(),
-                sellerDisplayName
+                sellerDisplayName,
+                commercePolicyService.getPolicyUrlForEvent(listing.getEvent().getSlug())
         );
     }
 }

--- a/backend/src/main/resources/static/llms.txt
+++ b/backend/src/main/resources/static/llms.txt
@@ -110,10 +110,11 @@ Compatible clients: Claude (desktop/web/mobile), Cursor, MCP Inspector, any OAut
 Sessions are in-memory — after server redeploys, clients must re-initialize.
 - searchEvents(query?, category?, city?, page?, size?) — search and filter events with pagination
 - getEventDetail(slug) — full event details by URL slug
-- getEventListings(slug, page?, size?) — active listings for an event with pagination (default 20, max 50)
+- getEventListings(slug, page?, size?) — active listings for an event with pagination (default 20, max 50) plus the event commercePolicy
 - getFeaturedEvents() — curated featured events
-- getListingDetail(listingId) — single listing by ID
-- findTickets(query?, category?, city?, dateFrom?, dateTo?, minPrice?, maxPrice?, section?, maxResults?) — RECOMMENDED: compound search returning matching listings sorted by price. Date params are ISO-8601 strings (e.g. '2026-04-01T00:00:00Z'). Reduces round-trips from 3 to 1.
+- getListingDetail(listingId) — single listing by ID, including commercePolicyUrl
+- findTickets(query?, category?, city?, dateFrom?, dateTo?, minPrice?, maxPrice?, section?, maxResults?) — RECOMMENDED: compound search returning matching listings sorted by price, including commercePolicyUrl for each listing. Date params are ISO-8601 strings (e.g. '2026-04-01T00:00:00Z'). Reduces round-trips from 3 to 1.
+- getCommercePolicy(eventSlug) — structured commerce policy for agent purchase decisions (refunds, cancellations, transfer, fees, support)
 - getPriceHistory(eventSlug) — historical price snapshots
 - getPricePrediction(eventSlug) — AI price forecast (requires AI provider)
 - getCart(userEmail) — current cart contents
@@ -141,6 +142,13 @@ POST /acp/v1/checkout/{checkoutId}/complete — Complete checkout. JSON body: {"
 POST /acp/v1/checkout/{checkoutId}/cancel — Cancel checkout. JSON body: {"agentId", "mandateId"}. Header: X-Buyer-Email
 GET /acp/v1/catalog — Browse product catalog. Query params: query, category, city, page, size
 GET /acp/v1/listings — Browse actionable ticket offers. Query params: query, category, city, dateFrom, dateTo, minPrice, maxPrice, section, page, size
+
+## Commerce Policies
+GET /api/v1/commerce/policies/default — Default agent-readable commerce policy
+GET /api/v1/commerce/policies/events/{eventSlug} — Event-scoped commerce policy
+Policy fields: policyId, version, eventSlug, policyUrl, updatedAt, sections[], supportContact, supportUrl.
+ACP catalog items, ACP listing items, ACP checkout responses, and MCP getEventListings include commercePolicy directly.
+MCP findTickets and getListingDetail include commercePolicyUrl for each actionable listing.
 
 ## Agent Mandates
 

--- a/backend/src/test/java/com/mockhub/acp/controller/AcpControllerTest.java
+++ b/backend/src/test/java/com/mockhub/acp/controller/AcpControllerTest.java
@@ -22,6 +22,7 @@ import com.mockhub.acp.dto.AcpLineItemResponse;
 import com.mockhub.acp.dto.AcpPricing;
 import com.mockhub.acp.service.AcpCatalogService;
 import com.mockhub.acp.service.AcpCheckoutService;
+import com.mockhub.commerce.dto.CommercePolicyDto;
 import com.mockhub.auth.repository.UserRepository;
 import com.mockhub.auth.security.JwtAuthenticationFilter;
 import com.mockhub.auth.security.JwtTokenProvider;
@@ -247,7 +248,7 @@ class AcpControllerTest {
                         "test-concert", "Test Concert", "Test Concert", "rock",
                         "Test Venue", "NYC", Instant.now(),
                         new BigDecimal("50.00"), new BigDecimal("50.00"), 10,
-                        "/events/test-concert")),
+                        "/events/test-concert", createPolicy("test-concert"))),
                 0, 20, 1, 1);
         when(acpCatalogService.getCatalog(null, null, null, 0, 20)).thenReturn(catalogResponse);
 
@@ -282,7 +283,8 @@ class AcpControllerTest {
                 List.of(new AcpListingItem(
                         10L, "test-concert", "Test Concert", "test-concert", "Test Concert",
                         "rock", "Test Venue", "NYC", Instant.now(),
-                        "Floor", "A", "1", new BigDecimal("50.00"), "/events/test-concert")),
+                        "Floor", "A", "1", new BigDecimal("50.00"),
+                        "/events/test-concert", createPolicy("test-concert"))),
                 0, 20, 1, 1);
         when(acpCatalogService.getListings(any(), any(), any(), any(), any(), any(), any(), any(), eq(0), eq(20)))
                 .thenReturn(listingsResponse);
@@ -328,8 +330,18 @@ class AcpControllerTest {
                 "buyer@test.com",
                 lineItems,
                 pricing,
+                createPolicy(null),
                 Instant.now(),
                 "COMPLETED".equals(status) ? Instant.now() : null
         );
+    }
+
+    private CommercePolicyDto createPolicy(String eventSlug) {
+        return new CommercePolicyDto(
+                "policy", "v1", eventSlug == null ? "all_mockhub_ticket_purchases" : "event:" + eventSlug,
+                eventSlug, List.of(), "support@mockhub.dev", "/support",
+                eventSlug == null ? "/api/v1/commerce/policies/default"
+                        : "/api/v1/commerce/policies/events/" + eventSlug,
+                Instant.now());
     }
 }

--- a/backend/src/test/java/com/mockhub/acp/service/AcpCatalogServiceTest.java
+++ b/backend/src/test/java/com/mockhub/acp/service/AcpCatalogServiceTest.java
@@ -14,6 +14,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.mockhub.acp.dto.AcpCatalogItem;
 import com.mockhub.acp.dto.AcpListingItem;
+import com.mockhub.commerce.dto.CommercePolicyDto;
+import com.mockhub.commerce.service.CommercePolicyService;
 import com.mockhub.common.dto.PagedResponse;
 import com.mockhub.event.dto.EventSearchRequest;
 import com.mockhub.event.dto.EventSummaryDto;
@@ -24,6 +26,7 @@ import com.mockhub.ticket.repository.ListingRepository;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,10 +38,14 @@ class AcpCatalogServiceTest {
     @Mock
     private ListingRepository listingRepository;
 
+    @Mock
+    private CommercePolicyService commercePolicyService;
+
     @InjectMocks
     private AcpCatalogService acpCatalogService;
 
     private EventSummaryDto testEvent;
+    private CommercePolicyDto testPolicy;
 
     @BeforeEach
     void setUp() {
@@ -46,6 +53,12 @@ class AcpCatalogServiceTest {
                 1L, "Rock Festival", "rock-festival", "Band A",
                 "Madison Square Garden", "NYC", Instant.now(),
                 new BigDecimal("75.00"), 50, null, "rock", true);
+        testPolicy = new CommercePolicyDto(
+                "policy", "v1", "event:rock-festival", "rock-festival",
+                List.of(), "support@mockhub.dev", "/support",
+                "/api/v1/commerce/policies/events/rock-festival", Instant.now());
+        lenient().when(commercePolicyService.getPolicyForEvent(any()))
+                .thenReturn(testPolicy);
     }
 
     @Test
@@ -66,6 +79,7 @@ class AcpCatalogServiceTest {
         assertEquals(new BigDecimal("75.00"), item.minPrice());
         assertEquals(50, item.availableTickets());
         assertEquals("/events/rock-festival", item.url());
+        assertEquals(testPolicy, item.commercePolicy());
     }
 
     @Test
@@ -102,6 +116,7 @@ class AcpCatalogServiceTest {
         assertEquals(1, result.content().size());
         assertEquals(10L, result.content().getFirst().listingId());
         assertEquals(new BigDecimal("80.00"), result.content().getFirst().price());
+        assertEquals(testPolicy, result.content().getFirst().commercePolicy());
     }
 
     @Test

--- a/backend/src/test/java/com/mockhub/acp/service/AcpCheckoutServiceTest.java
+++ b/backend/src/test/java/com/mockhub/acp/service/AcpCheckoutServiceTest.java
@@ -115,6 +115,8 @@ class AcpCheckoutServiceTest {
         lenient().when(cartService.getCartDto(testUser))
                 .thenReturn(new CartDto(1L, 1L, List.of(), new BigDecimal("55.00"), 1, null));
         lenient().when(commercePolicyService.getDefaultPolicy()).thenReturn(createCommercePolicy());
+        lenient().when(commercePolicyService.getPolicyForEvent("test-concert"))
+                .thenReturn(createCommercePolicy("test-concert"));
     }
 
     private CommercePolicyDto createCommercePolicy() {
@@ -122,6 +124,13 @@ class AcpCheckoutServiceTest {
                 "policy", "v1", "all_mockhub_ticket_purchases", null,
                 List.of(), "support@mockhub.dev", "/support",
                 "/api/v1/commerce/policies/default", Instant.now());
+    }
+
+    private CommercePolicyDto createCommercePolicy(String eventSlug) {
+        return new CommercePolicyDto(
+                "policy", "v1", "event:" + eventSlug, eventSlug,
+                List.of(), "support@mockhub.dev", "/support",
+                "/api/v1/commerce/policies/events/" + eventSlug, Instant.now());
     }
 
     private AcpCheckoutRequest createCheckoutRequest(String buyerEmail, List<AcpLineItem> lineItems,
@@ -194,6 +203,7 @@ class AcpCheckoutServiceTest {
         assertEquals("USD", response.pricing().currency());
         assertEquals(new BigDecimal("55.00"), response.pricing().total());
         assertNotNull(response.commercePolicy());
+        assertEquals("test-concert", response.commercePolicy().eventSlug());
 
         verify(cartService).clearCart(testUser);
         verify(cartService).addToCart(testUser, 10L);
@@ -272,6 +282,7 @@ class AcpCheckoutServiceTest {
         assertNotNull(response);
         assertEquals("COMPLETED", response.status());
         assertNotNull(response.completedAt());
+        assertEquals("test-concert", response.commercePolicy().eventSlug());
 
         verify(paymentService).confirmPayment("pi_test");
     }
@@ -309,6 +320,7 @@ class AcpCheckoutServiceTest {
         assertEquals("CANCELLED", response.status());
         assertNull(response.completedAt());
         assertNotNull(response.commercePolicy());
+        assertEquals("test-concert", response.commercePolicy().eventSlug());
 
         verify(orderService).failOrder("MH-20260323-0001");
     }

--- a/backend/src/test/java/com/mockhub/acp/service/AcpCheckoutServiceTest.java
+++ b/backend/src/test/java/com/mockhub/acp/service/AcpCheckoutServiceTest.java
@@ -21,6 +21,8 @@ import com.mockhub.auth.entity.User;
 import com.mockhub.auth.repository.UserRepository;
 import com.mockhub.cart.dto.CartDto;
 import com.mockhub.cart.service.CartService;
+import com.mockhub.commerce.dto.CommercePolicyDto;
+import com.mockhub.commerce.service.CommercePolicyService;
 import com.mockhub.common.exception.ConflictException;
 import com.mockhub.common.exception.ResourceNotFoundException;
 import com.mockhub.eval.dto.EvalResult;
@@ -69,6 +71,9 @@ class AcpCheckoutServiceTest {
     @Mock
     private PaymentService paymentService;
 
+    @Mock
+    private CommercePolicyService commercePolicyService;
+
     @InjectMocks
     private AcpCheckoutService acpCheckoutService;
 
@@ -109,6 +114,14 @@ class AcpCheckoutServiceTest {
                 .thenAnswer(invocation -> Optional.of(createListing(invocation.getArgument(0))));
         lenient().when(cartService.getCartDto(testUser))
                 .thenReturn(new CartDto(1L, 1L, List.of(), new BigDecimal("55.00"), 1, null));
+        lenient().when(commercePolicyService.getDefaultPolicy()).thenReturn(createCommercePolicy());
+    }
+
+    private CommercePolicyDto createCommercePolicy() {
+        return new CommercePolicyDto(
+                "policy", "v1", "all_mockhub_ticket_purchases", null,
+                List.of(), "support@mockhub.dev", "/support",
+                "/api/v1/commerce/policies/default", Instant.now());
     }
 
     private AcpCheckoutRequest createCheckoutRequest(String buyerEmail, List<AcpLineItem> lineItems,
@@ -180,6 +193,7 @@ class AcpCheckoutServiceTest {
         assertEquals(1, response.lineItems().size());
         assertEquals("USD", response.pricing().currency());
         assertEquals(new BigDecimal("55.00"), response.pricing().total());
+        assertNotNull(response.commercePolicy());
 
         verify(cartService).clearCart(testUser);
         verify(cartService).addToCart(testUser, 10L);
@@ -294,6 +308,7 @@ class AcpCheckoutServiceTest {
         assertNotNull(response);
         assertEquals("CANCELLED", response.status());
         assertNull(response.completedAt());
+        assertNotNull(response.commercePolicy());
 
         verify(orderService).failOrder("MH-20260323-0001");
     }

--- a/backend/src/test/java/com/mockhub/commerce/controller/CommercePolicyControllerTest.java
+++ b/backend/src/test/java/com/mockhub/commerce/controller/CommercePolicyControllerTest.java
@@ -1,0 +1,80 @@
+package com.mockhub.commerce.controller;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.mockhub.auth.security.JwtAuthenticationFilter;
+import com.mockhub.auth.security.JwtTokenProvider;
+import com.mockhub.auth.security.UserDetailsServiceImpl;
+import com.mockhub.commerce.dto.CommercePolicyDto;
+import com.mockhub.commerce.dto.CommercePolicySectionDto;
+import com.mockhub.commerce.service.CommercePolicyService;
+import com.mockhub.config.SecurityConfig;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CommercePolicyController.class)
+@Import({SecurityConfig.class, JwtAuthenticationFilter.class})
+class CommercePolicyControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CommercePolicyService commercePolicyService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private UserDetailsServiceImpl userDetailsService;
+
+    @Test
+    @DisplayName("GET /api/v1/commerce/policies/default - returns public default policy")
+    void getDefaultPolicy_returnsPublicDefaultPolicy() throws Exception {
+        when(commercePolicyService.getDefaultPolicy()).thenReturn(createPolicy(null));
+
+        mockMvc.perform(get("/api/v1/commerce/policies/default"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.policyId").value("policy"))
+                .andExpect(jsonPath("$.appliesTo").value("all_mockhub_ticket_purchases"))
+                .andExpect(jsonPath("$.sections[0].code").value("refunds"));
+    }
+
+    @Test
+    @DisplayName("GET /api/v1/commerce/policies/events/{eventSlug} - returns event policy")
+    void getEventPolicy_returnsEventPolicy() throws Exception {
+        when(commercePolicyService.getPolicyForEvent("rock-festival")).thenReturn(createPolicy("rock-festival"));
+
+        mockMvc.perform(get("/api/v1/commerce/policies/events/rock-festival"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.eventSlug").value("rock-festival"))
+                .andExpect(jsonPath("$.policyUrl").value("/api/v1/commerce/policies/events/rock-festival"));
+    }
+
+    private CommercePolicyDto createPolicy(String eventSlug) {
+        return new CommercePolicyDto(
+                "policy",
+                "v1",
+                eventSlug == null ? "all_mockhub_ticket_purchases" : "event:" + eventSlug,
+                eventSlug,
+                List.of(new CommercePolicySectionDto(
+                        "refunds", "Refund policy", "summary", "details", "guidance")),
+                "support@mockhub.dev",
+                "/support",
+                eventSlug == null ? "/api/v1/commerce/policies/default"
+                        : "/api/v1/commerce/policies/events/" + eventSlug,
+                Instant.now());
+    }
+}

--- a/backend/src/test/java/com/mockhub/commerce/service/CommercePolicyServiceTest.java
+++ b/backend/src/test/java/com/mockhub/commerce/service/CommercePolicyServiceTest.java
@@ -37,6 +37,26 @@ class CommercePolicyServiceTest {
     }
 
     @Test
+    @DisplayName("getPolicyForEvent - given blank slug - returns default policy")
+    void getPolicyForEvent_givenBlankSlug_returnsDefaultPolicy() {
+        CommercePolicyDto policy = commercePolicyService.getPolicyForEvent("   ");
+
+        assertEquals("all_mockhub_ticket_purchases", policy.appliesTo());
+        assertNull(policy.eventSlug());
+        assertEquals("/api/v1/commerce/policies/default", policy.policyUrl());
+    }
+
+    @Test
+    @DisplayName("getPolicyForEvent - given null slug - returns default policy")
+    void getPolicyForEvent_givenNullSlug_returnsDefaultPolicy() {
+        CommercePolicyDto policy = commercePolicyService.getPolicyForEvent(null);
+
+        assertEquals("all_mockhub_ticket_purchases", policy.appliesTo());
+        assertNull(policy.eventSlug());
+        assertEquals("/api/v1/commerce/policies/default", policy.policyUrl());
+    }
+
+    @Test
     @DisplayName("getPolicyUrlForEvent - given blank slug - returns default policy URL")
     void getPolicyUrlForEvent_givenBlankSlug_returnsDefaultPolicyUrl() {
         assertEquals("/api/v1/commerce/policies/default",

--- a/backend/src/test/java/com/mockhub/commerce/service/CommercePolicyServiceTest.java
+++ b/backend/src/test/java/com/mockhub/commerce/service/CommercePolicyServiceTest.java
@@ -1,0 +1,45 @@
+package com.mockhub.commerce.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.mockhub.commerce.dto.CommercePolicyDto;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class CommercePolicyServiceTest {
+
+    private final CommercePolicyService commercePolicyService = new CommercePolicyService();
+
+    @Test
+    @DisplayName("getDefaultPolicy - returns structured policy sections for all purchases")
+    void getDefaultPolicy_returnsStructuredPolicySections() {
+        CommercePolicyDto policy = commercePolicyService.getDefaultPolicy();
+
+        assertEquals("mockhub-standard-commerce-policy", policy.policyId());
+        assertEquals("all_mockhub_ticket_purchases", policy.appliesTo());
+        assertNull(policy.eventSlug());
+        assertEquals("/api/v1/commerce/policies/default", policy.policyUrl());
+        assertFalse(policy.sections().isEmpty(), "Policy should include structured sections");
+        assertEquals("refunds", policy.sections().getFirst().code());
+    }
+
+    @Test
+    @DisplayName("getPolicyForEvent - given event slug - returns event-scoped policy URL")
+    void getPolicyForEvent_givenEventSlug_returnsEventScopedPolicyUrl() {
+        CommercePolicyDto policy = commercePolicyService.getPolicyForEvent(" rock-festival ");
+
+        assertEquals("event:rock-festival", policy.appliesTo());
+        assertEquals("rock-festival", policy.eventSlug());
+        assertEquals("/api/v1/commerce/policies/events/rock-festival", policy.policyUrl());
+    }
+
+    @Test
+    @DisplayName("getPolicyUrlForEvent - given blank slug - returns default policy URL")
+    void getPolicyUrlForEvent_givenBlankSlug_returnsDefaultPolicyUrl() {
+        assertEquals("/api/v1/commerce/policies/default",
+                commercePolicyService.getPolicyUrlForEvent("   "));
+    }
+}

--- a/backend/src/test/java/com/mockhub/mcp/tools/EventToolsTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/tools/EventToolsTest.java
@@ -12,6 +12,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mockhub.commerce.dto.CommercePolicyDto;
+import com.mockhub.commerce.service.CommercePolicyService;
 import com.mockhub.common.dto.PagedResponse;
 import com.mockhub.common.exception.ResourceNotFoundException;
 import com.mockhub.event.dto.EventDto;
@@ -39,6 +41,9 @@ class EventToolsTest {
     @Mock
     private ListingService listingService;
 
+    @Mock
+    private CommercePolicyService commercePolicyService;
+
     private ObjectMapper objectMapper;
     private EventTools eventTools;
 
@@ -46,7 +51,9 @@ class EventToolsTest {
     void setUp() {
         objectMapper = new ObjectMapper();
         objectMapper.findAndRegisterModules();
-        eventTools = new EventTools(eventService, listingService, objectMapper);
+        eventTools = new EventTools(eventService, listingService, commercePolicyService, objectMapper);
+        org.mockito.Mockito.lenient().when(commercePolicyService.getPolicyForEvent(any()))
+                .thenAnswer(invocation -> createPolicy(invocation.getArgument(0)));
     }
 
     // --- searchEvents ---
@@ -164,6 +171,8 @@ class EventToolsTest {
         assertTrue(result.contains("\"totalListings\":506"), "Result should contain total count");
         assertTrue(result.contains("\"page\":0"), "Result should contain page number");
         assertTrue(result.contains("\"size\":20"), "Result should contain page size");
+        assertTrue(result.contains("\"commercePolicy\""), "Result should include policy metadata");
+        assertTrue(result.contains("\"policyId\":\"policy\""), "Policy metadata should identify the policy");
     }
 
     @Test
@@ -231,6 +240,17 @@ class EventToolsTest {
 
         assertTrue(result.startsWith("["), "Result should be a JSON array");
         verify(eventService).listFeatured();
+    }
+
+    @Test
+    @DisplayName("getCommercePolicy - given event slug - returns structured policy JSON")
+    void getCommercePolicy_givenEventSlug_returnsStructuredPolicyJson() {
+        String result = eventTools.getCommercePolicy("rock-festival");
+
+        assertTrue(result.contains("\"policyId\":\"policy\""), "Result should include policy ID");
+        assertTrue(result.contains("\"eventSlug\":\"rock-festival\""), "Result should include event slug");
+        assertTrue(result.contains("\"policyUrl\":\"/api/v1/commerce/policies/events/rock-festival\""),
+                "Result should include event policy URL");
     }
 
     @Test
@@ -429,7 +449,8 @@ class EventToolsTest {
         return new ListingDto(
                 id, id, eventSlug, section, "Row 1", "Seat " + id,
                 "STANDARD", price, price, BigDecimal.ONE,
-                "ACTIVE", Instant.now(), null);
+                "ACTIVE", Instant.now(), null,
+                "/api/v1/commerce/policies/events/" + eventSlug);
     }
 
     private TicketSearchResultDto createSearchResult(Long listingId, String eventName,
@@ -438,6 +459,17 @@ class EventToolsTest {
                 listingId, listingId, eventName, eventSlug, "Artist",
                 "rock", "Venue", "NYC", Instant.now(),
                 "Section A", "Row 1", "Seat " + listingId,
-                "STANDARD", price, null);
+                "STANDARD", price, null,
+                "/api/v1/commerce/policies/events/" + eventSlug);
+    }
+
+    private CommercePolicyDto createPolicy(String eventSlug) {
+        String safeSlug = eventSlug == null || eventSlug.isBlank() ? null : eventSlug;
+        return new CommercePolicyDto(
+                "policy", "v1", safeSlug == null ? "all_mockhub_ticket_purchases" : "event:" + safeSlug,
+                safeSlug, List.of(), "support@mockhub.dev", "/support",
+                safeSlug == null ? "/api/v1/commerce/policies/default"
+                        : "/api/v1/commerce/policies/events/" + safeSlug,
+                Instant.now());
     }
 }

--- a/backend/src/test/java/com/mockhub/ticket/service/ListingServiceTest.java
+++ b/backend/src/test/java/com/mockhub/ticket/service/ListingServiceTest.java
@@ -15,6 +15,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.mockhub.auth.repository.UserRepository;
+import com.mockhub.commerce.service.CommercePolicyService;
 import com.mockhub.order.entity.OrderItem;
 import com.mockhub.common.exception.ConflictException;
 import com.mockhub.common.exception.ResourceNotFoundException;
@@ -43,6 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -63,6 +65,9 @@ class ListingServiceTest {
 
     @Mock
     private OrderItemRepository orderItemRepository;
+
+    @Mock
+    private CommercePolicyService commercePolicyService;
 
     @InjectMocks
     private ListingService listingService;
@@ -100,6 +105,9 @@ class ListingServiceTest {
         testListing.setPriceMultiplier(BigDecimal.ONE);
         testListing.setStatus("ACTIVE");
         testListing.setListedAt(Instant.now());
+
+        lenient().when(commercePolicyService.getPolicyUrlForEvent(any()))
+                .thenAnswer(invocation -> "/api/v1/commerce/policies/events/" + invocation.getArgument(0));
     }
 
     @Test
@@ -114,6 +122,7 @@ class ListingServiceTest {
         assertNotNull(result, "Result should not be null");
         assertEquals(1, result.size(), "Should return one listing");
         assertEquals("Floor", result.get(0).sectionName(), "Section name should match");
+        assertEquals("/api/v1/commerce/policies/events/test-event", result.get(0).commercePolicyUrl());
     }
 
     @Test
@@ -301,6 +310,7 @@ class ListingServiceTest {
         assertEquals("test-event", results.get(0).eventSlug());
         assertEquals("Floor", results.get(0).sectionName());
         assertEquals(new BigDecimal("75.00"), results.get(0).price());
+        assertEquals("/api/v1/commerce/policies/events/test-event", results.get(0).commercePolicyUrl());
     }
 
     @Test

--- a/docs/acp-openapi.yaml
+++ b/docs/acp-openapi.yaml
@@ -417,6 +417,8 @@ components:
             $ref: '#/components/schemas/LineItemResponse'
         pricing:
           $ref: '#/components/schemas/Pricing'
+        commercePolicy:
+          $ref: '#/components/schemas/CommercePolicy'
         createdAt:
           type: string
           format: date-time
@@ -496,6 +498,8 @@ components:
         url:
           type: string
           description: Relative URL to event page
+        commercePolicy:
+          $ref: '#/components/schemas/CommercePolicy'
 
     CatalogPage:
       type: object
@@ -550,6 +554,8 @@ components:
           format: decimal
         url:
           type: string
+        commercePolicy:
+          $ref: '#/components/schemas/CommercePolicy'
 
     ListingPage:
       type: object
@@ -567,3 +573,60 @@ components:
           format: int64
         totalPages:
           type: integer
+
+    CommercePolicy:
+      type: object
+      description: Structured commerce policy for agent purchase decisions
+      properties:
+        policyId:
+          type: string
+          example: mockhub-standard-commerce-policy
+        version:
+          type: string
+          example: "2026-05-01"
+        appliesTo:
+          type: string
+          description: Scope label for the policy
+          example: event:jazz-night
+        eventSlug:
+          type: string
+          nullable: true
+          description: Event slug when the policy is event-scoped
+          example: jazz-night
+        policyUrl:
+          type: string
+          description: REST URL where the full policy can be retrieved
+          example: /api/v1/commerce/policies/events/jazz-night
+        updatedAt:
+          type: string
+          format: date-time
+        sections:
+          type: array
+          items:
+            $ref: '#/components/schemas/CommercePolicySection'
+        supportContact:
+          type: string
+          format: email
+          example: support@mockhub.dev
+        supportUrl:
+          type: string
+          example: /support
+
+    CommercePolicySection:
+      type: object
+      properties:
+        code:
+          type: string
+          example: refunds
+        title:
+          type: string
+          example: Refunds
+        summary:
+          type: string
+          example: All MockHub ticket sales are final once an order is confirmed.
+        details:
+          type: string
+          example: Pending orders can be cancelled before confirmation.
+        agentGuidance:
+          type: string
+          example: Before checkout, tell the buyer that confirmed tickets are usually non-refundable.

--- a/docs/agentic-commerce.md
+++ b/docs/agentic-commerce.md
@@ -15,7 +15,7 @@ Agentic commerce in MockHub is organized into three layers, each independently v
 │  EvalCondition — what can this agent do?    │
 ├─────────────────────────────────────────────┤
 │  Layer 1: MCP Tools (Capabilities)          │
-│  searchEvents, findTickets, addToCart, ...   │
+│  searchEvents, findTickets, getCommercePolicy │
 └─────────────────────────────────────────────┘
 ```
 
@@ -27,15 +27,15 @@ Agentic commerce in MockHub is organized into three layers, each independently v
 
 ### Tool Inventory
 
-MockHub exposes 20 MCP tools across 5 tool classes:
+MockHub exposes 24 MCP tools across 5 tool classes:
 
 | Tool Class | Tools | Purpose |
 |---|---|---|
-| **EventTools** | `searchEvents`, `getEventDetail`, `getEventListings`, `getFeaturedEvents`, `getListingDetail`, `findTickets` | Discovery and search |
+| **EventTools** | `searchEvents`, `getEventDetail`, `getEventListings`, `getFeaturedEvents`, `getListingDetail`, `findTickets`, `getCommercePolicy` | Discovery, search, and purchase policy context |
 | **PricingTools** | `getPriceHistory`, `getPricePrediction` | Price intelligence |
-| **CartTools** | `getCart`, `addToCart`, `removeFromCart`, `clearCart` | Shopping cart management |
-| **OrderTools** | `checkout`, `confirmOrder`, `getOrder`, `listOrders` | Order lifecycle |
-| **MandateTools** | `createMandate`, `revokeMandate`, `listMandates`, `validateMandate` | Agent authorization |
+| **CartTools** | `getCart`, `addToCart`, `removeFromCart`, `clearCart`, `refreshCart` | Shopping cart management |
+| **OrderTools** | `checkout`, `confirmOrder`, `getOrder`, `listOrders`, `getCalendarEntry` | Order lifecycle |
+| **MandateTools** | `createMandate`, `revokeMandate`, `listMandates`, `validateMandate`, `getBestMandate` | Agent authorization |
 
 ### The Complete Purchase Flow
 
@@ -44,7 +44,7 @@ An agent can now execute a full purchase on behalf of a user:
 ```
 1. findTickets(query="concert", city="New York", dateFrom="2026-04-01T00:00:00Z",
                dateTo="2026-04-30T23:59:59Z", maxPrice=200)
-   → Returns matching listings with event/date metadata, sorted by price
+   → Returns matching listings with event/date metadata and commercePolicyUrl, sorted by price
 
 2. addToCart(userEmail="buyer@example.com", listingId=42,
              agentId="shopping-agent-1", mandateId="abc-123")
@@ -84,6 +84,18 @@ findTickets(
 ```
 
 This is an example of **agent-ergonomic API design** — reducing round-trips and letting agents express intent in a single call. Traditional REST APIs are designed for human-driven UIs with navigation; agent APIs should support goal-directed actions.
+
+### Agent-Readable Commerce Policies
+
+Agents need purchase policy context before they commit a user to checkout. MockHub exposes structured commerce policies through both REST and agent-facing responses:
+
+| Surface | Policy Access |
+|---|---|
+| REST | `GET /api/v1/commerce/policies/default`, `GET /api/v1/commerce/policies/events/{eventSlug}` |
+| MCP | `getCommercePolicy(eventSlug)` returns the full policy; `getEventListings` embeds it; `findTickets` and `getListingDetail` include `commercePolicyUrl` |
+| ACP | Catalog items, listing items, and checkout responses include `commercePolicy` |
+
+The policy document is intentionally structured rather than prose-only. It includes a stable `policyId`, `version`, event scope, `policyUrl`, `updatedAt`, policy sections (`refunds`, `cancellations`, `ticket_transfer`, `fees`, `support_and_disputes`), and support contact fields. This lets agents answer questions like "can this be refunded?" or "what fees apply?" without scraping UI text.
 
 ### Eval Conditions as Guardrails
 
@@ -203,9 +215,9 @@ MockHub exposes ACP-compatible endpoints at `/acp/v1/`:
 ```
 1. Agent discovers products and offers
    GET /acp/v1/catalog?query=jazz&city=NYC
-   → Returns AcpCatalogItem[] with event-level discovery data
+   → Returns AcpCatalogItem[] with event-level discovery data and commercePolicy
    GET /acp/v1/listings?query=yo-yo%20ma&city=New%20York&dateFrom=2026-04-01T00:00:00Z&dateTo=2026-04-30T23:59:59Z
-   → Returns AcpListingItem[] with actionable listings sorted by price
+   → Returns AcpListingItem[] with actionable listings sorted by price and commercePolicy
 
 2. Agent creates checkout
    POST /acp/v1/checkout
@@ -216,7 +228,7 @@ MockHub exposes ACP-compatible endpoints at `/acp/v1/`:
      "lineItems": [{"listingId": 42, "quantity": 1}],
      "paymentMethod": "mock"
    }
-   → Returns AcpCheckoutResponse with status CREATED
+   → Returns AcpCheckoutResponse with status CREATED and commercePolicy
 
 3. Agent completes checkout
    POST /acp/v1/checkout/MH-20260323-0001/complete
@@ -225,7 +237,7 @@ MockHub exposes ACP-compatible endpoints at `/acp/v1/`:
      "agentId": "shopping-agent-1",
      "mandateId": "abc-123"
    }
-   → Returns AcpCheckoutResponse with status COMPLETED
+   → Returns AcpCheckoutResponse with status COMPLETED and commercePolicy
 ```
 
 ### How ACP Maps to Existing Business Logic
@@ -244,9 +256,10 @@ ACP cancelCheckout   →  OrderService.failOrder()
 
 ACP getCatalog      →  EventService.listEvents()
 ACP getListings     →  EventService.listEvents() + ListingRepository.findByEventIdAndStatus()
+Policy context      →  CommercePolicyService
 ```
 
-No existing service was modified. The ACP controller and service wrap the same business logic that the MCP tools and REST API use.
+The ACP controller and service wrap the same business logic that the MCP tools and REST API use. The commerce policy service is deliberately read-only and static for now, so policy context can be added to agent responses without changing checkout behavior.
 
 ### Connection to the Protocol Landscape
 
@@ -406,7 +419,7 @@ CREATE TABLE mandates (
 ## File Reference
 
 ### Phase 1: MCP Tools
-- `backend/src/main/java/com/mockhub/mcp/tools/EventTools.java` — `findTickets`, `getListingDetail`
+- `backend/src/main/java/com/mockhub/mcp/tools/EventTools.java` — `findTickets`, `getListingDetail`, `getCommercePolicy`
 - `backend/src/main/java/com/mockhub/mcp/tools/OrderTools.java` — `confirmOrder`
 - `backend/src/main/java/com/mockhub/eval/condition/SpendingLimitCondition.java`
 
@@ -419,6 +432,9 @@ CREATE TABLE mandates (
 ### Phase 3: ACP
 - `backend/src/main/java/com/mockhub/acp/` — controller, service, dto, API key filter
 - `docs/agentic-commerce.md` — this document
+
+### Commerce Policies
+- `backend/src/main/java/com/mockhub/commerce/` — agent-readable commerce policy controller, service, and DTOs
 
 ### MCP OAuth2 Authentication
 - `backend/src/main/java/com/mockhub/mcp/config/McpOAuth2SecurityConfig.java` — authorization server + resource server chains


### PR DESCRIPTION
## Summary
- add structured commerce policy REST endpoints for default and event-scoped policies
- include policy context in ACP catalog/listing/checkout responses and MCP listing surfaces
- document policy discovery in llms.txt, agentic commerce docs, and ACP OpenAPI schema

## Validation
- ./gradlew test jacocoTestReport
- git diff --check

## Review
- Headless Claude review attempted twice but timed out without output
- Gemini CLI review attempted but local authentication is not configured

Closes #213