### PR TITLE
Document UCP discovery profile decision

### DIFF
--- a/docs/agentic-commerce-strategy.md
+++ b/docs/agentic-commerce-strategy.md
@@ -69,7 +69,7 @@ Eight issues now in the backlog, grouped by what they accomplish.
 
 ### Keeping it honest
 
-- **#237** — UCP discovery profile spike. Investigates whether a `/.well-known/ucp` manifest is worth publishing. The honest disposition is that the spike may end with "do not implement yet" if a truthful profile would overstate what MockHub supports. A misleading manifest is worse than none, especially for a teaching repo.
+- **#237** — UCP discovery profile spike. Investigated whether a `/.well-known/ucp` manifest is worth publishing and concluded "not yet": a profile should wait until MockHub has UCP-shaped service bindings, scoped payment credentials, risk signals, and profile-content tests. A misleading manifest is worse than none, especially for a teaching repo.
 - **#240** — Spec version pins. Records which ACP / UCP / AP2 revisions MockHub targets, with last-verified dates. Protocols are churning weekly; without this pin, course materials silently age out of date.
 
 ## 5. The August Course Arc

--- a/docs/agentic-commerce-strategy.md
+++ b/docs/agentic-commerce-strategy.md
@@ -50,7 +50,7 @@ What MockHub does *not* yet implement:
 
 ## 4. What We Decided To Build
 
-Eight issues now in the backlog, grouped by what they accomplish.
+Eight issues now tracked in the backlog or decision log, grouped by what they accomplish.
 
 ### Building the parts
 
@@ -69,7 +69,7 @@ Eight issues now in the backlog, grouped by what they accomplish.
 
 ### Keeping it honest
 
-- **#237** — UCP discovery profile spike. Investigated whether a `/.well-known/ucp` manifest is worth publishing and concluded "not yet": a profile should wait until MockHub has UCP-shaped service bindings, scoped payment credentials, risk signals, and profile-content tests. A misleading manifest is worse than none, especially for a teaching repo.
+- **#237** — UCP discovery profile spike (decision captured: not yet). Investigated whether a `/.well-known/ucp` manifest is worth publishing and concluded that a profile should wait until MockHub has UCP-shaped service bindings, scoped payment credentials, risk signals, pinned protocol revisions, and profile-content tests. A misleading manifest is worse than none, especially for a teaching repo.
 - **#240** — Spec version pins. Records which ACP / UCP / AP2 revisions MockHub targets, with last-verified dates. Protocols are churning weekly; without this pin, course materials silently age out of date.
 
 ## 5. The August Course Arc

--- a/docs/agentic-commerce.md
+++ b/docs/agentic-commerce.md
@@ -326,7 +326,7 @@ Coverage labels in this table describe MockHub surfaces that exist today. They d
 
 | UCP Concept | MockHub Surface | MockHub Coverage | Notes |
 |---|---|---|---|
-| Business profile and capability discovery | `llms.txt`, MCP OAuth metadata, A2A agent card, future `/.well-known/ucp` | Partial | MockHub exposes agent-readable metadata, but not a UCP business profile or capability negotiation document. Issue #237 evaluates whether a minimal truthful profile should exist. |
+| Business profile and capability discovery | `llms.txt`, MCP OAuth metadata, A2A agent card | Partial | MockHub exposes agent-readable metadata, but not a UCP business profile or capability negotiation document. Issue #237 concluded that publishing `/.well-known/ucp` now would overstate UCP support. |
 | Catalog and offer discovery | MCP `searchEvents`, `findTickets`, `compareTickets`; ACP `GET /catalog` and `GET /listings`; REST event/listing APIs | Implemented | Agents can discover products and actionable ticket offers through both MCP and ACP-shaped endpoints. |
 | Cart lifecycle | MCP cart tools, REST cart API, ACP checkout creation/update flow | Implemented | ACP treats checkout creation as the agent-facing cart/checkout boundary; MCP exposes explicit cart operations. |
 | Checkout lifecycle | ACP `/acp/v1/checkout/**`, MCP `checkout` and `confirmOrder`, `OrderService`, `PaymentService` | Partial | MockHub supports create, update, cancel, and complete flows, but does not implement UCP version negotiation or UCP response envelopes. |
@@ -339,6 +339,23 @@ Coverage labels in this table describe MockHub surfaces that exist today. They d
 | Preference and personalization memory | Favorites, purchase history, Spotify listening data, future user preference package | Planned | Recommendations already use several signals; #219 should turn explicit buyer preferences into a first-class agent-shopping model. |
 | Extensions and version negotiation | None | Not implemented | UCP's capability model relies on dated protocol versions and negotiated capability versions. MockHub should not advertise support until it can produce a truthful profile and validate versioned requests. |
 | Machine-to-machine API payments | None | Intentionally out of scope | x402 and similar rails monetize API access. MockHub's agents buy tickets; API access itself is free. |
