### PR TITLE
Add agent purchase evidence trail

### DIFF
--- a/backend/src/main/java/com/mockhub/agentapproval/repository/AgentPurchaseApprovalRepository.java
+++ b/backend/src/main/java/com/mockhub/agentapproval/repository/AgentPurchaseApprovalRepository.java
@@ -16,6 +16,8 @@ public interface AgentPurchaseApprovalRepository extends JpaRepository<AgentPurc
 
     Optional<AgentPurchaseApproval> findByApprovalId(String approvalId);
 
+    Optional<AgentPurchaseApproval> findFirstByFinalOrderNumberOrderByCreatedAtDesc(String finalOrderNumber);
+
     List<AgentPurchaseApproval> findByUserEmailOrderByCreatedAtDesc(String userEmail);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/backend/src/main/java/com/mockhub/agentpurchaseevidence/controller/AgentPurchaseEvidenceController.java
+++ b/backend/src/main/java/com/mockhub/agentpurchaseevidence/controller/AgentPurchaseEvidenceController.java
@@ -1,0 +1,52 @@
+package com.mockhub.agentpurchaseevidence.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto;
+import com.mockhub.agentpurchaseevidence.service.AgentPurchaseEvidenceService;
+import com.mockhub.auth.security.SecurityUser;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@RequestMapping("/api/v1/orders")
+@Tag(name = "Agent Purchase Evidence", description = "Read-only evidence trails for agent-initiated orders")
+public class AgentPurchaseEvidenceController {
+
+    private static final String ROLE_ADMIN = "ROLE_ADMIN";
+
+    private final AgentPurchaseEvidenceService evidenceService;
+
+    public AgentPurchaseEvidenceController(AgentPurchaseEvidenceService evidenceService) {
+        this.evidenceService = evidenceService;
+    }
+
+    @GetMapping("/{orderNumber}/agent-evidence")
+    @Operation(summary = "Get agent purchase evidence",
+            description = "Return the mandate, approval, payment credential, risk, checkout, and fulfillment "
+                    + "evidence associated with an agent-initiated order. Only the order owner or an admin "
+                    + "can view it.")
+    @ApiResponse(responseCode = "200", description = "Evidence returned")
+    @ApiResponse(responseCode = "401", description = "Not authenticated or authenticated user does not own the order")
+    @ApiResponse(responseCode = "404", description = "Order not found")
+    public ResponseEntity<AgentPurchaseEvidenceDto> getEvidence(
+            @AuthenticationPrincipal SecurityUser securityUser,
+            @PathVariable String orderNumber) {
+        return ResponseEntity.ok(evidenceService.getEvidence(
+                orderNumber,
+                securityUser.getEmail(),
+                isAdmin(securityUser)));
+    }
+
+    private boolean isAdmin(SecurityUser securityUser) {
+        return securityUser.getAuthorities().stream()
+                .anyMatch(authority -> ROLE_ADMIN.equals(authority.getAuthority()));
+    }
+}

--- a/backend/src/main/java/com/mockhub/agentpurchaseevidence/dto/AgentPurchaseEvidenceDto.java
+++ b/backend/src/main/java/com/mockhub/agentpurchaseevidence/dto/AgentPurchaseEvidenceDto.java
@@ -1,0 +1,199 @@
+package com.mockhub.agentpurchaseevidence.dto;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+public record AgentPurchaseEvidenceDto(
+        String orderNumber,
+        String userEmail,
+        String agentId,
+        String status,
+        Instant createdAt,
+        AgentPurchaseEvidenceOrderDto order,
+        AgentPurchaseEvidenceMandateDto mandate,
+        AgentPurchaseEvidenceApprovalDto approval,
+        AgentPurchaseEvidencePaymentCredentialDto paymentCredential,
+        AgentPurchaseEvidenceCheckoutDto checkout,
+        AgentPurchaseEvidenceFulfillmentDto fulfillment,
+        List<AgentPurchaseEvidenceRiskSignalDto> riskSignals,
+        List<AgentPurchaseEvidenceEvalOutcomeDto> evalOutcomes,
+        List<AgentPurchaseEvidenceActorStepDto> actorTimeline
+) {
+
+    public record AgentPurchaseEvidenceOrderDto(
+            Long id,
+            String orderNumber,
+            String status,
+            BigDecimal subtotal,
+            BigDecimal serviceFee,
+            BigDecimal total,
+            String paymentMethod,
+            String paymentIntentId,
+            String agentId,
+            String mandateId,
+            Instant confirmedAt,
+            Instant createdAt,
+            List<AgentPurchaseEvidenceOrderItemDto> items
+    ) {
+    }
+
+    public record AgentPurchaseEvidenceOrderItemDto(
+            Long id,
+            Long listingId,
+            Long ticketId,
+            String eventName,
+            String eventSlug,
+            Instant eventDate,
+            String venueName,
+            String sectionName,
+            String rowLabel,
+            String seatNumber,
+            String ticketType,
+            BigDecimal pricePaid,
+            Instant scannedAt
+    ) {
+    }
+
+    public record AgentPurchaseEvidenceMandateDto(
+            String mandateId,
+            String agentId,
+            String userEmail,
+            String scope,
+            BigDecimal maxSpendPerTransaction,
+            BigDecimal maxSpendTotal,
+            BigDecimal totalSpent,
+            BigDecimal remainingBudget,
+            String allowedCategories,
+            String allowedEvents,
+            String allowedSections,
+            String approvalMode,
+            String status,
+            Instant expiresAt,
+            Instant revokedAt,
+            Instant createdAt
+    ) {
+    }
+
+    public record AgentPurchaseEvidenceApprovalDto(
+            String approvalId,
+            String userEmail,
+            String agentId,
+            String mandateId,
+            String status,
+            String proposedOrderSnapshot,
+            String agentRationale,
+            BigDecimal subtotal,
+            BigDecimal serviceFee,
+            BigDecimal total,
+            String commercePolicySnapshot,
+            Instant proposedAt,
+            Instant approvedAt,
+            Instant deniedAt,
+            Instant expiresAt,
+            Instant completedAt,
+            Instant failedAt,
+            String finalOrderNumber,
+            String denialReason,
+            String failureReason,
+            Instant createdAt
+    ) {
+    }
+
+    public record AgentPurchaseEvidencePaymentCredentialDto(
+            String credentialId,
+            String userEmail,
+            String agentId,
+            String allowedMerchant,
+            BigDecimal maxAmount,
+            String currency,
+            String usage,
+            String status,
+            String backingPaymentMethod,
+            Instant expiresAt,
+            Instant revokedAt,
+            Instant consumedAt,
+            String consumedByOrderNumber,
+            Instant lastUsedAt,
+            Instant createdAt
+    ) {
+    }
+
+    public record AgentPurchaseEvidenceCheckoutDto(
+            String checkoutId,
+            String acpStatus,
+            String paymentMethod,
+            String paymentIntentId,
+            String idempotencyKey,
+            boolean agentInitiated,
+            Instant createdAt,
+            Instant completedAt
+    ) {
+    }
+
+    public record AgentPurchaseEvidenceFulfillmentDto(
+            boolean ticketPdfAvailable,
+            String publicTicketViewUrl,
+            String orderViewTokenType,
+            String qrSigningKeyReference,
+            AgentPurchaseEvidenceDispatchDto emailDispatch,
+            AgentPurchaseEvidenceDispatchDto smsDispatch,
+            List<AgentPurchaseEvidenceTicketArtifactDto> ticketArtifacts
+    ) {
+    }
+
+    public record AgentPurchaseEvidenceDispatchDto(
+            String channel,
+            String status,
+            String recipient,
+            Instant attemptedAt,
+            String providerReference,
+            String note
+    ) {
+    }
+
+    public record AgentPurchaseEvidenceTicketArtifactDto(
+            Long ticketId,
+            Long orderItemId,
+            String ticketPdfUrl,
+            String qrCodeUrl,
+            String verificationTokenType,
+            Instant scannedAt
+    ) {
+    }
+
+    public record AgentPurchaseEvidenceRiskSignalDto(
+            Long id,
+            String signalType,
+            String severity,
+            String actionType,
+            String resourceType,
+            String resourceId,
+            String orderNumber,
+            String mandateId,
+            BigDecimal amount,
+            String message,
+            Instant createdAt
+    ) {
+    }
+
+    public record AgentPurchaseEvidenceEvalOutcomeDto(
+            String ruleName,
+            String status,
+            String severity,
+            String message,
+            Instant recordedAt,
+            String sourceReference
+    ) {
+    }
+
+    public record AgentPurchaseEvidenceActorStepDto(
+            String step,
+            String actorType,
+            String actorId,
+            Instant timestamp,
+            String referenceId,
+            String detail
+    ) {
+    }
+}

--- a/backend/src/main/java/com/mockhub/agentpurchaseevidence/service/AgentPurchaseEvidenceService.java
+++ b/backend/src/main/java/com/mockhub/agentpurchaseevidence/service/AgentPurchaseEvidenceService.java
@@ -178,12 +178,13 @@ public class AgentPurchaseEvidenceService {
         if (orderNumber.equals(signal.getOrderNumber())) {
             return true;
         }
+        if (orderNumber.equals(signal.getResourceId())) {
+            return true;
+        }
         if (signal.getResourceId() != null && listingIds.contains(signal.getResourceId())) {
             return true;
         }
-        return signal.getOrderNumber() == null && signal.getResourceId() == null
-                && signal.getActionType() != null
-                && (signal.getActionType().contains("CHECKOUT") || signal.getActionType().contains("CONFIRM"));
+        return false;
     }
 
     private AgentPurchaseEvidenceOrderDto toOrderDto(Order order) {
@@ -364,7 +365,7 @@ public class AgentPurchaseEvidenceService {
                 item.getTicket().getId(),
                 item.getId(),
                 ticketPdfUrl,
-                qrCodeUrl,
+                qrCodeUrl != null ? hostRelativeUrl(qrCodeUrl) : null,
                 confirmed ? TICKET_VERIFICATION_TOKEN_TYPE : null,
                 item.getScannedAt());
     }
@@ -455,14 +456,11 @@ public class AgentPurchaseEvidenceService {
         if (credential == null) {
             return;
         }
-        boolean consumedForOrder = order.getOrderNumber().equals(credential.getConsumedByOrderNumber());
         outcomes.add(new AgentPurchaseEvidenceEvalOutcomeDto(
                 "payment-credential",
-                consumedForOrder ? PASSED : WARNING,
-                consumedForOrder ? EvalSeverity.INFO.name() : EvalSeverity.WARNING.name(),
-                consumedForOrder
-                        ? "Scoped payment credential was consumed for this order"
-                        : "Payment credential was found but is not consumed by this order",
+                PASSED,
+                EvalSeverity.INFO.name(),
+                "Scoped payment credential was consumed for this order",
                 Optional.ofNullable(credential.getConsumedAt()).orElse(credential.getCreatedAt()),
                 credential.getCredentialId()));
     }
@@ -631,5 +629,13 @@ public class AgentPurchaseEvidenceService {
             trimmed = trimmed.substring(0, trimmed.length() - 1);
         }
         return trimmed;
+    }
+
+    private String hostRelativeUrl(String absoluteUrl) {
+        String prefix = orderBaseUrl + "/";
+        if (absoluteUrl.startsWith(prefix)) {
+            return "/" + absoluteUrl.substring(prefix.length());
+        }
+        return absoluteUrl;
     }
 }

