### PR TITLE
Refresh conditional mandate documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -533,7 +533,8 @@ Two implementations controlled by Spring profiles:
 MockHub exposes a three-layer agentic commerce stack:
 
 - **MCP tools** at `/mcp` for agent capabilities: event discovery, listing comparison, cart/order actions, pricing, mandates, and purchase approvals.
-- **Mandates** in `com.mockhub.mandate` for agent authorization, including scope, spending limits, allowed categories/events, expiration, revocation, and cumulative spend tracking.
+- **Mandates** in `com.mockhub.mandate` for agent authorization, including scope, spending limits,
+  allowed categories/events/sections, approval mode, expiration, revocation, and cumulative spend tracking.
 - **Purchase approval records** in `com.mockhub.agentapproval` for durable human-approval audit trails. Agents propose a purchase, users approve or deny it, and an optional `approvalId` can be supplied to MCP `confirmOrder` or ACP `completeCheckout`.
 - **ACP endpoints** at `/acp/v1/**` as a protocol adapter over the same cart, order, payment, mandate, and approval services.
 - **Commerce policies** in `com.mockhub.commerce` provide structured refund, cancellation, fee, transfer, and support metadata to MCP, ACP, REST, and `llms.txt` consumers.

--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -1089,6 +1089,39 @@ Observed local reviewer behavior:
 - All remote gates passed before merge: Backend, Frontend, E2E Smoke, Docker smoke, GitGuardian, SonarCloud Analysis, and SonarCloud Code Analysis.
 - Follow-up docs pass opened to refresh the journal, ACP OpenAPI contract, and architecture notes after the recent agentic commerce issues.
 
+### Issues #228 and #214
+
+Closed the recent agentic commerce burst with two follow-up PRs:
+
+- **Docs refresh / PR #228** — Refreshed the agentic commerce teaching docs after the commerce policy,
+  comparison, and approval-record work.
+- **#214 / PR #229** — Added conditional agent mandates:
+  - New `allowedSections` mandate restriction, persisted by Flyway migration
+    `V32__add_conditional_mandate_fields.sql`.
+  - New `approvalMode` field with `AUTO_PURCHASE` default and `APPROVAL_REQUIRED` support.
+  - MCP mandate tools now accept and return section restrictions and approval mode.
+  - MCP `confirmOrder` and ACP `completeCheckout` require an approved `approvalId` when the mandate
+    is approval-required.
+  - Section-restricted mandates require listing/cart-item section context; missing section context does
+    not authorize checkout.
+  - Frontend mandate management now supports allowed sections and approval mode.
+
+Gemini review eventually completed after CLI plan-mode/tool-policy friction and found a valid
+section-restriction bypass. Fixed it before merge by enforcing section context during MCP and ACP
+checkout validation.
+
+SonarCloud caught a coverage regression after the review fix (`78.7%` new coverage). Added focused ACP
+cart mandate validation tests, reran `./gradlew test jacocoTestReport`, and rechecked SonarCloud before
+merge. Final PR #229 quality gate passed with `86.6%` new-code coverage.
+
+Status after merge:
+
+- PR #228 merged at `ceac323`.
+- PR #229 merged at `d9081d1`.
+- No open MockHub PRs remained after the burst.
+- Remote gates for PR #229 passed before merge: Backend, Frontend, E2E Smoke, Docker smoke, GitGuardian,
+  SonarCloud Analysis, and SonarCloud Code Analysis.
+
 ---
 
 *Last updated: 2026-05-06*

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Any authenticated user can both buy and sell tickets.
 - **AI recommendations** — personalized event suggestions with relevance scores
 - **AI price predictions** — trend analysis on event detail pages
 - **MCP server** — 29 tools for AI agent integration (events, cart, orders, pricing, mandates, approvals) with OAuth 2.1 authentication and Dynamic Client Registration (DCR) — works natively with Claude (desktop, web, mobile), Cursor, and any MCP-compatible client
-- **Agent mandates** — authorization model for AI agents with spending limits and scope restrictions
+- **Agent mandates** — authorization model for AI agents with spending limits, scope/category/event/section restrictions, and optional approval-required completion
 - **ACP endpoints** — Agentic Commerce Protocol checkout API for agent interoperability
 - **Agent discovery** — `llms.txt` at `/llms.txt` describes all API endpoints, MCP tools, and ACP endpoints
 

--- a/docs/agentic-commerce.md
+++ b/docs/agentic-commerce.md
@@ -72,7 +72,9 @@ Mandates answer whether an agent is authorized to act. Approval records answer w
 
 Agents can create a proposal with `proposePurchase`, including a snapshot of the proposed listings or order, the agent rationale, price and fee totals, and the relevant commerce policy snapshot. The user can then approve or deny that proposal. An approved `approvalId` may be supplied to `confirmOrder` or ACP `completeCheckout` to link the final purchase to the recorded approval.
 
-Approval IDs are optional for backward compatibility. Existing mandate-authorized purchases still work, while future conditional mandate work can decide when a human approval record is required.
+Approval IDs are optional for `AUTO_PURCHASE` mandates. Mandates with `approvalMode=APPROVAL_REQUIRED`
+require an approved purchase approval before MCP `confirmOrder` or ACP `completeCheckout` can finish
+the purchase.
 
 ### Key Design: `findTickets` — The Compound Search Tool
 
@@ -190,7 +192,8 @@ A **mandate** is a record of what an agent is authorized to do on behalf of a sp
 3. Check the scope matches the action (BROWSE for reads, PURCHASE for buys)
 4. Check per-transaction spending limit
 5. Check cumulative spending limit (tracks `totalSpent`)
-6. Check category, event, and section restrictions
+6. Check category, event, and section restrictions. A section-restricted mandate only authorizes a
+   purchase when the listing or cart item supplies a matching section name.
 7. For mandates with `approvalMode=APPROVAL_REQUIRED`, require an approved purchase approval before order completion
 
 If any check fails, the condition returns a CRITICAL failure — the action is blocked.
@@ -431,7 +434,7 @@ The OAuth2 discovery flow is automatic: client requests `/.well-known/oauth-prot
 
 ## Database Schema
 
-### Mandates Table (V22)
+### Mandates Table (V22 + V32 conditional fields)
 
 ```sql
 CREATE TABLE mandates (


### PR DESCRIPTION
## Summary
- Update agentic commerce docs for implemented approvalMode behavior and section-restricted mandate enforcement
- Refresh architecture and README summaries for allowedSections and approval-required completion
- Add project journal notes for PR #229, Gemini review finding, and Sonar coverage follow-up

## Testing
- Not run; documentation-only changes
