### PR TITLE
Suppress MCP discovery probe noise (#231)

### DIFF
--- a/backend/src/main/java/com/mockhub/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/mockhub/common/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -58,6 +59,16 @@ public class GlobalExceptionHandler {
         problem.setProperty("fieldErrors", fieldErrors);
 
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problem);
+    }
+
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<ProblemDetail> handleNoResourceFound(NoResourceFoundException ex) {
+        log.debug("No static resource for request: {}", ex.getResourcePath());
+
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(
+                HttpStatus.NOT_FOUND, "Resource not found");
+        problem.setTitle("Not Found");
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(problem);
     }
 
     @ExceptionHandler(Exception.class)

--- a/backend/src/main/java/com/mockhub/mcp/controller/McpWellKnownController.java
+++ b/backend/src/main/java/com/mockhub/mcp/controller/McpWellKnownController.java
@@ -1,0 +1,37 @@
+package com.mockhub.mcp.controller;
+
+import java.net.URI;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+/**
+ * Serves MCP-suffixed OAuth2 discovery paths.
+ *
+ * <p>Per RFC 8414 §3.1, an MCP client of a resource hosted at {@code /mcp} constructs
+ * the authorization server metadata URL by inserting
+ * {@code /.well-known/oauth-authorization-server} between the host and the resource
+ * path, yielding {@code /.well-known/oauth-authorization-server/mcp}. Spring
+ * Authorization Server registers only the unsuffixed form, so MCP clients (Claude,
+ * mcp-remote, Cursor) hit a 404 on their first discovery probe without this controller.
+ *
+ * <p>The suffixed and unsuffixed forms serve identical metadata in a single-AS
+ * deployment, so this controller responds with a 301 redirect. The redirect is
+ * permanent — the suffix has no distinct metadata document of its own.
+ */
+@Controller
+@Profile("mcp-oauth2")
+public class McpWellKnownController {
+
+    private static final String AS_METADATA = "/.well-known/oauth-authorization-server";
+
+    @GetMapping(AS_METADATA + "/mcp")
+    public ResponseEntity<Void> redirectAuthorizationServerMetadata() {
+        return ResponseEntity.status(HttpStatus.MOVED_PERMANENTLY)
+                .location(URI.create(AS_METADATA))
+                .build();
+    }
+}

--- a/backend/src/main/resources/static/llms.txt
+++ b/backend/src/main/resources/static/llms.txt
@@ -104,8 +104,11 @@ Eval results are logged for observability. Critical eval failures may block agen
 
 ## MCP Tools (OAuth 2.1 authentication)
 MockHub exposes MCP tools for AI agents at /mcp (Streamable HTTP transport).
-Authentication: OAuth 2.1 with Dynamic Client Registration (DCR). Clients discover the authorization
-server via /.well-known/oauth-protected-resource/mcp and register automatically.
+Authentication: OAuth 2.1 with Dynamic Client Registration (DCR). Discovery endpoints:
+- /.well-known/oauth-protected-resource/mcp — MCP resource metadata (points to the authorization server)
+- /.well-known/oauth-authorization-server — authorization server metadata (issuer, token, authorize, jwks, registration)
+- /.well-known/oauth-authorization-server/mcp — RFC 8414 path-suffixed alias of the above (301 redirect)
+DCR endpoint: POST /connect/register. Clients register automatically.
 Compatible clients: Claude (desktop/web/mobile), Cursor, MCP Inspector, any OAuth 2.1 MCP client.
 Sessions are in-memory — after server redeploys, clients must re-initialize.
 - searchEvents(query?, category?, city?, page?, size?) — search and filter events with pagination

--- a/backend/src/test/java/com/mockhub/common/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/mockhub/common/exception/GlobalExceptionHandlerTest.java
@@ -7,7 +7,9 @@ import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -110,6 +112,24 @@ class GlobalExceptionHandlerTest {
         assertEquals("Event not found with slug: 'rock-fest'", body.getDetail());
         assertEquals("Not Found", body.getTitle());
         assertEquals(404, body.getStatus());
+    }
+
+    @Test
+    @DisplayName("handleNoResourceFound - returns 404 ProblemDetail without ERROR-level logging")
+    void handleNoResourceFound_returns404ProblemDetail() {
+        NoResourceFoundException ex = new NoResourceFoundException(
+                HttpMethod.GET,
+                "/.well-known/openid-configuration/mcp",
+                ".well-known/openid-configuration/mcp");
+
+        ResponseEntity<ProblemDetail> response = handler.handleNoResourceFound(ex);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        ProblemDetail body = response.getBody();
+        assertNotNull(body);
+        assertEquals(404, body.getStatus());
+        assertEquals("Not Found", body.getTitle());
+        assertEquals("Resource not found", body.getDetail());
     }
 
     @Test

--- a/backend/src/test/java/com/mockhub/mcp/controller/McpWellKnownControllerTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/controller/McpWellKnownControllerTest.java
@@ -1,0 +1,21 @@
+package com.mockhub.mcp.controller;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class McpWellKnownControllerTest {
+
+    private final McpWellKnownController controller = new McpWellKnownController();
+
+    @Test
+    void redirectAuthorizationServerMetadata_returns301_toCanonicalPath() {
+        ResponseEntity<Void> response = controller.redirectAuthorizationServerMetadata();
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.MOVED_PERMANENTLY);
+        assertThat(response.getHeaders().getLocation())
+                .hasToString("/.well-known/oauth-authorization-server");
+    }
+}


### PR DESCRIPTION
Fixes #231.

## Summary

- New `McpWellKnownController` (under `mcp-oauth2` profile) serves the RFC 8414 path-suffixed AS metadata URL `/.well-known/oauth-authorization-server/mcp` as a `301 MOVED_PERMANENTLY` to the canonical `/.well-known/oauth-authorization-server`. Single-AS deployments serve identical metadata for both forms, so the redirect is semantically correct.
- New `@ExceptionHandler(NoResourceFoundException.class)` in `GlobalExceptionHandler` returns a clean `404 ProblemDetail` and logs at `DEBUG`, suppressing the ERROR-level catch-all noise from suffixed OIDC probes and any other 404 fishing requests.
- `llms.txt` now documents the AS metadata discovery URLs (canonical + suffixed) so agents reading it have the full discovery picture.

## Why

Production logs (verified via Railway) show recurring ERROR entries from MCP clients probing `/.well-known/oauth-authorization-server/mcp` and `/.well-known/openid-configuration/mcp` on first connect. These are not real failures — they are RFC 8414 §3.1 path-suffixed discovery probes — but the catch-all exception handler surfaced them as 500/ERROR. After this change, the AS suffixed probe gets the metadata via redirect, and the OIDC suffixed probe gets a clean 404 with no ERROR noise.

## Out of scope

Enabling OIDC discovery on the AS configurer. Currently `McpAuthorizationServerConfigurer` (spring-ai-community) does not register the OIDC endpoints. OIDC implies UserInfo / ID tokens which MockHub does not currently expose; pursuing that is a separate decision.

## Test plan

- [x] `McpWellKnownControllerTest` — verifies 301 + Location header
- [x] `GlobalExceptionHandlerTest.handleNoResourceFound_returns404ProblemDetail` — verifies clean 404 ProblemDetail
- [x] Full backend test suite passes locally (`./gradlew test`)
- [ ] After merge + Railway deploy: hit `/.well-known/oauth-authorization-server/mcp` and confirm 301 → 200 with metadata; hit `/.well-known/openid-configuration/mcp` and confirm 404 with no ERROR log entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)