--- a/backend/src/main/java/com/mockhub/agentpurchaseevidence/service/AgentPurchaseEvidenceService.java
+++ b/backend/src/main/java/com/mockhub/agentpurchaseevidence/service/AgentPurchaseEvidenceService.java
@@ -1,0 +1,635 @@
+package com.mockhub.agentpurchaseevidence.service;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mockhub.agentapproval.entity.AgentPurchaseApproval;
+import com.mockhub.agentapproval.repository.AgentPurchaseApprovalRepository;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto.AgentPurchaseEvidenceActorStepDto;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto.AgentPurchaseEvidenceApprovalDto;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto.AgentPurchaseEvidenceCheckoutDto;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto.AgentPurchaseEvidenceDispatchDto;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto.AgentPurchaseEvidenceEvalOutcomeDto;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto.AgentPurchaseEvidenceFulfillmentDto;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto.AgentPurchaseEvidenceMandateDto;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto.AgentPurchaseEvidenceOrderDto;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto.AgentPurchaseEvidenceOrderItemDto;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto.AgentPurchaseEvidencePaymentCredentialDto;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto.AgentPurchaseEvidenceRiskSignalDto;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto.AgentPurchaseEvidenceTicketArtifactDto;
+import com.mockhub.agentrisk.entity.AgentRiskSignal;
+import com.mockhub.agentrisk.repository.AgentRiskSignalRepository;
+import com.mockhub.auth.entity.User;
+import com.mockhub.common.exception.ResourceNotFoundException;
+import com.mockhub.common.exception.UnauthorizedException;
+import com.mockhub.eval.dto.EvalSeverity;
+import com.mockhub.mandate.entity.Mandate;
+import com.mockhub.mandate.repository.MandateRepository;
+import com.mockhub.order.entity.Order;
+import com.mockhub.order.entity.OrderItem;
+import com.mockhub.order.entity.OrderStatus;
+import com.mockhub.order.repository.OrderRepository;
+import com.mockhub.paymentcredential.entity.PaymentCredential;
+import com.mockhub.paymentcredential.repository.PaymentCredentialRepository;
+import com.mockhub.ticket.entity.Listing;
+import com.mockhub.ticket.entity.Ticket;
+import com.mockhub.ticket.service.TicketSigningService;
+import com.mockhub.venue.entity.Seat;
+
+@Service
+public class AgentPurchaseEvidenceService {
+
+    private static final Duration AGENT_SIGNAL_LOOKBACK = Duration.ofMinutes(15);
+    private static final String ORDER_VIEW_TOKEN_TYPE = "order-view";
+    private static final String TICKET_VERIFICATION_TOKEN_TYPE = "ticket-verification";
+    private static final String QR_SIGNING_KEY_REFERENCE = "mockhub.ticket.signing-secret";
+    private static final String NOT_PERSISTED = "NOT_PERSISTED";
+    private static final String NOT_APPLICABLE = "NOT_APPLICABLE";
+    private static final String PASSED = "PASSED";
+    private static final String WARNING = "WARNING";
+    private static final String BLOCKED = "BLOCKED";
+
+    private final OrderRepository orderRepository;
+    private final MandateRepository mandateRepository;
+    private final AgentPurchaseApprovalRepository approvalRepository;
+    private final PaymentCredentialRepository paymentCredentialRepository;
+    private final AgentRiskSignalRepository agentRiskSignalRepository;
+    private final TicketSigningService ticketSigningService;
+    private final String orderBaseUrl;
+
+    public AgentPurchaseEvidenceService(OrderRepository orderRepository,
+                                        MandateRepository mandateRepository,
+                                        AgentPurchaseApprovalRepository approvalRepository,
+                                        PaymentCredentialRepository paymentCredentialRepository,
+                                        AgentRiskSignalRepository agentRiskSignalRepository,
+                                        TicketSigningService ticketSigningService,
+                                        @Value("${mockhub.sms.order-base-url}") String orderBaseUrl) {
+        this.orderRepository = orderRepository;
+        this.mandateRepository = mandateRepository;
+        this.approvalRepository = approvalRepository;
+        this.paymentCredentialRepository = paymentCredentialRepository;
+        this.agentRiskSignalRepository = agentRiskSignalRepository;
+        this.ticketSigningService = ticketSigningService;
+        this.orderBaseUrl = trimTrailingSlash(orderBaseUrl);
+    }
+
+    @Transactional(readOnly = true)
+    public AgentPurchaseEvidenceDto getEvidence(String orderNumber, String requesterEmail, boolean admin) {
+        Order order = loadOrder(orderNumber);
+        verifyAccess(order, requesterEmail, admin);
+        return assembleEvidence(order);
+    }
+
+    @Transactional(readOnly = true)
+    public AgentPurchaseEvidenceDto getEvidenceForUser(String userEmail, String orderNumber) {
+        return getEvidence(orderNumber, userEmail, false);
+    }
+
+    private Order loadOrder(String orderNumber) {
+        String normalizedOrderNumber = required(orderNumber, "Order number");
+        return orderRepository.findByOrderNumber(normalizedOrderNumber)
+                .orElseThrow(() -> new ResourceNotFoundException("Order", "orderNumber", normalizedOrderNumber));
+    }
+
+    private void verifyAccess(Order order, String requesterEmail, boolean admin) {
+        if (admin) {
+            return;
+        }
+        String normalizedEmail = required(requesterEmail, "Requester email");
+        if (!order.getUser().getEmail().equals(normalizedEmail)) {
+            throw new UnauthorizedException("You do not have access to this agent purchase evidence");
+        }
+    }
+
+    private AgentPurchaseEvidenceDto assembleEvidence(Order order) {
+        Mandate mandate = findMandate(order).orElse(null);
+        AgentPurchaseApproval approval = approvalRepository
+                .findFirstByFinalOrderNumberOrderByCreatedAtDesc(order.getOrderNumber())
+                .orElse(null);
+        PaymentCredential paymentCredential = paymentCredentialRepository
+                .findFirstByConsumedByOrderNumberOrderByConsumedAtDesc(order.getOrderNumber())
+                .orElse(null);
+        List<AgentRiskSignal> riskSignals = findRiskSignals(order);
+        AgentPurchaseEvidenceFulfillmentDto fulfillment = toFulfillmentDto(order);
+        List<AgentPurchaseEvidenceEvalOutcomeDto> evalOutcomes =
+                toEvalOutcomes(order, mandate, approval, paymentCredential, riskSignals);
+
+        return new AgentPurchaseEvidenceDto(
+                order.getOrderNumber(),
+                order.getUser().getEmail(),
+                order.getAgentId(),
+                order.getStatus().name(),
+                order.getCreatedAt(),
+                toOrderDto(order),
+                mandate != null ? toMandateDto(mandate) : null,
+                approval != null ? toApprovalDto(approval) : null,
+                paymentCredential != null ? toPaymentCredentialDto(paymentCredential) : null,
+                toCheckoutDto(order),
+                fulfillment,
+                riskSignals.stream().map(this::toRiskSignalDto).toList(),
+                evalOutcomes,
+                toActorTimeline(order, mandate, approval, paymentCredential, riskSignals));
+    }
+
+    private Optional<Mandate> findMandate(Order order) {
+        if (order.getMandateId() == null || order.getMandateId().isBlank()) {
+            return Optional.empty();
+        }
+        return mandateRepository.findByMandateId(order.getMandateId());
+    }
+
+    private List<AgentRiskSignal> findRiskSignals(Order order) {
+        if (order.getAgentId() == null || order.getAgentId().isBlank()) {
+            return List.of();
+        }
+        Instant createdAt = Optional.ofNullable(order.getCreatedAt()).orElse(Instant.EPOCH);
+        Instant endAt = Optional.ofNullable(order.getConfirmedAt())
+                .orElse(Optional.ofNullable(order.getUpdatedAt()).orElse(Instant.now()));
+        List<AgentRiskSignal> candidates = agentRiskSignalRepository
+                .findByUserEmailAndAgentIdAndCreatedAtBetweenOrderByCreatedAtAsc(
+                        order.getUser().getEmail(),
+                        order.getAgentId(),
+                        createdAt.minus(AGENT_SIGNAL_LOOKBACK),
+                        endAt.plus(AGENT_SIGNAL_LOOKBACK));
+
+        Set<String> listingIds = new HashSet<>();
+        for (OrderItem item : order.getItems()) {
+            listingIds.add(item.getListing().getId().toString());
+        }
+
+        return candidates.stream()
+                .filter(signal -> belongsToOrderEvidence(signal, order.getOrderNumber(), listingIds))
+                .toList();
+    }
+
+    private boolean belongsToOrderEvidence(AgentRiskSignal signal, String orderNumber, Set<String> listingIds) {
+        if (orderNumber.equals(signal.getOrderNumber())) {
+            return true;
+        }
+        if (signal.getResourceId() != null && listingIds.contains(signal.getResourceId())) {
+            return true;
+        }
+        return signal.getOrderNumber() == null && signal.getResourceId() == null
+                && signal.getActionType() != null
+                && (signal.getActionType().contains("CHECKOUT") || signal.getActionType().contains("CONFIRM"));
+    }
+
+    private AgentPurchaseEvidenceOrderDto toOrderDto(Order order) {
+        return new AgentPurchaseEvidenceOrderDto(
+                order.getId(),
+                order.getOrderNumber(),
+                order.getStatus().name(),
+                order.getSubtotal(),
+                order.getServiceFee(),
+                order.getTotal(),
+                order.getPaymentMethod(),
+                order.getPaymentIntentId(),
+                order.getAgentId(),
+                order.getMandateId(),
+                order.getConfirmedAt(),
+                order.getCreatedAt(),
+                order.getItems().stream().map(this::toOrderItemDto).toList());
+    }
+
+    private AgentPurchaseEvidenceOrderItemDto toOrderItemDto(OrderItem item) {
+        Listing listing = item.getListing();
+        Ticket ticket = item.getTicket();
+        Seat seat = ticket.getSeat();
+        String rowLabel = seat != null && seat.getRow() != null ? seat.getRow().getRowLabel() : null;
+        String seatNumber = seat != null ? seat.getSeatNumber() : null;
+
+        return new AgentPurchaseEvidenceOrderItemDto(
+                item.getId(),
+                listing.getId(),
+                ticket.getId(),
+                listing.getEvent().getName(),
+                listing.getEvent().getSlug(),
+                listing.getEvent().getEventDate(),
+                listing.getEvent().getVenue() != null ? listing.getEvent().getVenue().getName() : null,
+                ticket.getSection() != null ? ticket.getSection().getName() : null,
+                rowLabel,
+                seatNumber,
+                ticket.getTicketType(),
+                item.getPricePaid(),
+                item.getScannedAt());
+    }
+
+    private AgentPurchaseEvidenceMandateDto toMandateDto(Mandate mandate) {
+        BigDecimal remainingBudget = mandate.getMaxSpendTotal() != null
+                ? mandate.getMaxSpendTotal().subtract(mandate.getTotalSpent())
+                : null;
+        return new AgentPurchaseEvidenceMandateDto(
+                mandate.getMandateId(),
+                mandate.getAgentId(),
+                mandate.getUserEmail(),
+                mandate.getScope(),
+                mandate.getMaxSpendPerTransaction(),
+                mandate.getMaxSpendTotal(),
+                mandate.getTotalSpent(),
+                remainingBudget,
+                mandate.getAllowedCategories(),
+                mandate.getAllowedEvents(),
+                mandate.getAllowedSections(),
+                mandate.getApprovalMode(),
+                mandate.getStatus(),
+                mandate.getExpiresAt(),
+                mandate.getRevokedAt(),
+                mandate.getCreatedAt());
+    }
+
+    private AgentPurchaseEvidenceApprovalDto toApprovalDto(AgentPurchaseApproval approval) {
+        return new AgentPurchaseEvidenceApprovalDto(
+                approval.getApprovalId(),
+                approval.getUserEmail(),
+                approval.getAgentId(),
+                approval.getMandateId(),
+                approval.getStatus().name(),
+                approval.getProposedOrderSnapshot(),
+                approval.getAgentRationale(),
+                approval.getSubtotal(),
+                approval.getServiceFee(),
+                approval.getTotal(),
+                approval.getCommercePolicySnapshot(),
+                approval.getProposedAt(),
+                approval.getApprovedAt(),
+                approval.getDeniedAt(),
+                approval.getExpiresAt(),
+                approval.getCompletedAt(),
+                approval.getFailedAt(),
+                approval.getFinalOrderNumber(),
+                approval.getDenialReason(),
+                approval.getFailureReason(),
+                approval.getCreatedAt());
+    }
+
+    private AgentPurchaseEvidencePaymentCredentialDto toPaymentCredentialDto(PaymentCredential credential) {
+        return new AgentPurchaseEvidencePaymentCredentialDto(
+                credential.getCredentialId(),
+                credential.getUserEmail(),
+                credential.getAgentId(),
+                credential.getAllowedMerchant(),
+                credential.getMaxAmount(),
+                credential.getCurrency(),
+                credential.getUsage().name(),
+                credential.getStatus().name(),
+                credential.getBackingPaymentMethod(),
+                credential.getExpiresAt(),
+                credential.getRevokedAt(),
+                credential.getConsumedAt(),
+                credential.getConsumedByOrderNumber(),
+                credential.getLastUsedAt(),
+                credential.getCreatedAt());
+    }
+
+    private AgentPurchaseEvidenceCheckoutDto toCheckoutDto(Order order) {
+        return new AgentPurchaseEvidenceCheckoutDto(
+                order.getOrderNumber(),
+                mapOrderStatusToAcpStatus(order.getStatus()),
+                order.getPaymentMethod(),
+                order.getPaymentIntentId(),
+                order.getIdempotencyKey(),
+                order.getAgentId() != null && !order.getAgentId().isBlank(),
+                order.getCreatedAt(),
+                order.getConfirmedAt());
+    }
+
+    private AgentPurchaseEvidenceFulfillmentDto toFulfillmentDto(Order order) {
+        boolean confirmed = order.getStatus() == OrderStatus.CONFIRMED;
+        String orderViewToken = confirmed ? ticketSigningService.generateOrderViewToken(order.getOrderNumber()) : null;
+        String publicTicketViewUrl = confirmed ? orderBaseUrl + "/tickets/view?token=" + orderViewToken : null;
+        User user = order.getUser();
+
+        return new AgentPurchaseEvidenceFulfillmentDto(
+                confirmed,
+                publicTicketViewUrl,
+                confirmed ? ORDER_VIEW_TOKEN_TYPE : null,
+                confirmed ? QR_SIGNING_KEY_REFERENCE : null,
+                confirmed ? dispatchDto("EMAIL", user.getEmail(), order.getConfirmedAt()) : null,
+                smsDispatchDto(user, order.getConfirmedAt(), confirmed),
+                order.getItems().stream()
+                        .map(item -> toTicketArtifactDto(item, confirmed, orderViewToken))
+                        .toList());
+    }
+
+    private AgentPurchaseEvidenceDispatchDto smsDispatchDto(User user, Instant confirmedAt, boolean confirmed) {
+        if (!confirmed) {
+            return null;
+        }
+        if (user.getPhone() == null || user.getPhone().isBlank()) {
+            return new AgentPurchaseEvidenceDispatchDto(
+                    "SMS",
+                    NOT_APPLICABLE,
+                    null,
+                    null,
+                    null,
+                    "User has no phone number, so no SMS dispatch was attempted");
+        }
+        return dispatchDto("SMS", user.getPhone(), confirmedAt);
+    }
+
+    private AgentPurchaseEvidenceDispatchDto dispatchDto(String channel, String recipient, Instant attemptedAt) {
+        return new AgentPurchaseEvidenceDispatchDto(
+                channel,
+                NOT_PERSISTED,
+                recipient,
+                attemptedAt,
+                null,
+                "MockHub sends this notification on confirmation but does not persist provider delivery records");
+    }
+
+    private AgentPurchaseEvidenceTicketArtifactDto toTicketArtifactDto(OrderItem item, boolean confirmed,
+                                                                       String orderViewToken) {
+        String ticketPdfUrl = confirmed
+                ? "/api/v1/orders/" + item.getOrder().getOrderNumber()
+                        + "/tickets/" + item.getTicket().getId() + "/download"
+                : null;
+        String qrCodeUrl = confirmed
+                ? orderBaseUrl + "/api/v1/tickets/" + item.getOrder().getOrderNumber()
+                        + "/" + item.getTicket().getId() + "/qr?token=" + orderViewToken
+                : null;
+
+        return new AgentPurchaseEvidenceTicketArtifactDto(
+                item.getTicket().getId(),
+                item.getId(),
+                ticketPdfUrl,
+                qrCodeUrl,
+                confirmed ? TICKET_VERIFICATION_TOKEN_TYPE : null,
+                item.getScannedAt());
+    }
+
+    private AgentPurchaseEvidenceRiskSignalDto toRiskSignalDto(AgentRiskSignal signal) {
+        return new AgentPurchaseEvidenceRiskSignalDto(
+                signal.getId(),
+                signal.getSignalType().name(),
+                signal.getSeverity().name(),
+                signal.getActionType(),
+                signal.getResourceType(),
+                signal.getResourceId(),
+                signal.getOrderNumber(),
+                signal.getMandateId(),
+                signal.getAmount(),
+                signal.getMessage(),
+                signal.getCreatedAt());
+    }
+
+    private List<AgentPurchaseEvidenceEvalOutcomeDto> toEvalOutcomes(Order order,
+                                                                     Mandate mandate,
+                                                                     AgentPurchaseApproval approval,
+                                                                     PaymentCredential credential,
+                                                                     List<AgentRiskSignal> riskSignals) {
+        List<AgentPurchaseEvidenceEvalOutcomeDto> outcomes = new ArrayList<>();
+        addMandateOutcome(outcomes, order, mandate);
+        addApprovalOutcome(outcomes, mandate, approval);
+        addPaymentCredentialOutcome(outcomes, credential, order);
+        addRiskOutcomes(outcomes, riskSignals, order);
+        return outcomes;
+    }
+
+    private void addMandateOutcome(List<AgentPurchaseEvidenceEvalOutcomeDto> outcomes,
+                                   Order order, Mandate mandate) {
+        if (order.getMandateId() == null || order.getMandateId().isBlank()) {
+            return;
+        }
+        if (mandate == null) {
+            outcomes.add(new AgentPurchaseEvidenceEvalOutcomeDto(
+                    "mandate-authorization",
+                    WARNING,
+                    EvalSeverity.WARNING.name(),
+                    "Order references mandate " + order.getMandateId() + ", but no mandate record was found",
+                    order.getCreatedAt(),
+                    order.getMandateId()));
+            return;
+        }
+        outcomes.add(new AgentPurchaseEvidenceEvalOutcomeDto(
+                "mandate-authorization",
+                PASSED,
+                EvalSeverity.INFO.name(),
+                "Order was created with recorded agent and mandate context",
+                order.getCreatedAt(),
+                mandate.getMandateId()));
+    }
+
+    private void addApprovalOutcome(List<AgentPurchaseEvidenceEvalOutcomeDto> outcomes,
+                                    Mandate mandate, AgentPurchaseApproval approval) {
+        if (approval != null) {
+            String status = switch (approval.getStatus()) {
+                case COMPLETED -> PASSED;
+                case FAILED, DENIED, EXPIRED -> BLOCKED;
+                case APPROVED, PROPOSED -> WARNING;
+            };
+            EvalSeverity severity = severityForOutcomeStatus(status);
+            outcomes.add(new AgentPurchaseEvidenceEvalOutcomeDto(
+                    "purchase-approval",
+                    status,
+                    severity.name(),
+                    "Purchase approval is " + approval.getStatus().name(),
+                    mostRelevantApprovalTimestamp(approval),
+                    approval.getApprovalId()));
+            return;
+        }
+        if (mandate != null && "APPROVAL_REQUIRED".equals(mandate.getApprovalMode())) {
+            outcomes.add(new AgentPurchaseEvidenceEvalOutcomeDto(
+                    "purchase-approval",
+                    WARNING,
+                    EvalSeverity.WARNING.name(),
+                    "Mandate requires approval, but no completed approval record is linked to this order",
+                    mandate.getCreatedAt(),
+                    mandate.getMandateId()));
+        }
+    }
+
+    private void addPaymentCredentialOutcome(List<AgentPurchaseEvidenceEvalOutcomeDto> outcomes,
+                                             PaymentCredential credential, Order order) {
+        if (credential == null) {
+            return;
+        }
+        boolean consumedForOrder = order.getOrderNumber().equals(credential.getConsumedByOrderNumber());
+        outcomes.add(new AgentPurchaseEvidenceEvalOutcomeDto(
+                "payment-credential",
+                consumedForOrder ? PASSED : WARNING,
+                consumedForOrder ? EvalSeverity.INFO.name() : EvalSeverity.WARNING.name(),
+                consumedForOrder
+                        ? "Scoped payment credential was consumed for this order"
+                        : "Payment credential was found but is not consumed by this order",
+                Optional.ofNullable(credential.getConsumedAt()).orElse(credential.getCreatedAt()),
+                credential.getCredentialId()));
+    }
+
+    private EvalSeverity severityForOutcomeStatus(String status) {
+        return switch (status) {
+            case PASSED -> EvalSeverity.INFO;
+            case BLOCKED -> EvalSeverity.CRITICAL;
+            default -> EvalSeverity.WARNING;
+        };
+    }
+
+    private void addRiskOutcomes(List<AgentPurchaseEvidenceEvalOutcomeDto> outcomes,
+                                 List<AgentRiskSignal> riskSignals, Order order) {
+        List<AgentRiskSignal> nonInfoSignals = riskSignals.stream()
+                .filter(signal -> signal.getSeverity() != EvalSeverity.INFO)
+                .toList();
+        if (nonInfoSignals.isEmpty() && order.getAgentId() != null) {
+            outcomes.add(new AgentPurchaseEvidenceEvalOutcomeDto(
+                    "agent-risk",
+                    PASSED,
+                    EvalSeverity.INFO.name(),
+                    "No warning or critical risk signals are linked to this order evidence window",
+                    order.getConfirmedAt() != null ? order.getConfirmedAt() : order.getCreatedAt(),
+                    order.getAgentId()));
+            return;
+        }
+        for (AgentRiskSignal signal : nonInfoSignals) {
+            outcomes.add(new AgentPurchaseEvidenceEvalOutcomeDto(
+                    riskRuleName(signal),
+                    signal.getSeverity() == EvalSeverity.CRITICAL ? BLOCKED : WARNING,
+                    signal.getSeverity().name(),
+                    signal.getMessage(),
+                    signal.getCreatedAt(),
+                    signal.getId() != null ? signal.getId().toString() : null));
+        }
+    }
+
+    private List<AgentPurchaseEvidenceActorStepDto> toActorTimeline(Order order,
+                                                                    Mandate mandate,
+                                                                    AgentPurchaseApproval approval,
+                                                                    PaymentCredential credential,
+                                                                    List<AgentRiskSignal> riskSignals) {
+        List<AgentPurchaseEvidenceActorStepDto> steps = new ArrayList<>();
+        if (mandate != null) {
+            steps.add(new AgentPurchaseEvidenceActorStepDto(
+                    "MANDATE_CREATED", "USER", mandate.getUserEmail(), mandate.getCreatedAt(),
+                    mandate.getMandateId(), "Mandate created for agent " + mandate.getAgentId()));
+        }
+        if (credential != null) {
+            steps.add(new AgentPurchaseEvidenceActorStepDto(
+                    "PAYMENT_CREDENTIAL_ISSUED", "USER", credential.getUserEmail(), credential.getCreatedAt(),
+                    credential.getCredentialId(), "Scoped payment credential issued for agent "
+                            + credential.getAgentId()));
+            if (credential.getConsumedAt() != null) {
+                steps.add(new AgentPurchaseEvidenceActorStepDto(
+                        "PAYMENT_CREDENTIAL_CONSUMED", "AGENT", credential.getAgentId(),
+                        credential.getConsumedAt(), credential.getCredentialId(),
+                        "Payment credential consumed for order " + credential.getConsumedByOrderNumber()));
+            }
+        }
+        addApprovalSteps(steps, approval);
+        for (AgentRiskSignal signal : riskSignals) {
+            steps.add(new AgentPurchaseEvidenceActorStepDto(
+                    "RISK_SIGNAL_RECORDED", "AGENT", signal.getAgentId(), signal.getCreatedAt(),
+                    signal.getId() != null ? signal.getId().toString() : null,
+                    signal.getSignalType().name() + ": " + signal.getMessage()));
+        }
+        String orderActorType = order.getAgentId() != null ? "AGENT" : "USER";
+        String orderActorId = order.getAgentId() != null ? order.getAgentId() : order.getUser().getEmail();
+        steps.add(new AgentPurchaseEvidenceActorStepDto(
+                "ORDER_CREATED", orderActorType, orderActorId, order.getCreatedAt(),
+                order.getOrderNumber(), "Checkout created order " + order.getOrderNumber()));
+        if (order.getConfirmedAt() != null) {
+            steps.add(new AgentPurchaseEvidenceActorStepDto(
+                    "ORDER_CONFIRMED", orderActorType, orderActorId, order.getConfirmedAt(),
+                    order.getOrderNumber(), "Payment confirmed and tickets fulfilled"));
+        }
+        return steps.stream()
+                .sorted(Comparator.comparing(
+                        AgentPurchaseEvidenceActorStepDto::timestamp,
+                        Comparator.nullsLast(Comparator.naturalOrder())))
+                .toList();
+    }
+
+    private void addApprovalSteps(List<AgentPurchaseEvidenceActorStepDto> steps,
+                                  AgentPurchaseApproval approval) {
+        if (approval == null) {
+            return;
+        }
+        steps.add(new AgentPurchaseEvidenceActorStepDto(
+                "PURCHASE_APPROVAL_PROPOSED", "AGENT", approval.getAgentId(), approval.getProposedAt(),
+                approval.getApprovalId(), "Agent proposed a purchase for user approval"));
+        if (approval.getApprovedAt() != null) {
+            steps.add(new AgentPurchaseEvidenceActorStepDto(
+                    "PURCHASE_APPROVAL_APPROVED", "USER", approval.getUserEmail(), approval.getApprovedAt(),
+                    approval.getApprovalId(), "User approved the proposed purchase"));
+        }
+        if (approval.getDeniedAt() != null) {
+            steps.add(new AgentPurchaseEvidenceActorStepDto(
+                    "PURCHASE_APPROVAL_DENIED", "USER", approval.getUserEmail(), approval.getDeniedAt(),
+                    approval.getApprovalId(), "User denied the proposed purchase"));
+        }
+        if (approval.getCompletedAt() != null) {
+            steps.add(new AgentPurchaseEvidenceActorStepDto(
+                    "PURCHASE_APPROVAL_COMPLETED", "AGENT", approval.getAgentId(), approval.getCompletedAt(),
+                    approval.getApprovalId(), "Approved proposal completed as order "
+                            + approval.getFinalOrderNumber()));
+        }
+        if (approval.getFailedAt() != null) {
+            steps.add(new AgentPurchaseEvidenceActorStepDto(
+                    "PURCHASE_APPROVAL_FAILED", "SYSTEM", "MockHub", approval.getFailedAt(),
+                    approval.getApprovalId(), approval.getFailureReason()));
+        }
+    }
+
+    private Instant mostRelevantApprovalTimestamp(AgentPurchaseApproval approval) {
+        if (approval.getCompletedAt() != null) {
+            return approval.getCompletedAt();
+        }
+        if (approval.getFailedAt() != null) {
+            return approval.getFailedAt();
+        }
+        if (approval.getDeniedAt() != null) {
+            return approval.getDeniedAt();
+        }
+        if (approval.getApprovedAt() != null) {
+            return approval.getApprovedAt();
+        }
+        return approval.getProposedAt();
+    }
+
+    private String riskRuleName(AgentRiskSignal signal) {
+        return switch (signal.getSignalType()) {
+            case MANDATE_MISMATCH -> "mandate-authorization";
+            case AGENT_RISK_BLOCK -> "agent-risk";
+            case PAYMENT_CREDENTIAL_FAILURE -> "payment-credential";
+            case HIGH_SPEND_ATTEMPT -> "high-spend-threshold";
+            case RAPID_CART_HOLD -> "rapid-cart-hold";
+            case FAILED_CHECKOUT -> "checkout-completion";
+            case CART_HOLD_ATTEMPT, CHECKOUT_ATTEMPT -> "agent-activity";
+        };
+    }
+
+    private String mapOrderStatusToAcpStatus(OrderStatus orderStatus) {
+        return switch (orderStatus) {
+            case PENDING -> "CREATED";
+            case CONFIRMED -> "COMPLETED";
+            case FAILED, CANCELLED -> "CANCELLED";
+        };
+    }
+
+    private String required(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException(fieldName + " is required");
+        }
+        return value.strip();
+    }
+
+    private static String trimTrailingSlash(String value) {
+        if (value == null || value.isBlank()) {
+            return "";
+        }
+        String trimmed = value.strip();
+        while (trimmed.endsWith("/")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 1);
+        }
+        return trimmed;
+    }
+}

