### PR TITLE
Refresh agentic commerce documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,6 +23,7 @@ mockhub/
 │       ├── ai/                 # Chat, recommendations, price predictions
 │       ├── eval/               # Evaluation conditions (Design by Contract for AI)
 │       ├── mandate/            # Agent mandates (authorization for agentic commerce)
+│       ├── agentapproval/      # Agent purchase approval records and audit trail
 │       ├── mcp/                # MCP server (tools, OAuth2 security, session recovery)
 │       ├── lifecycle/          # Scheduled cleanup (expired listings, past events, old notifications)
 │       ├── admin/              # Admin dashboard
@@ -63,7 +64,8 @@ The schema has six clusters. Flyway migrations are the source of truth (see `bac
 4. **Marketplace**: `tickets`, `listings`, `price_history`
 5. **Commerce**: `carts`, `cart_items`, `orders`, `order_items`, `transaction_logs`
 6. **Engagement**: `favorites`, `notifications`, `reviews`, `conversations`, `conversation_messages`, `user_preferences`
-7. **Agentic**: `mandates` (agent authorization with scope, spending limits, restrictions)
+7. **Agentic**: `mandates` (agent authorization with scope, spending limits, restrictions),
+   `agent_purchase_approvals` (human approval records for agent-initiated purchases)
 
 ### Identity
 
@@ -525,6 +527,18 @@ Two implementations controlled by Spring profiles:
 - **`AiController`** injects `Optional<ChatService>` etc. and returns 503 when no AI provider is active
 - **Personalized recommendations:** `RecommendationService` accepts a nullable `userId` and optional `city` — when provided, enriches the AI prompt with user favorites, purchase history, and Spotify listening data (top artists, genres, recently played) for personalized ranking. Spotify-matched events are included in the candidate pool even if not featured. Falls back to generic recommendations for anonymous users.
 - **Circular dependency** (MCP tools → PricingTools → PricePredictionService → ChatClient) broken with `@Lazy`
+
+### Agentic Commerce Integration
+
+MockHub exposes a three-layer agentic commerce stack:
+
+- **MCP tools** at `/mcp` for agent capabilities: event discovery, listing comparison, cart/order actions, pricing, mandates, and purchase approvals.
+- **Mandates** in `com.mockhub.mandate` for agent authorization, including scope, spending limits, allowed categories/events, expiration, revocation, and cumulative spend tracking.
+- **Purchase approval records** in `com.mockhub.agentapproval` for durable human-approval audit trails. Agents propose a purchase, users approve or deny it, and an optional `approvalId` can be supplied to MCP `confirmOrder` or ACP `completeCheckout`.
+- **ACP endpoints** at `/acp/v1/**` as a protocol adapter over the same cart, order, payment, mandate, and approval services.
+- **Commerce policies** in `com.mockhub.commerce` provide structured refund, cancellation, fee, transfer, and support metadata to MCP, ACP, REST, and `llms.txt` consumers.
+
+See [docs/agentic-commerce.md](docs/agentic-commerce.md) for the full protocol and teaching narrative.
 
 ### SMS Delivery
 

--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -1040,7 +1040,7 @@ The local `mockhub-pr-readiness` Codex skill was updated with these lessons.
 
 ### Status at End of Session
 
-- PR #225 is open as a draft.
+- PR #225 merged after the review-fix commit.
 - Commits:
   - `b7d6220` — Add agent-readable commerce policies
   - `ecf3494` — Address commerce policy review findings
@@ -1049,6 +1049,48 @@ The local `mockhub-pr-readiness` Codex skill was updated with these lessons.
 
 ---
 
-*Last updated: 2026-05-05*
-*Built with: Claude Opus 4.6 (1M context) via Claude Code; Codex GPT-5 for 2026-05-05 workflow trial*
+## Session 2026-05-06: Agentic Commerce Follow-Through
+
+### Issues #216 and #215
+
+Continued the issue-first MockHub PR-readiness workflow on the remaining agentic commerce backlog:
+
+- **#216 / PR #226** — Added deterministic agent-friendly ticket comparison:
+  - New `compareTickets` MCP tool for ranking candidate listings
+  - Cheapest, best-value, best-section, and lowest-risk recommendations
+  - Reason codes, rationale, and price warnings for explainable agent shopping decisions
+  - Documentation updates in `llms.txt`, `docs/agentic-commerce.md`, `README.md`, and `AGENTS.md`
+- **#215 / PR #227** — Added durable agent purchase approval records:
+  - New `com.mockhub.agentapproval` feature package with entity, DTOs, repository, service, controller, and Flyway migration `V31__create_agent_purchase_approvals.sql`
+  - New MCP `AgentApprovalTools`: `proposePurchase`, `approvePurchase`, `denyPurchase`, `listPurchaseApprovals`
+  - Optional `approvalId` support in MCP `confirmOrder` and ACP `completeCheckout`
+  - Approval completion/failure recording around payment confirmation
+  - Documentation updates in `llms.txt`, `docs/agentic-commerce.md`, `README.md`, and `AGENTS.md`
+
+### Review Workflow Update
+
+Gemini CLI became unreliable for the review step during this session. It emitted extension warnings and plan-mode/tool-policy noise, then stalled without producing a useful review. The local fallback added to the `mockhub-pr-readiness` skill worked well:
+
+```bash
+ollama run --keepalive 10m --think=false --hidethinking --nowordwrap gemma4:latest "Say ready."
+git diff origin/main...HEAD | ollama run --keepalive 10m --think=false --hidethinking --nowordwrap gemma4:latest "Review this MockHub diff for issue #<issue>. Focus on correctness, regressions, missing tests, security/auth exposure, and REST/MCP/ACP contract mismatches. Return only actionable findings with file paths and line numbers; say No findings if none."
+```
+
+Observed local reviewer behavior:
+
+- Warmed `gemma4:latest` was fast enough for routine smoke review and returned useful/no-finding output without external auth friction.
+- Larger local models can still be used for deeper passes, but the latency tradeoff did not look worthwhile for normal MockHub diffs.
+- Gemini remains worth keeping as the first external reviewer when it completes, but local Ollama is now the practical fallback.
+
+### Status at End of Session
+
+- PR #226 merged.
+- PR #227 merged at `d247aab`.
+- All remote gates passed before merge: Backend, Frontend, E2E Smoke, Docker smoke, GitGuardian, SonarCloud Analysis, and SonarCloud Code Analysis.
+- Follow-up docs pass opened to refresh the journal, ACP OpenAPI contract, and architecture notes after the recent agentic commerce issues.
+
+---
+
+*Last updated: 2026-05-06*
+*Built with: Claude Opus 4.6 (1M context) via Claude Code; Codex GPT-5 for 2026-05-05 and 2026-05-06 workflow trials*
 *Live at: https://mockhub.kousenit.com*

--- a/docs/acp-openapi.yaml
+++ b/docs/acp-openapi.yaml
@@ -175,12 +175,6 @@ paths:
       parameters:
         - $ref: '#/components/parameters/checkoutId'
         - $ref: '#/components/parameters/buyerEmail'
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/CompleteRequest'
       responses:
         '200':
           description: Checkout details
@@ -240,7 +234,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ActionRequest'
+              $ref: '#/components/schemas/CompleteRequest'
       responses:
         '200':
           description: Checkout completed
@@ -394,6 +388,9 @@ components:
         paymentIntentId:
           type: string
           description: Required for non-mock payment methods
+        approvalId:
+          type: string
+          description: Optional purchase approval record ID linking this checkout completion to a prior human approval
 
     CheckoutResponse:
       type: object


### PR DESCRIPTION
## Summary
- update PROJECT_JOURNAL.md with the merged #216/#227 agentic commerce follow-through
- document purchase approval records in ARCHITECTURE.md
- fix ACP OpenAPI checkout docs: remove GET request body, use CompleteRequest for completeCheckout, and document optional approvalId

## Validation
- ruby -e "require 'yaml'; YAML.load_file('docs/acp-openapi.yaml'); puts 'acp-openapi.yaml OK'"
- git diff --check