### PR TITLE
refactor(ticketmaster): add TicketmasterAttractionResponse.Builder and migrate tests

### DIFF
--- a/backend/src/main/java/com/mockhub/ticketmaster/dto/TicketmasterAttractionResponse.java
+++ b/backend/src/main/java/com/mockhub/ticketmaster/dto/TicketmasterAttractionResponse.java
@@ -18,4 +18,38 @@ public record TicketmasterAttractionResponse(
             String id
     ) {
     }
+
+    /**
+     * Builder for TicketmasterAttractionResponse. Avoids fragile positional constructors
+     * in test code, especially when the nested externalLinks map obscures intent.
+     * All fields default to null so callers only set what they need.
+     */
+    public static final class Builder {
+        private String id;
+        private String name;
+        private Map<String, List<ExternalLink>> externalLinks;
+
+        public Builder id(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder externalLinks(Map<String, List<ExternalLink>> externalLinks) {
+            this.externalLinks = externalLinks;
+            return this;
+        }
+
+        public TicketmasterAttractionResponse build() {
+            return new TicketmasterAttractionResponse(id, name, externalLinks);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
 }

--- a/backend/src/test/java/com/mockhub/ticketmaster/dto/TicketmasterAttractionResponseBuilderTest.java
+++ b/backend/src/test/java/com/mockhub/ticketmaster/dto/TicketmasterAttractionResponseBuilderTest.java
@@ -1,0 +1,102 @@
+package com.mockhub.ticketmaster.dto;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.mockhub.ticketmaster.dto.TicketmasterAttractionResponse.ExternalLink;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TicketmasterAttractionResponseBuilderTest {
+
+    @Test
+    void build_givenNoFieldsSet_returnsRecordWithAllNulls() {
+        TicketmasterAttractionResponse response = TicketmasterAttractionResponse.builder().build();
+
+        assertThat(response.id()).isNull();
+        assertThat(response.name()).isNull();
+        assertThat(response.externalLinks()).isNull();
+    }
+
+    @Test
+    void build_givenAllFieldsSet_returnsFullyPopulatedRecord() {
+        Map<String, List<ExternalLink>> externalLinks = Map.of(
+                "spotify", List.of(
+                        new ExternalLink("https://open.spotify.com/artist/0ECwFtbIWEVNwjlrfc6xoL", null)));
+
+        TicketmasterAttractionResponse response = TicketmasterAttractionResponse.builder()
+                .id("K8vZ9171ob7")
+                .name("Eagles")
+                .externalLinks(externalLinks)
+                .build();
+
+        assertThat(response.id()).isEqualTo("K8vZ9171ob7");
+        assertThat(response.name()).isEqualTo("Eagles");
+        assertThat(response.externalLinks()).isEqualTo(externalLinks);
+    }
+
+    @Test
+    void build_givenPartialFields_leavesUnsetFieldsNull() {
+        TicketmasterAttractionResponse response = TicketmasterAttractionResponse.builder()
+                .id("K8vZ9171ob7")
+                .name("Eagles")
+                .build();
+
+        assertThat(response.id()).isEqualTo("K8vZ9171ob7");
+        assertThat(response.name()).isEqualTo("Eagles");
+        assertThat(response.externalLinks()).isNull();
+        assertThat(response).isEqualTo(new TicketmasterAttractionResponse("K8vZ9171ob7", "Eagles", null));
+    }
+
+    @Test
+    void build_givenBuilderReused_eachBuildCreatesIndependentRecord() {
+        TicketmasterAttractionResponse.Builder builder = TicketmasterAttractionResponse.builder()
+                .id("K8vZ9171ob7")
+                .name("First");
+
+        TicketmasterAttractionResponse first = builder.build();
+        TicketmasterAttractionResponse second = builder.name("Second").build();
+
+        assertThat(first.name()).isEqualTo("First");
+        assertThat(second.name()).isEqualTo("Second");
+        assertThat(first.id()).isEqualTo("K8vZ9171ob7");
+        assertThat(second.id()).isEqualTo("K8vZ9171ob7");
+    }
+
+    @Test
+    void builder_givenStaticFactoryMethod_returnsNewBuilderInstance() {
+        TicketmasterAttractionResponse.Builder builder = TicketmasterAttractionResponse.builder();
+
+        assertThat(builder).isNotNull();
+        assertThat(builder).isInstanceOf(TicketmasterAttractionResponse.Builder.class);
+    }
+
+    @Test
+    void build_givenMethodChaining_eachSetterReturnsSameBuilder() {
+        TicketmasterAttractionResponse.Builder builder = TicketmasterAttractionResponse.builder();
+
+        assertThat(builder.id("id")).isSameAs(builder);
+        assertThat(builder.name("name")).isSameAs(builder);
+        assertThat(builder.externalLinks(null)).isSameAs(builder);
+    }
+
+    @Test
+    void build_givenBuiltRecord_isEqualToDirectConstructor() {
+        Map<String, List<ExternalLink>> externalLinks = Map.of(
+                "spotify", List.of(
+                        new ExternalLink("https://open.spotify.com/artist/0ECwFtbIWEVNwjlrfc6xoL", null)));
+
+        TicketmasterAttractionResponse fromBuilder = TicketmasterAttractionResponse.builder()
+                .id("K8vZ9171ob7")
+                .name("Eagles")
+                .externalLinks(externalLinks)
+                .build();
+
+        TicketmasterAttractionResponse fromConstructor = new TicketmasterAttractionResponse(
+                "K8vZ9171ob7", "Eagles", externalLinks);
+
+        assertThat(fromBuilder).isEqualTo(fromConstructor);
+    }
+}

--- a/backend/src/test/java/com/mockhub/ticketmaster/service/TicketmasterEventMapperTest.java
+++ b/backend/src/test/java/com/mockhub/ticketmaster/service/TicketmasterEventMapperTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import com.mockhub.event.entity.Category;
+import com.mockhub.event.entity.Event;
 import com.mockhub.ticketmaster.dto.TicketmasterAttractionResponse;
 import com.mockhub.ticketmaster.dto.TicketmasterAttractionResponse.ExternalLink;
 import com.mockhub.ticketmaster.dto.TicketmasterEventResponse;
@@ -26,8 +27,6 @@ import com.mockhub.ticketmaster.dto.TicketmasterEventResponse.Status;
 import com.mockhub.ticketmaster.dto.TicketmasterEventResponse.SubGenre;
 import com.mockhub.ticketmaster.dto.TicketmasterVenueResponse;
 import com.mockhub.venue.entity.Venue;
-
-import com.mockhub.event.entity.Event;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -114,88 +113,110 @@ class TicketmasterEventMapperTest {
 
         @Test
         void extractSpotifyArtistId_givenStandardUrl_returnsArtistId() {
-            TicketmasterAttractionResponse attraction = new TicketmasterAttractionResponse(
-                    "K8vZ9171ob7", "Eagles",
-                    Map.of("spotify", List.of(
-                            new ExternalLink("https://open.spotify.com/artist/0ECwFtbIWEVNwjlrfc6xoL", null))));
+            TicketmasterAttractionResponse attraction = TicketmasterAttractionResponse.builder()
+                    .id("K8vZ9171ob7")
+                    .name("Eagles")
+                    .externalLinks(Map.of("spotify", List.of(
+                            new ExternalLink("https://open.spotify.com/artist/0ECwFtbIWEVNwjlrfc6xoL", null))))
+                    .build();
 
             assertThat(mapper.extractSpotifyArtistId(attraction)).isEqualTo("0ECwFtbIWEVNwjlrfc6xoL");
         }
 
         @Test
         void extractSpotifyArtistId_givenMangledUri_recoversArtistId() {
-            TicketmasterAttractionResponse attraction = new TicketmasterAttractionResponse(
-                    "K8vZ917abc", "Luna",
-                    Map.of("spotify", List.of(
-                            new ExternalLink("https://open.spotify.com/user/spotify:artist:2AACqFGo8offvHCKGvrWxq", null))));
+            TicketmasterAttractionResponse attraction = TicketmasterAttractionResponse.builder()
+                    .id("K8vZ917abc")
+                    .name("Luna")
+                    .externalLinks(Map.of("spotify", List.of(
+                            new ExternalLink(
+                                    "https://open.spotify.com/user/spotify:artist:2AACqFGo8offvHCKGvrWxq",
+                                    null))))
+                    .build();
 
             assertThat(mapper.extractSpotifyArtistId(attraction)).isEqualTo("2AACqFGo8offvHCKGvrWxq");
         }
 
         @Test
         void extractSpotifyArtistId_givenUserProfileUrl_returnsNull() {
-            TicketmasterAttractionResponse attraction = new TicketmasterAttractionResponse(
-                    "K8vZ917def", "Black Joe Lewis",
-                    Map.of("spotify", List.of(
-                            new ExternalLink("https://open.spotify.com/user/blackjoelewismusic", null))));
+            TicketmasterAttractionResponse attraction = TicketmasterAttractionResponse.builder()
+                    .id("K8vZ917def")
+                    .name("Black Joe Lewis")
+                    .externalLinks(Map.of("spotify", List.of(
+                            new ExternalLink("https://open.spotify.com/user/blackjoelewismusic", null))))
+                    .build();
 
             assertThat(mapper.extractSpotifyArtistId(attraction)).isNull();
         }
 
         @Test
         void extractSpotifyArtistId_givenPlaylistUrl_returnsNull() {
-            TicketmasterAttractionResponse attraction = new TicketmasterAttractionResponse(
-                    "K8vZ917ghi", "Emo Night",
-                    Map.of("spotify", List.of(
-                            new ExternalLink("https://open.spotify.com/playlist/3vwjBackAZ0Rl9hueMkOwp", null))));
+            TicketmasterAttractionResponse attraction = TicketmasterAttractionResponse.builder()
+                    .id("K8vZ917ghi")
+                    .name("Emo Night")
+                    .externalLinks(Map.of("spotify", List.of(
+                            new ExternalLink("https://open.spotify.com/playlist/3vwjBackAZ0Rl9hueMkOwp", null))))
+                    .build();
 
             assertThat(mapper.extractSpotifyArtistId(attraction)).isNull();
         }
 
         @Test
         void extractSpotifyArtistId_givenAppleMusicUrl_returnsNull() {
-            TicketmasterAttractionResponse attraction = new TicketmasterAttractionResponse(
-                    "K8vZ917jkl", "Microwave",
-                    Map.of("spotify", List.of(
-                            new ExternalLink("https://music.apple.com/us/artist/microwave/613522668", null))));
+            TicketmasterAttractionResponse attraction = TicketmasterAttractionResponse.builder()
+                    .id("K8vZ917jkl")
+                    .name("Microwave")
+                    .externalLinks(Map.of("spotify", List.of(
+                            new ExternalLink("https://music.apple.com/us/artist/microwave/613522668", null))))
+                    .build();
 
             assertThat(mapper.extractSpotifyArtistId(attraction)).isNull();
         }
 
         @Test
         void extractSpotifyArtistId_givenUnrelatedUrl_returnsNull() {
-            TicketmasterAttractionResponse attraction = new TicketmasterAttractionResponse(
-                    "K8vZ917mno", "Trap Karaoke",
-                    Map.of("spotify", List.of(
-                            new ExternalLink("https://trapkaraoke.com/", null))));
+            TicketmasterAttractionResponse attraction = TicketmasterAttractionResponse.builder()
+                    .id("K8vZ917mno")
+                    .name("Trap Karaoke")
+                    .externalLinks(Map.of("spotify", List.of(
+                            new ExternalLink("https://trapkaraoke.com/", null))))
+                    .build();
 
             assertThat(mapper.extractSpotifyArtistId(attraction)).isNull();
         }
 
         @Test
         void extractSpotifyArtistId_givenNoExternalLinks_returnsNull() {
-            TicketmasterAttractionResponse attraction = new TicketmasterAttractionResponse(
-                    "K8vZ9171ob7", "Eagles", null);
+            TicketmasterAttractionResponse attraction = TicketmasterAttractionResponse.builder()
+                    .id("K8vZ9171ob7")
+                    .name("Eagles")
+                    .build();
 
             assertThat(mapper.extractSpotifyArtistId(attraction)).isNull();
         }
 
         @Test
         void extractSpotifyArtistId_givenNoSpotifyLink_returnsNull() {
-            TicketmasterAttractionResponse attraction = new TicketmasterAttractionResponse(
-                    "K8vZ9171ob7", "Eagles",
-                    Map.of("youtube", List.of(
-                            new ExternalLink("https://youtube.com/test", null))));
+            TicketmasterAttractionResponse attraction = TicketmasterAttractionResponse.builder()
+                    .id("K8vZ9171ob7")
+                    .name("Eagles")
+                    .externalLinks(Map.of("youtube", List.of(
+                            new ExternalLink("https://youtube.com/test", null))))
+                    .build();
 
             assertThat(mapper.extractSpotifyArtistId(attraction)).isNull();
         }
 
         @Test
         void extractSpotifyArtistId_givenUrlWithQueryParams_extractsCleanId() {
-            TicketmasterAttractionResponse attraction = new TicketmasterAttractionResponse(
-                    "K8vZ917pqr", "Taylor Swift",
-                    Map.of("spotify", List.of(
-                            new ExternalLink("https://open.spotify.com/artist/06HL4z0CvFAxyc27GXpf02?si=abc123", null))));
+            TicketmasterAttractionResponse attraction = TicketmasterAttractionResponse.builder()
+                    .id("K8vZ917pqr")
+                    .name("Taylor Swift")
+                    .externalLinks(Map.of("spotify", List.of(
+                            new ExternalLink(
+                                    "https://open.spotify.com/artist/06HL4z0CvFAxyc27GXpf02?si=abc123",
+                                    null))))
+                    .build();
 
             assertThat(mapper.extractSpotifyArtistId(attraction)).isEqualTo("06HL4z0CvFAxyc27GXpf02");
         }
@@ -488,10 +509,14 @@ class TicketmasterEventMapperTest {
                 .priceRanges(List.of(new PriceRange("standard", "USD", 75.0, 250.0)))
                 .embedded(new Embedded(
                         List.of(createSampleVenueResponse()),
-                        List.of(new TicketmasterAttractionResponse(
-                                "K8vZ9171ob7", "Eagles",
-                                Map.of("spotify", List.of(
-                                        new ExternalLink("https://open.spotify.com/artist/0ECwFtbIWEVNwjlrfc6xoL", null)))))))
+                        List.of(TicketmasterAttractionResponse.builder()
+                                .id("K8vZ9171ob7")
+                                .name("Eagles")
+                                .externalLinks(Map.of("spotify", List.of(
+                                        new ExternalLink(
+                                                "https://open.spotify.com/artist/0ECwFtbIWEVNwjlrfc6xoL",
+                                                null))))
+                                .build())))
                 .build();
     }
 

--- a/backend/src/test/java/com/mockhub/ticketmaster/service/TicketmasterSyncServiceTest.java
+++ b/backend/src/test/java/com/mockhub/ticketmaster/service/TicketmasterSyncServiceTest.java
@@ -460,10 +460,14 @@ class TicketmasterSyncServiceTest {
                                 "89169",
                                 new TicketmasterVenueResponse.Country("US", "US"),
                                 new TicketmasterVenueResponse.Location("36.12", "-115.16"))),