--- a/backend/src/main/java/com/mockhub/agentrisk/repository/AgentRiskSignalRepository.java
+++ b/backend/src/main/java/com/mockhub/agentrisk/repository/AgentRiskSignalRepository.java
@@ -33,4 +33,7 @@ public interface AgentRiskSignalRepository extends JpaRepository<AgentRiskSignal
             String userEmail, String agentId, EvalSeverity severity, Instant since);
 
     long countByUserEmailAndAgentIdAndCreatedAtAfter(String userEmail, String agentId, Instant since);
+
+    List<AgentRiskSignal> findByUserEmailAndAgentIdAndCreatedAtBetweenOrderByCreatedAtAsc(
+            String userEmail, String agentId, Instant start, Instant end);
 }

--- a/backend/src/main/java/com/mockhub/config/McpConfig.java
+++ b/backend/src/main/java/com/mockhub/config/McpConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.mockhub.mcp.tools.AgentApprovalTools;
+import com.mockhub.mcp.tools.AgentPurchaseEvidenceTools;
 import com.mockhub.mcp.tools.AgentRiskTools;
 import com.mockhub.mcp.tools.CartTools;
 import com.mockhub.mcp.tools.EventTools;
@@ -27,10 +28,11 @@ public class McpConfig {
                                                        MandateTools mandateTools,
                                                        AgentApprovalTools agentApprovalTools,
                                                        PaymentCredentialTools paymentCredentialTools,
-                                                       AgentRiskTools agentRiskTools) {
+                                                       AgentRiskTools agentRiskTools,
+                                                       AgentPurchaseEvidenceTools agentPurchaseEvidenceTools) {
         return MethodToolCallbackProvider.builder()
                 .toolObjects(eventTools, pricingTools, cartTools, orderTools, mandateTools,
-                        agentApprovalTools, paymentCredentialTools, agentRiskTools)
+                        agentApprovalTools, paymentCredentialTools, agentRiskTools, agentPurchaseEvidenceTools)
                 .build();
     }
 }

