### PR TITLE
Register AgentApprovalTools with MCP server (#233)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ The codebase uses Java DOP patterns where they add value:
 - **Three-layer architecture:** (1) MCP tools for agent capabilities, (2) Mandates for agent authorization, (3) ACP endpoints for protocol interoperability. See `docs/agentic-commerce.md` for full documentation.
 - **`llms.txt`** — served at `/llms.txt` (static resource), describes all API endpoints, MCP tools, and ACP endpoints for AI agents.
 - **RFC 9457 Problem Details** — all error responses use Spring's `ProblemDetail` format for machine-readable errors.
-- **MCP server** — 23 tools registered (EventTools, PricingTools, CartTools, OrderTools, MandateTools) via `spring-ai-starter-mcp-server-webmvc`. Uses Streamable HTTP transport (protocol: `STREAMABLE`) at `/mcp`.
+- **MCP server** — 29 tools registered (EventTools, PricingTools, CartTools, OrderTools, MandateTools, AgentApprovalTools) via `spring-ai-starter-mcp-server-webmvc`. Uses Streamable HTTP transport (protocol: `STREAMABLE`) at `/mcp`.
 - **MCP auth (two modes, profile-based):**
   - `mcp-oauth2` profile: OAuth 2.1 with Dynamic Client Registration (DCR). Enables native Claude connector support on all platforms (desktop, web, mobile) without `mcp-remote`. Uses `org.springaicommunity:mcp-authorization-server:0.1.5` and `org.springaicommunity:mcp-server-security:0.1.5`.
   - Without `mcp-oauth2` profile: Falls back to `X-API-Key` header auth via `McpApiKeyFilter`. Requires `mcp-remote` bridge for Claude Desktop.

--- a/backend/src/main/java/com/mockhub/config/McpConfig.java
+++ b/backend/src/main/java/com/mockhub/config/McpConfig.java
@@ -6,6 +6,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import com.mockhub.mcp.tools.AgentApprovalTools;
 import com.mockhub.mcp.tools.CartTools;
 import com.mockhub.mcp.tools.EventTools;
 import com.mockhub.mcp.tools.MandateTools;
@@ -21,9 +22,11 @@ public class McpConfig {
                                                        PricingTools pricingTools,
                                                        CartTools cartTools,
                                                        OrderTools orderTools,
-                                                       MandateTools mandateTools) {
+                                                       MandateTools mandateTools,
+                                                       AgentApprovalTools agentApprovalTools) {
         return MethodToolCallbackProvider.builder()
-                .toolObjects(eventTools, pricingTools, cartTools, orderTools, mandateTools)
+                .toolObjects(eventTools, pricingTools, cartTools, orderTools, mandateTools,
+                        agentApprovalTools)
                 .build();
     }
 }

--- a/backend/src/test/java/com/mockhub/config/McpConfigTest.java
+++ b/backend/src/test/java/com/mockhub/config/McpConfigTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.ai.tool.ToolCallbackProvider;
 
+import com.mockhub.mcp.tools.AgentApprovalTools;
 import com.mockhub.mcp.tools.CartTools;
 import com.mockhub.mcp.tools.EventTools;
 import com.mockhub.mcp.tools.MandateTools;
@@ -33,13 +34,16 @@ class McpConfigTest {
     @Mock
     private MandateTools mandateTools;
 
+    @Mock
+    private AgentApprovalTools agentApprovalTools;
+
     @Test
     @DisplayName("mcpToolCallbackProvider - creates provider with all tool objects")
     void mcpToolCallbackProvider_createsProviderWithAllToolObjects() {
         McpConfig config = new McpConfig();
 
         ToolCallbackProvider provider = config.mcpToolCallbackProvider(
-                eventTools, pricingTools, cartTools, orderTools, mandateTools);
+                eventTools, pricingTools, cartTools, orderTools, mandateTools, agentApprovalTools);
 
         assertNotNull(provider, "ToolCallbackProvider should not be null");
     }


### PR DESCRIPTION
Fixes #233.

## Summary

`AgentApprovalTools` defines four `@Tool`-annotated methods that `llms.txt` advertises as MCP tools (`proposePurchase`, `approvePurchase`, `denyPurchase`, `listPurchaseApprovals`), but the bean was never wired into `McpConfig.mcpToolCallbackProvider`. Spring AI's `MethodToolCallbackProvider` only registers methods on objects passed to `.toolObjects(...)`, so the four approval tools were silently absent from the runtime — an agent reading `llms.txt` could discover them but every call would fail with "tool not found".

## Changes

- Add `AgentApprovalTools` to the constructor parameters and `.toolObjects(...)` list in `McpConfig`.
- Add a matching `@Mock` to `McpConfigTest` so the wiring test still compiles.
- Bump `CLAUDE.md`'s MCP tool count from 23 to 29 and add `AgentApprovalTools` to the listed tool classes. README, AGENTS.md, `docs/agentic-commerce.md`, and `llms.txt` already say 29; this aligns CLAUDE.md.

## Verification before this PR

- 29 `@Tool` annotated methods across 6 tool classes
- `MethodToolCallbackProvider` was registering only the 5 classes passed to `.toolObjects(...)` → 25 runtime tools (matches the live count of 25 reported by an MCP client)
- After this change all 6 classes are passed → 29 runtime tools

## Test plan

- [x] `McpConfigTest.mcpToolCallbackProvider_createsProviderWithAllToolObjects` passes with the new arity
- [x] Full backend test suite passes locally
- [ ] After merge + Railway deploy: confirm an MCP client lists all 29 tools and that `proposePurchase`, `approvePurchase`, `denyPurchase`, `listPurchaseApprovals` are callable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)