+
+### UCP Discovery Profile Decision
+
+Issue #237 evaluated whether MockHub should publish a minimal `/.well-known/ucp` business profile now. The recommendation is: **do not publish a UCP profile yet**.
+
+The reason is not that MockHub lacks agentic-commerce capabilities. It has plenty of them. The problem is that a UCP profile is not just a marketing manifest; it is the protocol discovery document for versioned UCP services, capabilities, payment handlers, and negotiation behavior. Publishing a placeholder profile would invite platforms to treat MockHub as UCP-capable when the advertised endpoints still speak MockHub's existing ACP, MCP, and REST contracts.
+
+MockHub should wait until it can do at least the following:
+
+1. Choose a pinned UCP protocol version and keep the relevant service/capability schema references current.
+2. Expose UCP-shaped service bindings or clearly documented adapters, rather than pointing UCP clients at ACP endpoints with different request and response envelopes.
+3. Model payment credentials separately from mandates (#218), because UCP payment handlers and AP2-style autonomous payment flows depend on that boundary.
+4. Add basic agent risk signals (#217), because UCP's signal model expects transaction-environment data for authorization, rate limiting, and abuse prevention.
+5. Decide whether identity-linking and buyer-preference state (#219) belong in the first profile or remain outside the UCP surface.
+6. Add tests that assert the profile content matches the code's live endpoints and supported capabilities.
+
+Until then, `llms.txt`, MCP OAuth metadata, ACP endpoints, and the A2A agent card remain the honest discovery surfaces. The future UCP profile should be introduced in a dedicated implementation issue after #217, #218, and #219 have clarified risk, payment authority, and buyer context.
 
 ### Why UCP Matters for the Training Course
 

--- a/docs/agentic-commerce.md
+++ b/docs/agentic-commerce.md
@@ -326,7 +326,7 @@ Coverage labels in this table describe MockHub surfaces that exist today. They d
 
 | UCP Concept | MockHub Surface | MockHub Coverage | Notes |
 |---|---|---|---|
-| Business profile and capability discovery | `llms.txt`, MCP OAuth metadata, A2A agent card | Partial | MockHub exposes agent-readable metadata, but not a UCP business profile or capability negotiation document. Issue #237 concluded that publishing `/.well-known/ucp` now would overstate UCP support. |
+| Business profile and capability discovery | `llms.txt`, MCP OAuth metadata, A2A agent card | Not implemented | MockHub exposes agent-readable metadata, but not a UCP business profile or capability negotiation document. Issue #237 concluded that publishing `/.well-known/ucp` now would overstate UCP support. |
 | Catalog and offer discovery | MCP `searchEvents`, `findTickets`, `compareTickets`; ACP `GET /catalog` and `GET /listings`; REST event/listing APIs | Implemented | Agents can discover products and actionable ticket offers through both MCP and ACP-shaped endpoints. |
 | Cart lifecycle | MCP cart tools, REST cart API, ACP checkout creation/update flow | Implemented | ACP treats checkout creation as the agent-facing cart/checkout boundary; MCP exposes explicit cart operations. |
 | Checkout lifecycle | ACP `/acp/v1/checkout/**`, MCP `checkout` and `confirmOrder`, `OrderService`, `PaymentService` | Partial | MockHub supports create, update, cancel, and complete flows, but does not implement UCP version negotiation or UCP response envelopes. |
@@ -342,9 +342,9 @@ Coverage labels in this table describe MockHub surfaces that exist today. They d
 
 ### UCP Discovery Profile Decision
 
-Issue #237 evaluated whether MockHub should publish a minimal `/.well-known/ucp` business profile now. The recommendation is: **do not publish a UCP profile yet**.
+[Issue #237](https://github.com/kousen/mockhub/issues/237) asked whether MockHub should publish a minimal `/.well-known/ucp` business profile now. The recommendation is: **do not publish a UCP profile yet**.
 
-The reason is not that MockHub lacks agentic-commerce capabilities. It has plenty of them. The problem is that a UCP profile is not just a marketing manifest; it is the protocol discovery document for versioned UCP services, capabilities, payment handlers, and negotiation behavior. Publishing a placeholder profile would invite platforms to treat MockHub as UCP-capable when the advertised endpoints still speak MockHub's existing ACP, MCP, and REST contracts.
+The reason is not that MockHub lacks agentic-commerce capabilities. It has plenty of them. The problem is that a UCP profile is not just a static metadata file; it is the protocol discovery document for versioned UCP services, capabilities, payment handlers, and negotiation behavior. Publishing a placeholder profile would invite platforms to treat MockHub as UCP-capable when the advertised endpoints still speak MockHub's existing ACP, MCP, and REST contracts.
 
 MockHub should wait until it can do at least the following:
 
@@ -355,7 +355,7 @@ MockHub should wait until it can do at least the following:
 5. Decide whether identity-linking and buyer-preference state (#219) belong in the first profile or remain outside the UCP surface.
 6. Add tests that assert the profile content matches the code's live endpoints and supported capabilities.
 
-Until then, `llms.txt`, MCP OAuth metadata, ACP endpoints, and the A2A agent card remain the honest discovery surfaces. The future UCP profile should be introduced in a dedicated implementation issue after #217, #218, and #219 have clarified risk, payment authority, and buyer context.
+Until then, `llms.txt`, MCP OAuth metadata, ACP endpoints, and the A2A agent card remain the honest discovery surfaces. No follow-up UCP profile implementation issue exists yet; open one only after #217, #218, #219, and #240 have clarified risk, payment authority, buyer context, and pinned protocol revisions, and include profile-content tests in that future issue.
 
 ### Why UCP Matters for the Training Course
 


### PR DESCRIPTION
## Summary
- Record the #237 decision not to publish a UCP business profile yet
- Explain why `/.well-known/ucp` would overstate support before UCP-shaped bindings, payment credentials, risk signals, and version pins exist
- Update the strategy note so #237 is treated as a captured decision rather than unfinished implementation work

## Validation
- Verified current UCP discovery/profile behavior from the official UCP specification and Google UCP guide
- Ran `git diff --check origin/main...HEAD`
- Ran Claude Opus review; addressed actionable findings in a follow-up commit
- `npx --no-install markdownlint-cli2 docs/agentic-commerce.md docs/agentic-commerce-strategy.md` could not run because `markdownlint-cli2` is not installed locally and `--no-install` refused to fetch it

Closes #237