--- a/backend/src/main/java/com/mockhub/mcp/tools/AgentPurchaseEvidenceTools.java
+++ b/backend/src/main/java/com/mockhub/mcp/tools/AgentPurchaseEvidenceTools.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto.AgentPurchaseEvidenceFulfillmentDto;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto.AgentPurchaseEvidenceTicketArtifactDto;
 import com.mockhub.agentpurchaseevidence.service.AgentPurchaseEvidenceService;
 import com.mockhub.ai.service.ChatContext;
 
@@ -36,7 +38,7 @@ public class AgentPurchaseEvidenceTools {
         try {
             String effectiveEmail = ChatContext.resolveEmail(userEmail);
             AgentPurchaseEvidenceDto evidence = evidenceService.getEvidenceForUser(effectiveEmail, orderNumber);
-            return objectMapper.writeValueAsString(evidence);
+            return objectMapper.writeValueAsString(redactPublicTicketTokens(evidence));
         } catch (Exception e) {
             log.error("Error getting agent purchase evidence for order '{}' and user '{}': {}",
                     orderNumber, userEmail, e.getMessage(), e);
@@ -44,5 +46,49 @@ public class AgentPurchaseEvidenceTools {
                     .put("error", "Failed to get agent purchase evidence: " + e.getMessage())
                     .toString();
         }
+    }
+
+    private AgentPurchaseEvidenceDto redactPublicTicketTokens(AgentPurchaseEvidenceDto evidence) {
+        AgentPurchaseEvidenceFulfillmentDto fulfillment = evidence.fulfillment();
+        if (fulfillment == null) {
+            return evidence;
+        }
+
+        var redactedArtifacts = fulfillment.ticketArtifacts() == null
+                ? null
+                : fulfillment.ticketArtifacts().stream()
+                        .map(artifact -> new AgentPurchaseEvidenceTicketArtifactDto(
+                                artifact.ticketId(),
+                                artifact.orderItemId(),
+                                artifact.ticketPdfUrl(),
+                                null,
+                                artifact.verificationTokenType(),
+                                artifact.scannedAt()))
+                        .toList();
+
+        AgentPurchaseEvidenceFulfillmentDto redactedFulfillment = new AgentPurchaseEvidenceFulfillmentDto(
+                fulfillment.ticketPdfAvailable(),
+                null,
+                fulfillment.orderViewTokenType(),
+                fulfillment.qrSigningKeyReference(),
+                fulfillment.emailDispatch(),
+                fulfillment.smsDispatch(),
+                redactedArtifacts);
+
+        return new AgentPurchaseEvidenceDto(
+                evidence.orderNumber(),
+                evidence.userEmail(),
+                evidence.agentId(),
+                evidence.status(),
+                evidence.createdAt(),
+                evidence.order(),
+                evidence.mandate(),
+                evidence.approval(),
+                evidence.paymentCredential(),
+                evidence.checkout(),
+                redactedFulfillment,
+                evidence.riskSignals(),
+                evidence.evalOutcomes(),
+                evidence.actorTimeline());
     }
 }

--- a/backend/src/main/java/com/mockhub/mcp/tools/AgentPurchaseEvidenceTools.java
+++ b/backend/src/main/java/com/mockhub/mcp/tools/AgentPurchaseEvidenceTools.java
@@ -1,0 +1,48 @@
+package com.mockhub.mcp.tools;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.ai.tool.annotation.Tool;
+import org.springframework.ai.tool.annotation.ToolParam;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto;
+import com.mockhub.agentpurchaseevidence.service.AgentPurchaseEvidenceService;
+import com.mockhub.ai.service.ChatContext;
+
+@Component
+public class AgentPurchaseEvidenceTools {
+
+    private static final Logger log = LoggerFactory.getLogger(AgentPurchaseEvidenceTools.class);
+
+    private final AgentPurchaseEvidenceService evidenceService;
+    private final ObjectMapper objectMapper;
+
+    public AgentPurchaseEvidenceTools(AgentPurchaseEvidenceService evidenceService,
+                                      ObjectMapper objectMapper) {
+        this.evidenceService = evidenceService;
+        this.objectMapper = objectMapper;
+    }
+
+    @Tool(description = "Get the read-only evidence trail for a MockHub agent-initiated order. "
+            + "Returns mandate, purchase approval, scoped payment credential, checkout, risk, eval, "
+            + "and fulfillment evidence for the order owner.")
+    public String getAgentPurchaseEvidence(
+            @ToolParam(description = "Email of the user who owns the order", required = true)
+                    String userEmail,
+            @ToolParam(description = "Order number to inspect (e.g. 'MH-20260319-0001')", required = true)
+                    String orderNumber) {
+        try {
+            String effectiveEmail = ChatContext.resolveEmail(userEmail);
+            AgentPurchaseEvidenceDto evidence = evidenceService.getEvidenceForUser(effectiveEmail, orderNumber);
+            return objectMapper.writeValueAsString(evidence);
+        } catch (Exception e) {
+            log.error("Error getting agent purchase evidence for order '{}' and user '{}': {}",
+                    orderNumber, userEmail, e.getMessage(), e);
+            return objectMapper.createObjectNode()
+                    .put("error", "Failed to get agent purchase evidence: " + e.getMessage())
+                    .toString();
+        }
+    }
+}

--- a/backend/src/main/java/com/mockhub/paymentcredential/repository/PaymentCredentialRepository.java
+++ b/backend/src/main/java/com/mockhub/paymentcredential/repository/PaymentCredentialRepository.java
@@ -19,6 +19,8 @@ public interface PaymentCredentialRepository extends JpaRepository<PaymentCreden
 
     Optional<PaymentCredential> findByCredentialId(String credentialId);
 
+    Optional<PaymentCredential> findFirstByConsumedByOrderNumberOrderByConsumedAtDesc(String consumedByOrderNumber);
+
     List<PaymentCredential> findByUserEmailOrderByCreatedAtDesc(String userEmail);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)