-                        List.of(new TicketmasterAttractionResponse(
-                                "ATTR-001", "Eagles",
-                                Map.of("spotify", List.of(
-                                        new ExternalLink("https://open.spotify.com/artist/0ECwFtbIWEVNwjlrfc6xoL", null)))))))
+                        List.of(TicketmasterAttractionResponse.builder()
+                                .id("ATTR-001")
+                                .name("Eagles")
+                                .externalLinks(Map.of("spotify", List.of(
+                                        new ExternalLink(
+                                                "https://open.spotify.com/artist/0ECwFtbIWEVNwjlrfc6xoL",
+                                                null))))
+                                .build())))
                 .build();
     }
 


### PR DESCRIPTION
## Summary

Adds a `Builder` to `TicketmasterAttractionResponse`, mirroring the existing
`TicketmasterEventResponse.Builder` pattern, and migrates positional
constructor usage in the Ticketmaster test suite to the new builder API for
readability.

This is a test-only refactor on the call-site side: production code call sites
remain unchanged. The record gains a `Builder` inner class but its wire shape
and constructor remain intact.

## Changes

- Added `TicketmasterAttractionResponse.Builder` (matches
  `TicketmasterEventResponse.Builder` pattern).
- Migrated positional `TicketmasterAttractionResponse` construction in:
  - `TicketmasterEventMapperTest`
  - `TicketmasterSyncServiceTest`
- Added `TicketmasterAttractionResponseBuilderTest` as guardrails for the
  new builder.
- Preserved Jackson deserialization tests that drive construction through
  `ObjectMapper` — these intentionally remain as JSON-based guardrails.
- Preserved direct constructor usage only inside builder internals and
  builder-equivalence tests.

## Out of scope

- `MockTicketmasterService` production fixture construction is unchanged.
  The Ch9 capture spec explicitly keeps production code out of scope for
  this migration.
- No changes to wire DTO shape, Ticketmaster API behavior, mapper
  semantics, or sync behavior.

## Tests

- `git diff --check` — clean
- `./gradlew test jacocoTestReport --rerun-tasks --quiet`
- Backend test report: **1176 tests, 0 failures, 0 skipped**

## Reviewer notes

- The builder mirrors the existing `TicketmasterEventResponse.Builder`
  intentionally — please flag any drift from that pattern.
- Jackson-driven construction paths are deliberately left alone; the
  serialization contract is exercised through `ObjectMapper`, not the
  builder.
- The unchanged `MockTicketmasterService` call sites are intentional per
  the Ch9 capture spec; a follow-up issue can sweep production fixtures if
  desired.

Closes #167