--- a/backend/src/main/resources/static/llms.txt
+++ b/backend/src/main/resources/static/llms.txt
@@ -79,6 +79,7 @@ POST /api/v1/orders/checkout — Create order from cart. JSON body: {"paymentMet
 GET /api/v1/orders — List user's orders (paginated)
 GET /api/v1/orders/{orderNumber} — Order detail
 GET /api/v1/orders/{orderNumber}/calendar — Download .ics calendar file for event
+GET /api/v1/orders/{orderNumber}/agent-evidence — Owner/admin-scoped agent purchase evidence trail: mandate, approval, scoped payment credential, checkout, risk, eval, actor timeline, and fulfillment artifacts
 
 ## Ticket Download (requires auth)
 GET /api/v1/orders/{orderNumber}/tickets/{ticketId}/download — Download ticket PDF with QR code
@@ -149,6 +150,7 @@ Sessions are in-memory — after server redeploys, clients must re-initialize.
 - listPaymentCredentials(userEmail) — list active, consumed, revoked, and expired scoped payment credentials for a user
 - revokePaymentCredential(userEmail, credentialId) — revoke an active payment credential so it can no longer authorize payment
 - getAgentRiskSummary(userEmail, agentId) — get deterministic local risk summary for a user/agent pair, including recent signals, warning reasons, highest severity, and blocked status
+- getAgentPurchaseEvidence(userEmail, orderNumber) — get the read-only evidence trail for an agent-initiated order owned by the user
 
 ## ACP Endpoints (Agentic Commerce Protocol, requires API key: X-API-Key header)
 ACP-compatible checkout endpoints at /acp/v1/:
@@ -196,6 +198,12 @@ Agent risk signals are deterministic local records for agent shopping behavior. 
 Signals include cart hold attempts, rapid cart holds, checkout attempts, mandate mismatches, failed checkouts, high-spend attempts, payment-credential failures, and risk-condition blocks.
 AgentRiskCondition blocks repeated mandate mismatches as CRITICAL. Repeated failed checkouts, rapid cart holds, and high-spend attempts produce WARNING signals.
 MCP agents can call `getAgentRiskSummary(userEmail, agentId)` before or after a purchase flow.
+
+## Agent Purchase Evidence
+
+Agent purchase evidence is a read-only assembled record for a single order. It includes order/cart line items, mandate scope and budget, purchase approval state when present, scoped payment credential status and consumption, ACP-aligned checkout status, risk signals, derived eval outcomes, actor timeline entries, and ticket fulfillment artifacts.
+Use REST `GET /api/v1/orders/{orderNumber}/agent-evidence` as the authenticated owner/admin endpoint or MCP `getAgentPurchaseEvidence(userEmail, orderNumber)` for agent self-inspection.
+Email/SMS provider delivery receipts are not persisted; the evidence record marks those dispatch fields as not persisted instead of inventing provider IDs.
 
 ### Mandate Lifecycle
 

--- a/backend/src/test/java/com/mockhub/AgentPurchaseEvidenceIntegrationTest.java
+++ b/backend/src/test/java/com/mockhub/AgentPurchaseEvidenceIntegrationTest.java
@@ -1,0 +1,251 @@
+package com.mockhub;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+
+import com.mockhub.agentapproval.dto.AgentPurchaseApprovalDto;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto;
+import com.mockhub.auth.dto.AuthResponse;
+import com.mockhub.auth.entity.User;
+import com.mockhub.auth.repository.UserRepository;
+import com.mockhub.event.entity.Category;
+import com.mockhub.event.entity.Event;
+import com.mockhub.event.repository.CategoryRepository;
+import com.mockhub.event.repository.EventRepository;
+import com.mockhub.mandate.dto.CreateMandateRequest;
+import com.mockhub.mandate.dto.MandateDto;
+import com.mockhub.mandate.service.MandateService;
+import com.mockhub.mcp.tools.AgentApprovalTools;
+import com.mockhub.mcp.tools.CartTools;
+import com.mockhub.mcp.tools.OrderTools;
+import com.mockhub.order.dto.OrderDto;
+import com.mockhub.paymentcredential.dto.CreatePaymentCredentialRequest;
+import com.mockhub.paymentcredential.dto.PaymentCredentialDto;
+import com.mockhub.paymentcredential.service.PaymentCredentialService;
+import com.mockhub.ticket.entity.Listing;
+import com.mockhub.ticket.entity.Ticket;
+import com.mockhub.ticket.repository.ListingRepository;
+import com.mockhub.ticket.repository.TicketRepository;
+import com.mockhub.venue.entity.Section;
+import com.mockhub.venue.entity.Venue;
+import com.mockhub.venue.repository.VenueRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AgentPurchaseEvidenceIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private MandateService mandateService;
+
+    @Autowired
+    private PaymentCredentialService paymentCredentialService;
+
+    @Autowired
+    private CartTools cartTools;
+
+    @Autowired
+    private OrderTools orderTools;
+
+    @Autowired
+    private AgentApprovalTools agentApprovalTools;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private VenueRepository venueRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private EventRepository eventRepository;
+
+    @Autowired
+    private TicketRepository ticketRepository;
+
+    @Autowired
+    private ListingRepository listingRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("Agent purchase evidence endpoint returns full trail for mandate credential checkout fulfillment flow")
+    void getAgentPurchaseEvidence_givenFullAgentFlow_returnsPopulatedEvidence() throws Exception {
+        String email = "evidence-flow-" + UUID.randomUUID() + "@example.com";
+        AuthResponse auth = registerUser(email, "password123", "Agent", "Evidence");
+        assertThat(auth).isNotNull();
+
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new AssertionError("User not found after registration"));
+        user.setPhone("+15551234567");
+        userRepository.save(user);
+
+        Listing listing = createActiveListing(user);
+        MandateDto mandate = mandateService.createMandate(new CreateMandateRequest(
+                "evidence-agent",
+                email,
+                "PURCHASE",
+                new BigDecimal("500.00"),
+                new BigDecimal("2000.00"),
+                null,
+                null,
+                null,
+                "APPROVAL_REQUIRED",
+                null));
+
+        JsonNode addToCartJson = objectMapper.readTree(
+                cartTools.addToCart(email, listing.getId(), "evidence-agent", mandate.mandateId()));
+        assertThat(addToCartJson.has("error")).isFalse();
+
+        OrderDto pendingOrder = parseOrder(
+                orderTools.checkout(email, "mock", "evidence-agent", mandate.mandateId()));
+
+        AgentPurchaseApprovalDto approval = objectMapper.readValue(agentApprovalTools.proposePurchase(
+                email,
+                "evidence-agent",
+                mandate.mandateId(),
+                "{\"listingId\":" + listing.getId() + "}",
+                "Best available evidence test ticket",
+                pendingOrder.subtotal(),
+                pendingOrder.serviceFee(),
+                pendingOrder.total(),
+                "{\"policyId\":\"default\"}",
+                null), AgentPurchaseApprovalDto.class);
+        AgentPurchaseApprovalDto approved = objectMapper.readValue(
+                agentApprovalTools.approvePurchase(email, approval.approvalId()),
+                AgentPurchaseApprovalDto.class);
+        assertThat(approved.status()).isEqualTo("APPROVED");
+
+        PaymentCredentialDto credential = paymentCredentialService.issueCredential(
+                new CreatePaymentCredentialRequest(
+                        email,
+                        "evidence-agent",
+                        pendingOrder.total(),
+                        "USD",
+                        "ONE_TIME",
+                        "mock",
+                        null));
+
+        OrderDto confirmedOrder = parseOrder(orderTools.confirmOrder(
+                email,
+                pendingOrder.orderNumber(),
+                "evidence-agent",
+                mandate.mandateId(),
+                null,
+                credential.credentialId(),
+                approval.approvalId()));
+        assertThat(confirmedOrder.status()).isEqualTo("CONFIRMED");
+
+        ResponseEntity<AgentPurchaseEvidenceDto> response = restTemplate.exchange(
+                "/api/v1/orders/" + confirmedOrder.orderNumber() + "/agent-evidence",
+                HttpMethod.GET,
+                new HttpEntity<>(authHeaders(auth.accessToken())),
+                AgentPurchaseEvidenceDto.class);
+
+        assertThat(response.getStatusCode().is2xxSuccessful()).isTrue();
+        AgentPurchaseEvidenceDto evidence = response.getBody();
+        assertThat(evidence).isNotNull();
+        assertThat(evidence.mandate().mandateId()).isEqualTo(mandate.mandateId());
+        assertThat(evidence.approval().approvalId()).isEqualTo(approval.approvalId());
+        assertThat(evidence.approval().status()).isEqualTo("COMPLETED");
+        assertThat(evidence.paymentCredential().credentialId()).isEqualTo(credential.credentialId());
+        assertThat(evidence.paymentCredential().consumedByOrderNumber()).isEqualTo(confirmedOrder.orderNumber());
+        assertThat(evidence.checkout().checkoutId()).isEqualTo(confirmedOrder.orderNumber());
+        assertThat(evidence.fulfillment().ticketPdfAvailable()).isTrue();
+        assertThat(evidence.fulfillment().emailDispatch().status()).isEqualTo("NOT_PERSISTED");
+        assertThat(evidence.fulfillment().smsDispatch().status()).isEqualTo("NOT_PERSISTED");
+        assertThat(evidence.fulfillment().ticketArtifacts()).hasSize(1);
+        assertThat(evidence.riskSignals())
+                .extracting(AgentPurchaseEvidenceDto.AgentPurchaseEvidenceRiskSignalDto::signalType)
+                .contains("CART_HOLD_ATTEMPT", "CHECKOUT_ATTEMPT");
+        assertThat(evidence.evalOutcomes())
+                .extracting(AgentPurchaseEvidenceDto.AgentPurchaseEvidenceEvalOutcomeDto::ruleName)
+                .contains("mandate-authorization", "purchase-approval", "payment-credential", "agent-risk");
+        assertThat(evidence.actorTimeline())
+                .extracting(AgentPurchaseEvidenceDto.AgentPurchaseEvidenceActorStepDto::step)
+                .contains("ORDER_CREATED", "ORDER_CONFIRMED", "PURCHASE_APPROVAL_COMPLETED");
+    }
+
+    private OrderDto parseOrder(String json) throws Exception {
+        JsonNode node = objectMapper.readTree(json);
+        assertThat(node.has("error")).isFalse();
+        JsonNode orderNode = node.has("order") ? node.get("order") : node;
+        return objectMapper.treeToValue(orderNode, OrderDto.class);
+    }
+
+    private Listing createActiveListing(User seller) {
+        Venue venue = new Venue();
+        venue.setName("Evidence Arena");
+        venue.setSlug("evidence-arena-" + UUID.randomUUID());
+        venue.setAddressLine1("123 Test St");
+        venue.setCity("Test City");
+        venue.setState("TS");
+        venue.setZipCode("12345");
+        venue.setCountry("US");
+        venue.setCapacity(1000);
+        venue.setVenueType("ARENA");
+        venue = venueRepository.save(venue);
+
+        Section section = new Section();
+        section.setVenue(venue);
+        section.setName("Floor");
+        section.setSectionType("GENERAL");
+        section.setCapacity(100);
+        section.setSortOrder(1);
+        venue.getSections().add(section);
+        venue = venueRepository.save(venue);
+        section = venue.getSections().getFirst();
+
+        Category category = new Category();
+        category.setName("Evidence Music " + UUID.randomUUID());
+        category.setSlug("evidence-music-" + UUID.randomUUID());
+        category.setSortOrder(99);
+        category = categoryRepository.save(category);
+
+        Event event = new Event();
+        event.setVenue(venue);
+        event.setCategory(category);
+        event.setName("Evidence Concert");
+        event.setSlug("evidence-concert-" + UUID.randomUUID());
+        event.setEventDate(Instant.now().plus(30, ChronoUnit.DAYS));
+        event.setStatus("ACTIVE");
+        event.setBasePrice(new BigDecimal("75.00"));
+        event.setTotalTickets(100);
+        event.setAvailableTickets(100);
+        event.setFeatured(false);
+        event = eventRepository.save(event);
+
+        Ticket ticket = new Ticket();
+        ticket.setEvent(event);
+        ticket.setSection(section);
+        ticket.setTicketType("STANDARD");
+        ticket.setFaceValue(new BigDecimal("75.00"));
+        ticket.setStatus("LISTED");
+        ticket.setBarcode(UUID.randomUUID().toString().substring(0, 12));
+        ticket = ticketRepository.save(ticket);
+
+        Listing listing = new Listing();
+        listing.setTicket(ticket);
+        listing.setEvent(event);
+        listing.setSeller(seller);
+        listing.setListedPrice(new BigDecimal("85.00"));
+        listing.setComputedPrice(new BigDecimal("85.00"));
+        listing.setPriceMultiplier(new BigDecimal("1.133"));
+        listing.setStatus("ACTIVE");
+        listing.setListedAt(Instant.now());
+        return listingRepository.save(listing);
+    }
+}

--- a/backend/src/test/java/com/mockhub/agentpurchaseevidence/controller/AgentPurchaseEvidenceControllerTest.java
+++ b/backend/src/test/java/com/mockhub/agentpurchaseevidence/controller/AgentPurchaseEvidenceControllerTest.java
@@ -1,0 +1,92 @@
+package com.mockhub.agentpurchaseevidence.controller;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto;
+import com.mockhub.agentpurchaseevidence.service.AgentPurchaseEvidenceService;
+import com.mockhub.auth.entity.Role;
+import com.mockhub.auth.entity.User;
+import com.mockhub.auth.security.SecurityUser;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentPurchaseEvidenceControllerTest {
+
+    private static final String ORDER_NUMBER = "MH-20260522-0001";
+
+    @Mock
+    private AgentPurchaseEvidenceService evidenceService;
+
+    private AgentPurchaseEvidenceController controller;
+
+    @BeforeEach
+    void setUp() {
+        controller = new AgentPurchaseEvidenceController(evidenceService);
+    }
+
+    @Test
+    @DisplayName("getEvidence - owner principal - delegates with admin false")
+    void getEvidence_givenOwnerPrincipal_delegatesWithAdminFalse() {
+        SecurityUser securityUser = securityUser("buyer@example.com", Set.of("ROLE_BUYER"));
+        AgentPurchaseEvidenceDto dto = evidenceDto("buyer@example.com");
+        when(evidenceService.getEvidence(ORDER_NUMBER, "buyer@example.com", false)).thenReturn(dto);
+
+        ResponseEntity<AgentPurchaseEvidenceDto> response = controller.getEvidence(securityUser, ORDER_NUMBER);
+
+        assertThat(response.getBody()).isSameAs(dto);
+        verify(evidenceService).getEvidence(ORDER_NUMBER, "buyer@example.com", false);
+    }
+
+    @Test
+    @DisplayName("getEvidence - admin principal - delegates with admin true")
+    void getEvidence_givenAdminPrincipal_delegatesWithAdminTrue() {
+        SecurityUser securityUser = securityUser("admin@example.com", Set.of("ROLE_ADMIN"));
+        AgentPurchaseEvidenceDto dto = evidenceDto("buyer@example.com");
+        when(evidenceService.getEvidence(ORDER_NUMBER, "admin@example.com", true)).thenReturn(dto);
+
+        ResponseEntity<AgentPurchaseEvidenceDto> response = controller.getEvidence(securityUser, ORDER_NUMBER);
+
+        assertThat(response.getBody()).isSameAs(dto);
+        verify(evidenceService).getEvidence(ORDER_NUMBER, "admin@example.com", true);
+    }
+
+    private SecurityUser securityUser(String email, Set<String> roles) {
+        User user = new User();
+        user.setId(1L);
+        user.setEmail(email);
+        user.setPasswordHash("hash");
+        user.setRoles(roles.stream().map(Role::new).collect(java.util.stream.Collectors.toSet()));
+        return new SecurityUser(user);
+    }
+
+    private AgentPurchaseEvidenceDto evidenceDto(String userEmail) {
+        return new AgentPurchaseEvidenceDto(
+                ORDER_NUMBER,
+                userEmail,
+                "agent-1",
+                "CONFIRMED",
+                Instant.now(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(),
+                List.of(),
+                List.of());
+    }
+}

--- a/backend/src/test/java/com/mockhub/agentpurchaseevidence/service/AgentPurchaseEvidenceServiceTest.java
+++ b/backend/src/test/java/com/mockhub/agentpurchaseevidence/service/AgentPurchaseEvidenceServiceTest.java
@@ -1,0 +1,303 @@
+package com.mockhub.agentpurchaseevidence.service;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.mockhub.agentapproval.entity.AgentPurchaseApproval;
+import com.mockhub.agentapproval.entity.AgentPurchaseApprovalStatus;
+import com.mockhub.agentapproval.repository.AgentPurchaseApprovalRepository;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto;
+import com.mockhub.agentrisk.entity.AgentRiskSignal;
+import com.mockhub.agentrisk.entity.AgentRiskSignalType;
+import com.mockhub.agentrisk.repository.AgentRiskSignalRepository;
+import com.mockhub.auth.entity.User;
+import com.mockhub.common.exception.UnauthorizedException;
+import com.mockhub.eval.dto.EvalSeverity;
+import com.mockhub.event.entity.Event;
+import com.mockhub.mandate.entity.Mandate;
+import com.mockhub.mandate.repository.MandateRepository;
+import com.mockhub.order.entity.Order;
+import com.mockhub.order.entity.OrderItem;
+import com.mockhub.order.entity.OrderStatus;
+import com.mockhub.order.repository.OrderRepository;
+import com.mockhub.paymentcredential.entity.PaymentCredential;
+import com.mockhub.paymentcredential.entity.PaymentCredentialStatus;
+import com.mockhub.paymentcredential.entity.PaymentCredentialUsage;
+import com.mockhub.paymentcredential.repository.PaymentCredentialRepository;
+import com.mockhub.ticket.entity.Listing;
+import com.mockhub.ticket.entity.Ticket;
+import com.mockhub.ticket.service.TicketSigningService;
+import com.mockhub.venue.entity.Section;
+import com.mockhub.venue.entity.Venue;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentPurchaseEvidenceServiceTest {
+
+    private static final String ORDER_NUMBER = "MH-20260522-0001";
+    private static final String USER_EMAIL = "buyer@example.com";
+    private static final String AGENT_ID = "agent-1";
+    private static final String MANDATE_ID = "mandate-1";
+
+    @Mock
+    private OrderRepository orderRepository;
+
+    @Mock
+    private MandateRepository mandateRepository;
+
+    @Mock
+    private AgentPurchaseApprovalRepository approvalRepository;
+
+    @Mock
+    private PaymentCredentialRepository paymentCredentialRepository;
+
+    @Mock
+    private AgentRiskSignalRepository agentRiskSignalRepository;
+
+    @Mock
+    private TicketSigningService ticketSigningService;
+
+    private AgentPurchaseEvidenceService evidenceService;
+
+    @BeforeEach
+    void setUp() {
+        evidenceService = new AgentPurchaseEvidenceService(
+                orderRepository,
+                mandateRepository,
+                approvalRepository,
+                paymentCredentialRepository,
+                agentRiskSignalRepository,
+                ticketSigningService,
+                "https://mockhub.example.com");
+    }
+
+    @Test
+    @DisplayName("getEvidence - complete agent order - returns populated evidence trail")
+    void getEvidence_givenCompleteAgentOrder_returnsPopulatedEvidenceTrail() {
+        Order order = confirmedAgentOrder();
+        Mandate mandate = mandate();
+        AgentPurchaseApproval approval = approval();
+        PaymentCredential credential = consumedCredential();
+        AgentRiskSignal cartSignal = riskSignal(
+                1L, AgentRiskSignalType.CART_HOLD_ATTEMPT, EvalSeverity.INFO, "ADD_TO_CART", "LISTING", "10");
+        AgentRiskSignal checkoutSignal = riskSignal(
+                2L, AgentRiskSignalType.CHECKOUT_ATTEMPT, EvalSeverity.INFO, "CONFIRM_ORDER", "ORDER", ORDER_NUMBER);
+
+        when(orderRepository.findByOrderNumber(ORDER_NUMBER)).thenReturn(Optional.of(order));
+        when(mandateRepository.findByMandateId(MANDATE_ID)).thenReturn(Optional.of(mandate));
+        when(approvalRepository.findFirstByFinalOrderNumberOrderByCreatedAtDesc(ORDER_NUMBER))
+                .thenReturn(Optional.of(approval));
+        when(paymentCredentialRepository.findFirstByConsumedByOrderNumberOrderByConsumedAtDesc(ORDER_NUMBER))
+                .thenReturn(Optional.of(credential));
+        when(agentRiskSignalRepository.findByUserEmailAndAgentIdAndCreatedAtBetweenOrderByCreatedAtAsc(
+                any(), any(), any(), any()))
+                .thenReturn(List.of(cartSignal, checkoutSignal));
+        when(ticketSigningService.generateOrderViewToken(ORDER_NUMBER)).thenReturn("order-view-token");
+
+        AgentPurchaseEvidenceDto evidence = evidenceService.getEvidence(ORDER_NUMBER, USER_EMAIL, false);
+
+        assertThat(evidence.orderNumber()).isEqualTo(ORDER_NUMBER);
+        assertThat(evidence.mandate().mandateId()).isEqualTo(MANDATE_ID);
+        assertThat(evidence.approval().status()).isEqualTo("COMPLETED");
+        assertThat(evidence.paymentCredential().status()).isEqualTo("CONSUMED");
+        assertThat(evidence.checkout().acpStatus()).isEqualTo("COMPLETED");
+        assertThat(evidence.fulfillment().ticketPdfAvailable()).isTrue();
+        assertThat(evidence.fulfillment().publicTicketViewUrl()).contains("order-view-token");
+        assertThat(evidence.fulfillment().ticketArtifacts()).hasSize(1);
+        assertThat(evidence.riskSignals()).hasSize(2);
+        assertThat(evidence.evalOutcomes())
+                .extracting(AgentPurchaseEvidenceDto.AgentPurchaseEvidenceEvalOutcomeDto::ruleName)
+                .contains("mandate-authorization", "payment-credential", "agent-risk");
+        assertThat(evidence.actorTimeline())
+                .extracting(AgentPurchaseEvidenceDto.AgentPurchaseEvidenceActorStepDto::step)
+                .contains("MANDATE_CREATED", "ORDER_CONFIRMED", "PAYMENT_CREDENTIAL_CONSUMED");
+    }
+
+    @Test
+    @DisplayName("getEvidence - non-owner without admin role - throws UnauthorizedException")
+    void getEvidence_givenNonOwnerWithoutAdmin_throwsUnauthorizedException() {
+        Order order = confirmedAgentOrder();
+        when(orderRepository.findByOrderNumber(ORDER_NUMBER)).thenReturn(Optional.of(order));
+
+        assertThatThrownBy(() -> evidenceService.getEvidence(ORDER_NUMBER, "other@example.com", false))
+                .isInstanceOf(UnauthorizedException.class)
+                .hasMessageContaining("agent purchase evidence");
+    }
+
+    @Test
+    @DisplayName("getEvidence - admin requester - bypasses owner check")
+    void getEvidence_givenAdminRequester_bypassesOwnerCheck() {
+        Order order = pendingAgentOrder();
+        when(orderRepository.findByOrderNumber(ORDER_NUMBER)).thenReturn(Optional.of(order));
+        when(mandateRepository.findByMandateId(MANDATE_ID)).thenReturn(Optional.empty());
+        when(approvalRepository.findFirstByFinalOrderNumberOrderByCreatedAtDesc(ORDER_NUMBER))
+                .thenReturn(Optional.empty());
+        when(paymentCredentialRepository.findFirstByConsumedByOrderNumberOrderByConsumedAtDesc(ORDER_NUMBER))
+                .thenReturn(Optional.empty());
+        when(agentRiskSignalRepository.findByUserEmailAndAgentIdAndCreatedAtBetweenOrderByCreatedAtAsc(
+                any(), any(), any(), any()))
+                .thenReturn(List.of());
+
+        AgentPurchaseEvidenceDto evidence = evidenceService.getEvidence(ORDER_NUMBER, "admin@example.com", true);
+
+        assertThat(evidence.mandate()).isNull();
+        assertThat(evidence.paymentCredential()).isNull();
+        assertThat(evidence.fulfillment().ticketPdfAvailable()).isFalse();
+        assertThat(evidence.evalOutcomes())
+                .anyMatch(outcome -> outcome.ruleName().equals("mandate-authorization")
+                        && outcome.status().equals("WARNING"));
+        verify(orderRepository).findByOrderNumber(ORDER_NUMBER);
+    }
+
+    private Order confirmedAgentOrder() {
+        Order order = pendingAgentOrder();
+        order.setStatus(OrderStatus.CONFIRMED);
+        order.setConfirmedAt(Instant.parse("2026-05-22T15:00:00Z"));
+        order.setPaymentIntentId("mock_pi_123");
+        order.setItems(new ArrayList<>(List.of(orderItem(order))));
+        return order;
+    }
+
+    private Order pendingAgentOrder() {
+        User user = user();
+        Order order = new Order();
+        order.setId(99L);
+        order.setUser(user);
+        order.setOrderNumber(ORDER_NUMBER);
+        order.setStatus(OrderStatus.PENDING);
+        order.setSubtotal(new BigDecimal("85.00"));
+        order.setServiceFee(new BigDecimal("8.50"));
+        order.setTotal(new BigDecimal("93.50"));
+        order.setPaymentMethod("mock");
+        order.setAgentId(AGENT_ID);
+        order.setMandateId(MANDATE_ID);
+        order.setCreatedAt(Instant.parse("2026-05-22T14:55:00Z"));
+        order.setUpdatedAt(Instant.parse("2026-05-22T14:56:00Z"));
+        return order;
+    }
+
+    private OrderItem orderItem(Order order) {
+        Venue venue = new Venue();
+        venue.setName("Test Arena");
+
+        Event event = new Event();
+        event.setName("Test Concert");
+        event.setSlug("test-concert");
+        event.setEventDate(Instant.parse("2026-06-22T00:00:00Z"));
+        event.setVenue(venue);
+
+        Listing listing = new Listing();
+        listing.setId(10L);
+        listing.setEvent(event);
+
+        Section section = new Section();
+        section.setName("Floor");
+
+        Ticket ticket = new Ticket();
+        ticket.setId(20L);
+        ticket.setSection(section);
+        ticket.setTicketType("STANDARD");
+
+        OrderItem item = new OrderItem();
+        item.setId(30L);
+        item.setOrder(order);
+        item.setListing(listing);
+        item.setTicket(ticket);
+        item.setPricePaid(new BigDecimal("85.00"));
+        return item;
+    }
+
+    private User user() {
+        User user = new User();
+        user.setId(1L);
+        user.setEmail(USER_EMAIL);
+        user.setPasswordHash("hash");
+        user.setPhone("+15551234567");
+        return user;
+    }
+
+    private Mandate mandate() {
+        Mandate mandate = new Mandate();
+        mandate.setMandateId(MANDATE_ID);
+        mandate.setAgentId(AGENT_ID);
+        mandate.setUserEmail(USER_EMAIL);
+        mandate.setScope("PURCHASE");
+        mandate.setMaxSpendPerTransaction(new BigDecimal("500.00"));
+        mandate.setMaxSpendTotal(new BigDecimal("2000.00"));
+        mandate.setTotalSpent(new BigDecimal("93.50"));
+        mandate.setApprovalMode("APPROVAL_REQUIRED");
+        mandate.setStatus("ACTIVE");
+        mandate.setCreatedAt(Instant.parse("2026-05-22T14:50:00Z"));
+        return mandate;
+    }
+
+    private AgentPurchaseApproval approval() {
+        AgentPurchaseApproval approval = new AgentPurchaseApproval();
+        approval.setApprovalId("approval-1");
+        approval.setUserEmail(USER_EMAIL);
+        approval.setAgentId(AGENT_ID);
+        approval.setMandateId(MANDATE_ID);
+        approval.setStatus(AgentPurchaseApprovalStatus.COMPLETED);
+        approval.setProposedOrderSnapshot("{\"listingId\":10}");
+        approval.setSubtotal(new BigDecimal("85.00"));
+        approval.setServiceFee(new BigDecimal("8.50"));
+        approval.setTotal(new BigDecimal("93.50"));
+        approval.setProposedAt(Instant.parse("2026-05-22T14:57:00Z"));
+        approval.setApprovedAt(Instant.parse("2026-05-22T14:58:00Z"));
+        approval.setCompletedAt(Instant.parse("2026-05-22T15:00:01Z"));
+        approval.setFinalOrderNumber(ORDER_NUMBER);
+        approval.setCreatedAt(Instant.parse("2026-05-22T14:57:00Z"));
+        return approval;
+    }
+
+    private PaymentCredential consumedCredential() {
+        PaymentCredential credential = new PaymentCredential();
+        credential.setCredentialId("credential-1");
+        credential.setUserEmail(USER_EMAIL);
+        credential.setAgentId(AGENT_ID);
+        credential.setAllowedMerchant("MOCKHUB");
+        credential.setMaxAmount(new BigDecimal("100.00"));
+        credential.setCurrency("USD");
+        credential.setUsage(PaymentCredentialUsage.ONE_TIME);
+        credential.setStatus(PaymentCredentialStatus.CONSUMED);
+        credential.setBackingPaymentMethod("mock");
+        credential.setConsumedAt(Instant.parse("2026-05-22T14:59:59Z"));
+        credential.setConsumedByOrderNumber(ORDER_NUMBER);
+        credential.setCreatedAt(Instant.parse("2026-05-22T14:58:30Z"));
+        return credential;
+    }
+
+    private AgentRiskSignal riskSignal(Long id, AgentRiskSignalType type, EvalSeverity severity,
+                                       String actionType, String resourceType, String resourceId) {
+        AgentRiskSignal signal = new AgentRiskSignal();
+        signal.setId(id);
+        signal.setUserEmail(USER_EMAIL);
+        signal.setAgentId(AGENT_ID);
+        signal.setSignalType(type);
+        signal.setSeverity(severity);
+        signal.setActionType(actionType);
+        signal.setResourceType(resourceType);
+        signal.setResourceId(resourceId);
+        signal.setOrderNumber(ORDER_NUMBER.equals(resourceId) ? ORDER_NUMBER : null);
+        signal.setMandateId(MANDATE_ID);
+        signal.setAmount(new BigDecimal("93.50"));
+        signal.setMessage(type.name());
+        signal.setCreatedAt(Instant.parse("2026-05-22T14:56:00Z"));
+        return signal;
+    }
+}

--- a/backend/src/test/java/com/mockhub/agentpurchaseevidence/service/AgentPurchaseEvidenceServiceTest.java
+++ b/backend/src/test/java/com/mockhub/agentpurchaseevidence/service/AgentPurchaseEvidenceServiceTest.java
@@ -119,6 +119,8 @@ class AgentPurchaseEvidenceServiceTest {
         assertThat(evidence.fulfillment().ticketPdfAvailable()).isTrue();
         assertThat(evidence.fulfillment().publicTicketViewUrl()).contains("order-view-token");
         assertThat(evidence.fulfillment().ticketArtifacts()).hasSize(1);
+        assertThat(evidence.fulfillment().ticketArtifacts().getFirst().qrCodeUrl())
+                .startsWith("/api/v1/tickets/");
         assertThat(evidence.riskSignals()).hasSize(2);
         assertThat(evidence.evalOutcomes())
                 .extracting(AgentPurchaseEvidenceDto.AgentPurchaseEvidenceEvalOutcomeDto::ruleName)
@@ -126,6 +128,41 @@ class AgentPurchaseEvidenceServiceTest {
         assertThat(evidence.actorTimeline())
                 .extracting(AgentPurchaseEvidenceDto.AgentPurchaseEvidenceActorStepDto::step)
                 .contains("MANDATE_CREATED", "ORDER_CONFIRMED", "PAYMENT_CREDENTIAL_CONSUMED");
+    }
+
+    @Test
+    @DisplayName("getEvidence - risk resourceId matches order - includes only order-specific signals")
+    void getEvidence_givenRiskResourceIdMatchesOrder_includesOnlyOrderSpecificSignals() {
+        Order order = confirmedAgentOrder();
+        AgentRiskSignal blockedConfirmation = riskSignal(
+                3L, AgentRiskSignalType.MANDATE_MISMATCH, EvalSeverity.CRITICAL,
+                "ACP_CONFIRMATION_VALIDATION", "ORDER", ORDER_NUMBER);
+        blockedConfirmation.setOrderNumber(null);
+        AgentRiskSignal genericCheckout = riskSignal(
+                4L, AgentRiskSignalType.CHECKOUT_ATTEMPT, EvalSeverity.INFO,
+                "CHECKOUT", "ORDER", null);
+        genericCheckout.setOrderNumber(null);
+        genericCheckout.setResourceId(null);
+
+        when(orderRepository.findByOrderNumber(ORDER_NUMBER)).thenReturn(Optional.of(order));
+        when(mandateRepository.findByMandateId(MANDATE_ID)).thenReturn(Optional.empty());
+        when(approvalRepository.findFirstByFinalOrderNumberOrderByCreatedAtDesc(ORDER_NUMBER))
+                .thenReturn(Optional.empty());
+        when(paymentCredentialRepository.findFirstByConsumedByOrderNumberOrderByConsumedAtDesc(ORDER_NUMBER))
+                .thenReturn(Optional.empty());
+        when(agentRiskSignalRepository.findByUserEmailAndAgentIdAndCreatedAtBetweenOrderByCreatedAtAsc(
+                any(), any(), any(), any()))
+                .thenReturn(List.of(blockedConfirmation, genericCheckout));
+        when(ticketSigningService.generateOrderViewToken(ORDER_NUMBER)).thenReturn("order-view-token");
+
+        AgentPurchaseEvidenceDto evidence = evidenceService.getEvidence(ORDER_NUMBER, USER_EMAIL, false);
+
+        assertThat(evidence.riskSignals())
+                .extracting(AgentPurchaseEvidenceDto.AgentPurchaseEvidenceRiskSignalDto::id)
+                .containsExactly(3L);
+        assertThat(evidence.evalOutcomes())
+                .anyMatch(outcome -> outcome.ruleName().equals("mandate-authorization")
+                        && outcome.status().equals("BLOCKED"));
     }
 
     @Test

--- a/backend/src/test/java/com/mockhub/config/McpConfigTest.java
+++ b/backend/src/test/java/com/mockhub/config/McpConfigTest.java
@@ -8,6 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.ai.tool.ToolCallbackProvider;
 
 import com.mockhub.mcp.tools.AgentApprovalTools;
+import com.mockhub.mcp.tools.AgentPurchaseEvidenceTools;
 import com.mockhub.mcp.tools.AgentRiskTools;
 import com.mockhub.mcp.tools.CartTools;
 import com.mockhub.mcp.tools.EventTools;
@@ -45,6 +46,9 @@ class McpConfigTest {
     @Mock
     private AgentRiskTools agentRiskTools;
 
+    @Mock
+    private AgentPurchaseEvidenceTools agentPurchaseEvidenceTools;
+
     @Test
     @DisplayName("mcpToolCallbackProvider - creates provider with all tool objects")
     void mcpToolCallbackProvider_createsProviderWithAllToolObjects() {
@@ -52,9 +56,9 @@ class McpConfigTest {
 
         ToolCallbackProvider provider = config.mcpToolCallbackProvider(
                 eventTools, pricingTools, cartTools, orderTools, mandateTools, agentApprovalTools,
-                paymentCredentialTools, agentRiskTools);
+                paymentCredentialTools, agentRiskTools, agentPurchaseEvidenceTools);
 
-        assertEquals(33, provider.getToolCallbacks().length,
+        assertEquals(34, provider.getToolCallbacks().length,
                 "All MCP tool methods should be registered");
     }
 }

--- a/backend/src/test/java/com/mockhub/mcp/tools/AgentPurchaseEvidenceToolsTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/tools/AgentPurchaseEvidenceToolsTest.java
@@ -13,6 +13,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto.AgentPurchaseEvidenceFulfillmentDto;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto.AgentPurchaseEvidenceTicketArtifactDto;
 import com.mockhub.agentpurchaseevidence.service.AgentPurchaseEvidenceService;
 import com.mockhub.ai.service.ChatContext;
 
@@ -52,6 +54,10 @@ class AgentPurchaseEvidenceToolsTest {
 
         assertThat(result).contains("\"orderNumber\":\"" + ORDER_NUMBER + "\"");
         assertThat(result).contains("\"agentId\":\"agent-1\"");
+        assertThat(result).contains("\"ticketPdfUrl\":\"/api/v1/orders/" + ORDER_NUMBER);
+        assertThat(result).contains("\"publicTicketViewUrl\":null");
+        assertThat(result).contains("\"qrCodeUrl\":null");
+        assertThat(result).doesNotContain("order-view-token");
         verify(evidenceService).getEvidenceForUser("buyer@example.com", ORDER_NUMBER);
     }
 
@@ -91,7 +97,20 @@ class AgentPurchaseEvidenceToolsTest {
                 null,
                 null,
                 null,
-                null,
+                new AgentPurchaseEvidenceFulfillmentDto(
+                        true,
+                        "https://mockhub.example/tickets/view?token=order-view-token",
+                        "order-view",
+                        "mockhub.ticket.signing-secret",
+                        null,
+                        null,
+                        List.of(new AgentPurchaseEvidenceTicketArtifactDto(
+                                10L,
+                                20L,
+                                "/api/v1/orders/" + ORDER_NUMBER + "/tickets/10/download",
+                                "/api/v1/tickets/" + ORDER_NUMBER + "/10/qr?token=order-view-token",
+                                "ticket-verification",
+                                null))),
                 List.of(),
                 List.of(),
                 List.of());

--- a/backend/src/test/java/com/mockhub/mcp/tools/AgentPurchaseEvidenceToolsTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/tools/AgentPurchaseEvidenceToolsTest.java
@@ -1,0 +1,99 @@
+package com.mockhub.mcp.tools;
+
+import java.time.Instant;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mockhub.agentpurchaseevidence.dto.AgentPurchaseEvidenceDto;
+import com.mockhub.agentpurchaseevidence.service.AgentPurchaseEvidenceService;
+import com.mockhub.ai.service.ChatContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class AgentPurchaseEvidenceToolsTest {
+
+    private static final String ORDER_NUMBER = "MH-20260522-0001";
+
+    @Mock
+    private AgentPurchaseEvidenceService evidenceService;
+
+    private AgentPurchaseEvidenceTools tools;
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.findAndRegisterModules();
+        tools = new AgentPurchaseEvidenceTools(evidenceService, objectMapper);
+    }
+
+    @AfterEach
+    void tearDown() {
+        ChatContext.clear();
+    }
+
+    @Test
+    @DisplayName("getAgentPurchaseEvidence - valid request - returns evidence JSON")
+    void getAgentPurchaseEvidence_givenValidRequest_returnsEvidenceJson() {
+        when(evidenceService.getEvidenceForUser("buyer@example.com", ORDER_NUMBER))
+                .thenReturn(evidenceDto("buyer@example.com"));
+
+        String result = tools.getAgentPurchaseEvidence("buyer@example.com", ORDER_NUMBER);
+
+        assertThat(result).contains("\"orderNumber\":\"" + ORDER_NUMBER + "\"");
+        assertThat(result).contains("\"agentId\":\"agent-1\"");
+        verify(evidenceService).getEvidenceForUser("buyer@example.com", ORDER_NUMBER);
+    }
+
+    @Test
+    @DisplayName("getAgentPurchaseEvidence - ChatContext overrides userEmail")
+    void getAgentPurchaseEvidence_givenChatContext_usesAuthenticatedEmail() {
+        ChatContext.setAuthenticatedEmail("real@example.com");
+        when(evidenceService.getEvidenceForUser("real@example.com", ORDER_NUMBER))
+                .thenReturn(evidenceDto("real@example.com"));
+
+        tools.getAgentPurchaseEvidence("attacker@example.com", ORDER_NUMBER);
+
+        verify(evidenceService).getEvidenceForUser("real@example.com", ORDER_NUMBER);
+    }
+
+    @Test
+    @DisplayName("getAgentPurchaseEvidence - service failure - returns error JSON")
+    void getAgentPurchaseEvidence_givenServiceFailure_returnsErrorJson() {
+        when(evidenceService.getEvidenceForUser("buyer@example.com", ORDER_NUMBER))
+                .thenThrow(new IllegalArgumentException("Order number is required"));
+
+        String result = tools.getAgentPurchaseEvidence("buyer@example.com", ORDER_NUMBER);
+
+        assertThat(result).contains("\"error\"");
+        assertThat(result).contains("Failed to get agent purchase evidence");
+    }
+
+    private AgentPurchaseEvidenceDto evidenceDto(String userEmail) {
+        return new AgentPurchaseEvidenceDto(
+                ORDER_NUMBER,
+                userEmail,
+                "agent-1",
+                "CONFIRMED",
+                Instant.now(),
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                List.of(),
+                List.of(),
+                List.of());
+    }
+}

--- a/docs/agentic-commerce.md
+++ b/docs/agentic-commerce.md
@@ -27,7 +27,7 @@ Agentic commerce in MockHub is organized into three layers, each independently v
 
 ### Tool Inventory
 
-MockHub exposes 33 MCP tools across 8 tool classes:
+MockHub exposes 34 MCP tools across 9 tool classes:
 
 | Tool Class | Tools | Purpose |
 |---|---|---|
@@ -39,6 +39,7 @@ MockHub exposes 33 MCP tools across 8 tool classes:
 | **AgentApprovalTools** | `proposePurchase`, `approvePurchase`, `denyPurchase`, `listPurchaseApprovals` | Purchase approval audit trail |
 | **PaymentCredentialTools** | `issuePaymentCredential`, `listPaymentCredentials`, `revokePaymentCredential` | Scoped payment authority |
 | **AgentRiskTools** | `getAgentRiskSummary` | Deterministic local risk and abuse visibility |
+| **AgentPurchaseEvidenceTools** | `getAgentPurchaseEvidence` | Read-only purchase evidence trail for completed agent flows |
 
 ### The Complete Purchase Flow
 
@@ -71,6 +72,11 @@ An agent can now execute a full purchase on behalf of a user:
    → Marks order CONFIRMED only after successful payment confirmation
    → Records mandate spend once, updates ticket status to SOLD, triggers SMS + email
    → Returns confirmed OrderDto with any risk warnings
+
+5. getAgentPurchaseEvidence(userEmail="buyer@example.com",
+                            orderNumber="MH-20260323-0001")
+   → Returns the read-only mandate, approval, payment credential, checkout, risk,
+     eval, actor timeline, and fulfillment evidence trail for the order owner
 ```
 
 ### Purchase Approval Records
@@ -120,6 +126,27 @@ The initial model lives in `com.mockhub.agentrisk` and records:
 `AgentRiskCondition` reads the recent signal window during MCP and ACP purchase flows. Repeated mandate mismatches become a CRITICAL eval failure and block the action. Repeated failed checkouts, rapid cart holds, and high-spend attempts remain WARNING-level signals that are returned to MCP agents alongside the normal cart or order payload. Agents can also call `getAgentRiskSummary(userEmail, agentId)` to inspect the recent signals, warning reasons, highest severity, and blocked status.
 
 This is deliberately smaller than a production fraud stack. The teaching point is the boundary: authorization says whether the agent is allowed to act, payment credentials say whether it can pay, and risk signals describe whether the pattern of behavior still looks acceptable.
+
+### Agent Purchase Evidence Trails
+
+Agentic checkout adds more proof obligations than traditional checkout. A normal MockHub order needs buyer, cart, payment, ticket, and notification evidence. An agent order also needs to show which agent acted, what mandate authorized it, whether a user approval record was required and completed, which scoped payment credential paid, what risk signals were recorded, and which eval conditions passed, warned, or blocked.
+
+MockHub exposes that assembled record through:
+
+- `GET /api/v1/orders/{orderNumber}/agent-evidence` for the authenticated order owner or an admin.
+- MCP `getAgentPurchaseEvidence(userEmail, orderNumber)` for agent self-inspection. Website chat calls still use `ChatContext` so the authenticated user's email overrides any LLM-supplied email.
+
+The evidence service is intentionally read-only. It assembles existing durable records from `Order`, `Mandate`, `AgentPurchaseApproval`, `PaymentCredential`, and `AgentRiskSignal`, then derives ACP-aligned checkout status and fulfillment artifact links. Missing optional pieces are returned as `null` or empty lists rather than errors, because some legitimate orders use `AUTO_PURCHASE`, skip scoped credentials, or predate risk-signal persistence.
+
+| Evidence area | Traditional checkout | Agent checkout evidence |
+|---|---|---|
+| Authority | Authenticated buyer owns the cart/order | Buyer owner plus `agentId`, mandate scope, budget, expiry, and approval mode |
+| Human approval | Not separately modeled | Optional/required `AgentPurchaseApproval` record with proposal, decision, and final order |
+| Payment | Payment method and payment intent | Payment method plus optional scoped credential status and consumption state |
+| Risk/eval | Standard validation failures | Persisted local risk signals plus derived eval outcomes such as mandate authorization, purchase approval, payment credential, and agent risk |
+| Fulfillment | PDF tickets, QR verification, email/SMS notification attempts | Same fulfillment artifacts, attached to an actor timeline for the agent purchase flow |
+
+This fills one of the UCP-readiness gaps noted below: MockHub still does not publish a UCP profile or versioned UCP service envelope, but it can now explain the evidence behind an agent checkout in a single owner-scoped record.
 
 ### Key Design: `findTickets` — The Compound Search Tool
 
@@ -412,10 +439,10 @@ Coverage labels in this table describe MockHub surfaces that exist today. They d
 | Catalog and offer discovery | MCP `searchEvents`, `findTickets`, `compareTickets`; ACP `GET /catalog` and `GET /listings`; REST event/listing APIs | Implemented | Agents can discover products and actionable ticket offers through both MCP and ACP-shaped endpoints. |
 | Cart lifecycle | MCP cart tools, REST cart API, ACP checkout creation/update flow | Implemented | ACP treats checkout creation as the agent-facing cart/checkout boundary; MCP exposes explicit cart operations. |
 | Checkout lifecycle | ACP `/acp/v1/checkout/**`, MCP `checkout` and `confirmOrder`, `OrderService`, `PaymentService` | Partial | MockHub supports create, update, cancel, and complete flows, but does not implement UCP version negotiation or UCP response envelopes. |
-| Order and post-purchase support | MCP `getOrder`, `listOrders`, `getCalendarEntry`; public ticket view; PDF/QR tickets; SMS/email fulfillment | Partial | MockHub covers order lookup and fulfillment well for tickets, though it does not yet model returns, disputes, or shipment tracking. |
+| Order and post-purchase support | MCP `getOrder`, `listOrders`, `getCalendarEntry`, `getAgentPurchaseEvidence`; REST agent evidence endpoint; public ticket view; PDF/QR tickets; SMS/email fulfillment | Partial | MockHub covers order lookup, fulfillment, and owner-scoped agent evidence well for tickets, though it does not yet model returns, disputes, or shipment tracking. |
 | Identity linking | Website OAuth account linking, authenticated website user context, MCP OAuth2 for agent access | Partial | MockHub has account linking and authenticated agent transport, but not UCP identity-linking capability declarations. Buyer preference memory adds explicit user context without becoming a UCP identity-linking surface. |
 | Commerce policy | REST commerce policy endpoints, MCP `getCommercePolicy`, policy snapshots in ACP/listing responses | Implemented | Agents can fetch structured policy context before proposing or completing purchases. |
-| Authorization and proof | Mandates, `MandateCondition`, approval records, approval-required mandates | Partial | These map closely to AP2 concepts, but they are not cryptographically signed AP2 mandate credentials. Scoped payment credentials now keep "allowed to act" separate from "allowed to pay." |
+| Authorization and proof | Mandates, `MandateCondition`, approval records, approval-required mandates, agent purchase evidence trails | Partial | These map closely to AP2 concepts, but they are not cryptographically signed AP2 mandate credentials. Scoped payment credentials now keep "allowed to act" separate from "allowed to pay"; evidence trails assemble the records after checkout. |
 | Payment credentials | `PaymentCredentialService`, `PaymentCredentialTools`, ACP/MCP `paymentCredentialId`, mock payment service | Partial | MockHub supports mock-backed scoped credentials with one-time/reusable usage, expiration, revocation, limits, and checkout validation. Stripe-backed wallet credentials remain future work. |
 | Risk and abuse signals | `AgentRiskSignal`, `AgentRiskService`, `AgentRiskCondition`, MCP `getAgentRiskSummary` | Partial | MockHub persists deterministic local risk signals, returns warnings to MCP agents, and blocks repeated mandate mismatches. It does not integrate an external fraud/risk provider. |
 | Preference and personalization memory | `BuyerPreferenceService`, `buyer_preferences`, `GET/PUT /api/v1/preferences/me`, MCP `findTickets`/`compareTickets`, AI recommendations | Partial | MockHub stores explicit buyer preferences and returns preference-use metadata. It does not publish UCP capability declarations or cross-platform preference synchronization. |
@@ -505,10 +532,11 @@ The implementation is considered working when all of the following are true:
 5. Successful confirmation increments mandate `totalSpent` exactly once.
 6. Repeated mandate mismatches for the same user and agent create persisted risk signals and cause `AgentRiskCondition` to block later purchase actions.
 7. `getAgentRiskSummary` returns recent signals, warning reasons, highest severity, and blocked status for a user/agent pair.
-8. Users can store and update buyer preferences, and preference-aware searches return explicit `preferenceContext` metadata.
-9. `cd backend && ./gradlew test` passes.
-10. UCP readiness documentation is manually checked against the current MockHub tool/endpoint names and the pinned external protocol references. There is no automated UCP conformance check yet.
-11. The [Spec Versions](#spec-versions) table is re-checked before release prep and before any future UCP profile work. There is no automated spec-freshness check yet.
+8. `getAgentPurchaseEvidence` and `GET /api/v1/orders/{orderNumber}/agent-evidence` return the assembled agent purchase evidence record for the order owner or an admin.
+9. Users can store and update buyer preferences, and preference-aware searches return explicit `preferenceContext` metadata.
+10. `cd backend && ./gradlew test` passes.
+11. UCP readiness documentation is manually checked against the current MockHub tool/endpoint names and the pinned external protocol references. There is no automated UCP conformance check yet.
+12. The [Spec Versions](#spec-versions) table is re-checked before release prep and before any future UCP profile work. There is no automated spec-freshness check yet.
 
 ---
 
@@ -620,6 +648,11 @@ CREATE TABLE mandates (
 - `backend/src/main/java/com/mockhub/agentapproval/` — approval audit entity, DTOs, service, controller
 - `backend/src/main/java/com/mockhub/mcp/tools/AgentApprovalTools.java`
 - `backend/src/main/resources/db/migration/V31__create_agent_purchase_approvals.sql`
+
+### Phase 2c: Agent Purchase Evidence
+- `backend/src/main/java/com/mockhub/agentpurchaseevidence/` — owner/admin-scoped evidence DTOs, service, and REST controller
+- `backend/src/main/java/com/mockhub/mcp/tools/AgentPurchaseEvidenceTools.java` — MCP self-inspection tool
+- `backend/src/test/java/com/mockhub/AgentPurchaseEvidenceIntegrationTest.java` — full mandate, approval, credential, checkout, and fulfillment evidence flow
 
 ### Phase 3: ACP
 - `backend/src/main/java/com/mockhub/acp/` — controller, service, dto, API key filter


### PR DESCRIPTION
## Summary
- Add an owner/admin-scoped REST endpoint for agent purchase evidence: `GET /api/v1/orders/{orderNumber}/agent-evidence`
- Add MCP `getAgentPurchaseEvidence(userEmail, orderNumber)` with public ticket token redaction for external self-inspection
- Assemble evidence from existing order, mandate, approval, scoped payment credential, risk signal, eval, actor timeline, and fulfillment records
- Update `llms.txt`, agentic commerce docs, and MCP tool registration count

## Validation
- `cd backend && ./gradlew test jacocoTestReport`
- Claude ultrareview against `origin/main`: 5 verified findings; fixed risk-signal matching, generic signal attribution, QR URL shape, MCP token exposure, and credential outcome dead code
- Re-ran `cd backend && ./gradlew test jacocoTestReport` after review fixes

Closes #238
