### PR TITLE
feat(checkout): order review step before payment (#39 subitem)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -629,6 +629,7 @@ Never cached: carts, orders, notifications, pricing data.
 /events                          → EventListPage (search, filter, sort, paginate)
 /events/:slug                    → EventDetailPage (listings, price history, price prediction)
 /cart                            → CartPage
+/checkout/review                 → OrderReviewPage (auth required)
 /checkout                        → CheckoutPage (auth required)
 /orders/:orderNumber/confirmation → OrderConfirmationPage
 /orders                          → OrderHistoryPage (auth required)

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Any authenticated user can both buy and sell tickets.
 
 - **Event browsing** — search, filter by category/city/date/price, sort, paginate
 - **Dynamic pricing** — prices adjust based on supply, demand, and time to event
-- **Shopping cart and checkout** — full purchase flow with Stripe test mode
+- **Shopping cart and checkout** — cart → review → payment flow with Stripe test mode
 - **Seller marketplace** — any user can list tickets (with owned-ticket quick-sell and visual venue map), manage listings, track earnings
 - **OAuth social login** — Google, GitHub, and Spotify sign-in alongside email/password
 - **User profiles** — edit name/phone, view connected OAuth providers
@@ -143,7 +143,7 @@ Any authenticated user can both buy and sell tickets.
 
 ## Testing
 
-988 backend tests, 427 frontend tests, E2E across 3 browsers (Chrome, Safari, Mobile iOS) with CI sharding.
+988 backend tests, 465 frontend tests, E2E across 3 browsers (Chrome, Safari, Mobile iOS) with CI sharding.
 
 ```bash
 # Backend (requires Docker for Testcontainers)

--- a/docs/demo-scenarios.md
+++ b/docs/demo-scenarios.md
@@ -222,7 +222,7 @@ Run demo reset to clear any mandates. No orders to worry about (BROWSE-only mand
 ### Script
 
 1. **Both tabs:** Click the same listing → "Add to Cart"
-2. **Tab 1 (buyer):** Go to `/cart` → click "Checkout" → complete purchase
+2. **Tab 1 (buyer):** Go to `/cart` → click "Checkout" → review the order → complete purchase
 3. **Tab 2 (seller):** Go to `/cart` → click "Checkout"
 4. **Tab 2 result:** "This ticket was just purchased by another buyer" (409 Conflict)
 

--- a/frontend/e2e/cart-checkout.spec.ts
+++ b/frontend/e2e/cart-checkout.spec.ts
@@ -38,6 +38,29 @@ const MOCK_CART_WITH_ITEMS = {
   subtotal: 120.0,
 };
 
+const MOCK_CART_REVIEW_SHAPE = {
+  id: 1,
+  userId: 1,
+  items: [
+    {
+      id: 1,
+      listingId: 10,
+      eventName: 'Rock Festival 2026',
+      eventSlug: 'rock-festival-2026',
+      sectionName: 'Floor',
+      rowLabel: 'A',
+      seatNumber: '5',
+      ticketType: 'STANDARD',
+      priceAtAdd: 120.0,
+      currentPrice: 120.0,
+      addedAt: '2026-05-10T10:00:00',
+    },
+  ],
+  subtotal: 120.0,
+  itemCount: 1,
+  expiresAt: null,
+};
+
 async function authenticateUser(page: Page) {
   await page.addInitScript((authState) => {
     sessionStorage.setItem('mockhub-auth', JSON.stringify(authState));
@@ -82,6 +105,64 @@ test.describe('Cart and checkout', () => {
 
     // Cart button is only visible when authenticated, so we just check the header loaded
     await expect(page.getByRole('banner').getByRole('link', { name: 'MockHub' })).toBeVisible();
+  });
+
+  test('cart -> review -> payment flow walks through the review gate', async ({ page }) => {
+    await authenticateUser(page);
+
+    await page.route(/\/api\/v1\/cart$/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_CART_REVIEW_SHAPE),
+      });
+    });
+
+    // Start on the cart page
+    await page.goto('/cart');
+    await expect(page.getByRole('heading', { name: 'Shopping Cart' })).toBeVisible();
+    await expect(page.getByText('Rock Festival 2026')).toBeVisible();
+
+    // Click "Proceed to Checkout" -> lands on /checkout/review (not /checkout)
+    await page.getByRole('link', { name: 'Proceed to Checkout' }).click();
+    await expect(page).toHaveURL(/\/checkout\/review$/);
+    await expect(page.getByRole('heading', { level: 1, name: 'Order Review' })).toBeVisible();
+
+    // Itemized breakdown is visible (10% fee invariant comes from CartSummary)
+    await expect(page.getByText('Service Fee (10%)')).toBeVisible();
+    await expect(page.getByText('$12.00')).toBeVisible(); // 10% of $120
+    await expect(page.getByText('$132.00')).toBeVisible(); // total
+
+    // Back to Cart preserves cart state
+    await page.locator('a[href="/cart"]').filter({ hasText: 'Back to Cart' }).click();
+    await expect(page).toHaveURL(/\/cart$/);
+    await expect(page.getByText('Rock Festival 2026')).toBeVisible();
+
+    // Re-enter review and continue to payment
+    await page.getByRole('link', { name: 'Proceed to Checkout' }).click();
+    await expect(page).toHaveURL(/\/checkout\/review$/);
+    await page.getByRole('button', { name: 'Continue to Payment' }).click();
+    await expect(page).toHaveURL(/\/checkout$/);
+    await expect(page.getByRole('heading', { name: 'Checkout' })).toBeVisible();
+    await expect(page.getByText('Payment Method')).toBeVisible();
+  });
+
+  test('direct nav to /checkout with non-empty cart redirects to /checkout/review', async ({
+    page,
+  }) => {
+    await authenticateUser(page);
+
+    await page.route(/\/api\/v1\/cart$/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_CART_REVIEW_SHAPE),
+      });
+    });
+
+    await page.goto('/checkout');
+    await expect(page).toHaveURL(/\/checkout\/review$/);
+    await expect(page.getByRole('heading', { level: 1, name: 'Order Review' })).toBeVisible();
   });
 
   test('cart icon shows badge count when authenticated with items in cart', async ({

--- a/frontend/src/components/cart/CartDrawer.tsx
+++ b/frontend/src/components/cart/CartDrawer.tsx
@@ -75,7 +75,7 @@ export function CartDrawer() {
                 </div>
                 <div className="flex flex-col gap-2">
                   <Button asChild onClick={closeDrawer}>
-                    <Link to={ROUTES.CHECKOUT}>Checkout</Link>
+                    <Link to={ROUTES.CHECKOUT_REVIEW}>Checkout</Link>
                   </Button>
                   <Button variant="outline" asChild onClick={closeDrawer}>
                     <Link to={ROUTES.CART}>View Cart</Link>

--- a/frontend/src/components/cart/CartSummary.tsx
+++ b/frontend/src/components/cart/CartSummary.tsx
@@ -47,7 +47,7 @@ export function CartSummary({
       </div>
       {showCheckoutButton && (
         <Button className="mt-4 w-full" size="lg" asChild>
-          <Link to={ROUTES.CHECKOUT}>Proceed to Checkout</Link>
+          <Link to={ROUTES.CHECKOUT_REVIEW}>Proceed to Checkout</Link>
         </Button>
       )}
     </div>

--- a/frontend/src/lib/checkout-review-gate.test.ts
+++ b/frontend/src/lib/checkout-review-gate.test.ts
@@ -77,10 +77,7 @@ describe('checkout review gate', () => {
     const cart = makeCart();
     markReviewPassed(cart);
     const withMore = makeCart({
-      items: [
-        cart.items[0],
-        { ...cart.items[0], id: 101, listingId: 11 },
-      ],
+      items: [cart.items[0], { ...cart.items[0], id: 101, listingId: 11 }],
       itemCount: 2,
       subtotal: 200,
     });

--- a/frontend/src/lib/checkout-review-gate.test.ts
+++ b/frontend/src/lib/checkout-review-gate.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { Cart } from '@/types/cart';
+import {
+  cartReviewFingerprint,
+  clearReviewPassed,
+  hasReviewPassed,
+  markReviewPassed,
+} from './checkout-review-gate';
+
+function makeCart(overrides: Partial<Cart> = {}): Cart {
+  return {
+    id: 1,
+    userId: 1,
+    items: [
+      {
+        id: 100,
+        listingId: 10,
+        eventName: 'Event A',
+        eventSlug: 'event-a',
+        sectionName: 'Floor',
+        rowLabel: 'A',
+        seatNumber: '1',
+        ticketType: 'STANDARD',
+        priceAtAdd: 100,
+        currentPrice: 100,
+        addedAt: '2026-05-01T10:00:00',
+      },
+    ],
+    subtotal: 100,
+    itemCount: 1,
+    expiresAt: null,
+    ...overrides,
+  };
+}
+
+describe('checkout review gate', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  it('hasReviewPassed is false before marking', () => {
+    expect(hasReviewPassed(makeCart())).toBe(false);
+  });
+
+  it('marks and detects review passed for the same cart fingerprint', () => {
+    const cart = makeCart();
+    markReviewPassed(cart);
+    expect(hasReviewPassed(cart)).toBe(true);
+  });
+
+  it('invalidates the gate when cart subtotal changes', () => {
+    const cart = makeCart();
+    markReviewPassed(cart);
+    const repriced = makeCart({ subtotal: 150 });
+    expect(hasReviewPassed(repriced)).toBe(false);
+  });
+
+  it('invalidates the gate when an item changes price', () => {
+    const cart = makeCart();
+    markReviewPassed(cart);
+    const repriced = makeCart({
+      items: [{ ...cart.items[0], currentPrice: 120 }],
+    });
+    expect(hasReviewPassed(repriced)).toBe(false);
+  });
+
+  it('invalidates the gate when the since-added price signal changes', () => {
+    const cart = makeCart();
+    markReviewPassed(cart);
+    const changedSignal = makeCart({
+      items: [{ ...cart.items[0], priceAtAdd: 90 }],
+    });
+    expect(hasReviewPassed(changedSignal)).toBe(false);
+  });
+
+  it('invalidates the gate when items are added', () => {
+    const cart = makeCart();
+    markReviewPassed(cart);
+    const withMore = makeCart({
+      items: [
+        cart.items[0],
+        { ...cart.items[0], id: 101, listingId: 11 },
+      ],
+      itemCount: 2,
+      subtotal: 200,
+    });
+    expect(hasReviewPassed(withMore)).toBe(false);
+  });
+
+  it('clearReviewPassed removes the marker', () => {
+    const cart = makeCart();
+    markReviewPassed(cart);
+    clearReviewPassed();
+    expect(hasReviewPassed(cart)).toBe(false);
+  });
+
+  it('cartReviewFingerprint is stable for equivalent carts', () => {
+    expect(cartReviewFingerprint(makeCart())).toBe(cartReviewFingerprint(makeCart()));
+  });
+});

--- a/frontend/src/lib/checkout-review-gate.ts
+++ b/frontend/src/lib/checkout-review-gate.ts
@@ -1,0 +1,39 @@
+import type { Cart } from '@/types/cart';
+
+const STORAGE_KEY = 'mockhub-checkout-review-passed';
+
+/**
+ * Fingerprints the cart so the review gate auto-invalidates when items
+ * are added/removed or prices change. Includes subtotal so a price drift
+ * between review and payment forces another review.
+ */
+export function cartReviewFingerprint(cart: Cart): string {
+  const itemKey = cart.items
+    .map((item) => `${item.id}:${item.priceAtAdd}:${item.currentPrice}`)
+    .join(',');
+  return `${cart.id}|${cart.subtotal}|${itemKey}`;
+}
+
+export function markReviewPassed(cart: Cart): void {
+  try {
+    sessionStorage.setItem(STORAGE_KEY, cartReviewFingerprint(cart));
+  } catch {
+    // sessionStorage unavailable (private mode, etc.) makes the gate always block.
+  }
+}
+
+export function hasReviewPassed(cart: Cart): boolean {
+  try {
+    return sessionStorage.getItem(STORAGE_KEY) === cartReviewFingerprint(cart);
+  } catch {
+    return false;
+  }
+}
+
+export function clearReviewPassed(): void {
+  try {
+    sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // no-op
+  }
+}

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -10,6 +10,7 @@ export const ROUTES = {
   EVENT_DETAIL: '/events/:slug',
   CART: '/cart',
   CHECKOUT: '/checkout',
+  CHECKOUT_REVIEW: '/checkout/review',
   ORDERS: '/orders',
   FAVORITES: '/favorites',
   PROFILE: '/my/profile',

--- a/frontend/src/pages/CheckoutPage.test.tsx
+++ b/frontend/src/pages/CheckoutPage.test.tsx
@@ -1,7 +1,8 @@
-import { describe, it, expect, vi } from 'vitest';
-import { renderWithProviders, screen } from '@/test/test-utils';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithProviders, screen, userEvent, waitFor } from '@/test/test-utils';
 import { CheckoutPage } from './CheckoutPage';
 import type { Cart } from '@/types/cart';
+import { markReviewPassed, clearReviewPassed, hasReviewPassed } from '@/lib/checkout-review-gate';
 
 vi.mock('@/hooks/use-cart', () => ({
   useCart: vi.fn(() => ({
@@ -37,6 +38,7 @@ vi.mock('@/stores/cart-store', () => ({
 }));
 
 import { useCart } from '@/hooks/use-cart';
+import { useCheckout } from '@/hooks/use-orders';
 
 const mockCart: Cart = {
   id: 1,
@@ -82,13 +84,32 @@ function setCartState(data: Cart | undefined, isLoading = false) {
 }
 
 describe('CheckoutPage', () => {
-  it('renders order summary when cart has items', () => {
+  beforeEach(() => {
+    clearReviewPassed();
+    vi.mocked(useCheckout).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof useCheckout>);
+  });
+
+  it('renders order summary when cart has items and review has passed', () => {
     setCartState(mockCart);
+    markReviewPassed(mockCart);
 
     renderWithProviders(<CheckoutPage />);
 
     expect(screen.getByText('Checkout')).toBeDefined();
     expect(screen.getByText('Payment Method')).toBeDefined();
+  });
+
+  it('redirects to /checkout/review when cart has items but review gate not passed', () => {
+    setCartState(mockCart);
+    // Do not mark review passed
+
+    renderWithProviders(<CheckoutPage />);
+
+    // Navigate replaces the rendered content, so the Checkout heading is gone
+    expect(screen.queryByRole('heading', { name: 'Checkout' })).toBeNull();
   });
 
   it('shows empty cart message when no items', () => {
@@ -108,6 +129,43 @@ describe('CheckoutPage', () => {
     expect(screen.getByText('Nothing to checkout')).toBeDefined();
   });
 
+  it('clears the review gate after a reviewed cart becomes empty', async () => {
+    setCartState(mockCart);
+    markReviewPassed(mockCart);
+
+    const { rerender } = renderWithProviders(<CheckoutPage />);
+    expect(hasReviewPassed(mockCart)).toBe(true);
+
+    setCartState({ ...mockCart, items: [], itemCount: 0, subtotal: 0 });
+    rerender(<CheckoutPage />);
+
+    await waitFor(() => expect(hasReviewPassed(mockCart)).toBe(false));
+  });
+
+  it('keeps the payment view visible if the cart clears while mock payment is processing', async () => {
+    const mutate = vi.fn();
+    vi.mocked(useCheckout).mockReturnValue({
+      mutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useCheckout>);
+    setCartState(mockCart);
+    markReviewPassed(mockCart);
+
+    const { rerender } = renderWithProviders(<CheckoutPage />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Pay $368.50' }));
+    expect(mutate).toHaveBeenCalled();
+
+    setCartState({ ...mockCart, items: [], itemCount: 0, subtotal: 0 });
+    rerender(<CheckoutPage />);
+
+    expect(screen.queryByText('Nothing to checkout')).toBeNull();
+    expect(screen.getByText('Your order has been created. Complete payment below.')).toBeDefined();
+    expect((screen.getByRole('button', { name: /Processing/ }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+
   it('shows loading skeleton while fetching', () => {
     setCartState(undefined, true);
 
@@ -120,6 +178,7 @@ describe('CheckoutPage', () => {
 
   it('payment method tabs are visible when cart has items', () => {
     setCartState(mockCart);
+    markReviewPassed(mockCart);
 
     renderWithProviders(<CheckoutPage />);
 
@@ -130,6 +189,7 @@ describe('CheckoutPage', () => {
 
   it('renders order review with cart items', () => {
     setCartState(mockCart);
+    markReviewPassed(mockCart);
 
     renderWithProviders(<CheckoutPage />);
 
@@ -139,6 +199,7 @@ describe('CheckoutPage', () => {
 
   it('renders checkout heading', () => {
     setCartState(mockCart);
+    markReviewPassed(mockCart);
 
     renderWithProviders(<CheckoutPage />);
 
@@ -147,6 +208,7 @@ describe('CheckoutPage', () => {
 
   it('shows stripe tab', () => {
     setCartState(mockCart);
+    markReviewPassed(mockCart);
 
     renderWithProviders(<CheckoutPage />);
 

--- a/frontend/src/pages/CheckoutPage.tsx
+++ b/frontend/src/pages/CheckoutPage.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useState } from 'react';
-import { useNavigate } from 'react-router';
+import { useCallback, useEffect, useState } from 'react';
+import { Navigate, useNavigate } from 'react-router';
 import { toast } from 'sonner';
 import { Loader2, ShoppingCart } from 'lucide-react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -13,6 +13,7 @@ import { useCart } from '@/hooks/use-cart';
 import { useCheckout } from '@/hooks/use-orders';
 import { createPaymentIntent, confirmPayment } from '@/api/payments';
 import { ROUTES } from '@/lib/constants';
+import { clearReviewPassed, hasReviewPassed } from '@/lib/checkout-review-gate';
 
 const SERVICE_FEE_RATE = 0.1;
 
@@ -105,6 +106,14 @@ export function CheckoutPage() {
     toast.error(message);
   }, []);
 
+  // Once payment completes (mock or stripe) the cart is cleared on the server.
+  // Clear the review gate too so a future cart cycle re-enters review.
+  useEffect(() => {
+    if (cart && cart.items.length === 0) {
+      clearReviewPassed();
+    }
+  }, [cart]);
+
   if (isLoading) {
     return (
       <div className="mx-auto max-w-4xl px-4 py-6 sm:px-6 lg:px-8">
@@ -119,6 +128,13 @@ export function CheckoutPage() {
         </div>
       </div>
     );
+  }
+
+  // Gate: direct nav to /checkout with a fresh cart bounces back to review.
+  // Skip when a payment flow is already in flight (cart may have just cleared).
+  const inPaymentFlow = stripeReady || isMockProcessing;
+  if (!inPaymentFlow && cart && cart.items.length > 0 && !hasReviewPassed(cart)) {
+    return <Navigate to={ROUTES.CHECKOUT_REVIEW} replace />;
   }
 
   // Show empty state only if cart is empty AND we're not in a payment flow

--- a/frontend/src/pages/OrderReviewPage.test.tsx
+++ b/frontend/src/pages/OrderReviewPage.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithProviders, screen, userEvent } from '@/test/test-utils';
+import { OrderReviewPage } from './OrderReviewPage';
+import type { Cart } from '@/types/cart';
+import { hasReviewPassed } from '@/lib/checkout-review-gate';
+
+const navigateMock = vi.fn();
+
+vi.mock('react-router', async (importActual) => {
+  const actual = await importActual<typeof import('react-router')>();
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock('@/hooks/use-cart', () => ({
+  useCart: vi.fn(() => ({ data: undefined, isLoading: false })),
+}));
+
+import { useCart } from '@/hooks/use-cart';
+
+const mockCart: Cart = {
+  id: 1,
+  userId: 1,
+  items: [
+    {
+      id: 101,
+      listingId: 10,
+      eventName: 'Taylor Swift - Eras Tour',
+      eventSlug: 'taylor-swift-eras-tour',
+      sectionName: 'Floor A',
+      rowLabel: 'Row 5',
+      seatNumber: '12',
+      ticketType: 'STANDARD',
+      priceAtAdd: 250.0,
+      currentPrice: 275.0,
+      addedAt: '2026-03-20T10:00:00',
+    },
+  ],
+  subtotal: 275.0,
+  itemCount: 1,
+  expiresAt: null,
+};
+
+function setCartState(data: Cart | undefined, isLoading = false) {
+  vi.mocked(useCart).mockReturnValue({
+    data,
+    isLoading,
+  } as unknown as ReturnType<typeof useCart>);
+}
+
+describe('OrderReviewPage', () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    navigateMock.mockReset();
+  });
+
+  it('renders empty state when cart is empty', () => {
+    setCartState({ ...mockCart, items: [], itemCount: 0, subtotal: 0 });
+    renderWithProviders(<OrderReviewPage />);
+    expect(screen.getByText('Nothing to review')).toBeDefined();
+  });
+
+  it('renders empty state when cart is undefined', () => {
+    setCartState(undefined);
+    renderWithProviders(<OrderReviewPage />);
+    expect(screen.getByText('Nothing to review')).toBeDefined();
+  });
+
+  it('renders itemized order with subtotal, fee, and total', () => {
+    setCartState(mockCart);
+    renderWithProviders(<OrderReviewPage />);
+
+    expect(screen.getByRole('heading', { level: 1, name: 'Order Review' })).toBeDefined();
+    expect(screen.getByText('Taylor Swift - Eras Tour')).toBeDefined();
+    // Service fee (10% of 275) and total are computed in CartSummary
+    expect(screen.getByText('Service Fee (10%)')).toBeDefined();
+    expect(screen.getByText('$27.50')).toBeDefined(); // fee
+    expect(screen.getByText('$302.50')).toBeDefined(); // total
+  });
+
+  it('preserves the price-change signal for repriced items', () => {
+    setCartState(mockCart); // priceAtAdd=250, currentPrice=275 -> +$25
+    renderWithProviders(<OrderReviewPage />);
+    expect(screen.getByText(/\+\$25\.00 since added/)).toBeDefined();
+  });
+
+  it('Back to Cart link points at /cart', () => {
+    setCartState(mockCart);
+    renderWithProviders(<OrderReviewPage />);
+    const back = screen.getByRole('link', { name: 'Back to Cart' });
+    expect(back.getAttribute('href')).toBe('/cart');
+  });
+
+  it('Continue to Payment marks the gate and navigates to /checkout', async () => {
+    setCartState(mockCart);
+    renderWithProviders(<OrderReviewPage />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Continue to Payment' }));
+
+    expect(hasReviewPassed(mockCart)).toBe(true);
+    expect(navigateMock).toHaveBeenCalledWith('/checkout');
+  });
+});

--- a/frontend/src/pages/OrderReviewPage.tsx
+++ b/frontend/src/pages/OrderReviewPage.tsx
@@ -1,0 +1,76 @@
+import { Link, useNavigate } from 'react-router';
+import { ArrowLeft, ShoppingCart } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { OrderReview } from '@/components/checkout/OrderReview';
+import { EmptyState } from '@/components/common/EmptyState';
+import { useCart } from '@/hooks/use-cart';
+import { markReviewPassed } from '@/lib/checkout-review-gate';
+import { ROUTES } from '@/lib/constants';
+
+/**
+ * Dedicated review step shown between cart and payment.
+ * Renders the existing OrderReview (itemized breakdown + CartSummary's
+ * fee math) and gates entry to /checkout via sessionStorage fingerprint.
+ */
+export function OrderReviewPage() {
+  const { data: cart, isLoading } = useCart();
+  const navigate = useNavigate();
+
+  const handleContinue = () => {
+    if (!cart) return;
+    markReviewPassed(cart);
+    navigate(ROUTES.CHECKOUT);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-6 sm:px-6 lg:px-8">
+        <Skeleton className="mb-6 h-8 w-48" />
+        <div className="space-y-3">
+          {Array.from({ length: 3 }, (_, i) => i).map((n) => (
+            <Skeleton key={`skeleton-${n}`} className="h-24 w-full" />
+          ))}
+        </div>
+        <Skeleton className="mt-6 h-48 w-full" />
+      </div>
+    );
+  }
+
+  if (!cart || cart.items.length === 0) {
+    return (
+      <div className="mx-auto max-w-3xl px-4 py-6 sm:px-6 lg:px-8">
+        <EmptyState
+          icon={ShoppingCart}
+          title="Nothing to review"
+          description="Add tickets to your cart before reviewing your order."
+          action={{ label: 'Browse Events', href: ROUTES.EVENTS }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 py-6 sm:px-6 lg:px-8">
+      <div className="mb-6 flex items-center gap-3">
+        <Button variant="ghost" size="icon" asChild>
+          <Link to={ROUTES.CART} aria-label="Back to cart">
+            <ArrowLeft className="h-4 w-4" />
+          </Link>
+        </Button>
+        <h1 className="text-2xl font-bold">Order Review</h1>
+      </div>
+
+      <OrderReview cart={cart} />
+
+      <div className="mt-6 flex flex-col-reverse gap-3 sm:flex-row sm:justify-between">
+        <Button variant="outline" asChild>
+          <Link to={ROUTES.CART}>Back to Cart</Link>
+        </Button>
+        <Button size="lg" onClick={handleContinue}>
+          Continue to Payment
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -13,6 +13,7 @@ import { EventListPage } from '@/pages/EventListPage';
 import { EventDetailPage } from '@/pages/EventDetailPage';
 import { CartPage } from '@/pages/CartPage';
 import { CheckoutPage } from '@/pages/CheckoutPage';
+import { OrderReviewPage } from '@/pages/OrderReviewPage';
 import { OrderHistoryPage } from '@/pages/OrderHistoryPage';
 import { OrderConfirmationPage } from '@/pages/OrderConfirmationPage';
 import { FavoritesPage } from '@/pages/FavoritesPage';
@@ -46,6 +47,7 @@ export const router = createBrowserRouter([
         Component: ProtectedRoute,
         children: [
           { path: 'cart', Component: CartPage },
+          { path: 'checkout/review', Component: OrderReviewPage },
           { path: 'checkout', Component: CheckoutPage },
           { path: 'orders', Component: OrderHistoryPage },
           {


### PR DESCRIPTION
## Summary

Adds an Order Review step between the cart and the payment page so buyers confirm an itemized breakdown before any payment UI is shown.

- New route `/checkout/review` rendered by `OrderReviewPage`, which reuses the existing `OrderReview` component and `CartSummary` fee math. The 10% service-fee invariant is unchanged.
- "Proceed to Checkout" buttons in `CartDrawer` and `CartSummary` now point at `/checkout/review` instead of `/checkout`.
- `CheckoutPage` gates entry: a non-empty cart that has not been reviewed redirects to `/checkout/review`. Carts already in a payment flow (Stripe ready or mock processing) are not redirected even if the cart clears mid-flow.
- New `checkout-review-gate` module stores a fingerprint of the reviewed cart in `sessionStorage`. The fingerprint includes cart id, subtotal, and each item's `priceAtAdd` + `currentPrice`, so adding/removing items or any price drift invalidates the gate and forces a fresh review.
- Gate is cleared automatically once the cart becomes empty post-purchase, so the next cart cycle starts at review again.

## Scope boundaries

Implements only the "Order review step with itemized breakdown before payment" subitem of #39. This intentionally does **not** close the broader #39 issue.

No backend changes. No changes to MCP `checkout`/`confirmOrder` tools or ACP `/acp/v1/checkout` endpoints. Request/response shapes and behavior are identical. The review gate is sessionStorage-based UX, not a security control; server-side cart ownership, listing availability, pricing, and order validation continue to be the authoritative checks.

## Tests run

- Frontend Vitest unit tests:
  - `frontend/src/lib/checkout-review-gate.test.ts` covers mark/clear/detect plus fingerprint invalidation on subtotal change, item reprice, `priceAtAdd` change, and item add.
  - `frontend/src/pages/OrderReviewPage.test.tsx` covers empty state, itemized totals, price-change signal, Back to Cart link, and Continue to Payment behavior.
  - `frontend/src/pages/CheckoutPage.test.tsx` covers gate redirect, gate clearing after an empty cart, and keeping the payment view mounted if the cart clears mid mock-payment.
- Playwright E2E (`cart-checkout.spec.ts`): cart -> review -> payment happy path, Back to Cart round trip, 10% fee assertion, and direct `/checkout` redirect for unreviewed carts.
- Captured verification from the Ch8 run:
  - 465 frontend tests passed across 69 files.
  - Changed-file ESLint clean.
  - Frontend typecheck clean.
  - Frontend build succeeded with existing bundle-size warning.
  - Backend `./gradlew test --quiet` exit 0.
  - Playwright `cart-checkout.spec.ts`: 17 passed, 1 skipped.
  - `git diff --check` clean.

## Reviewer notes

- The gate is intentionally fingerprint-based rather than a single boolean. Any cart mutation or price drift between review and payment forces a re-review.
- `CheckoutPage` skips the redirect when `stripeReady || isMockProcessing` is true, so the cart-cleared-after-payment moment does not bounce the buyer back to review mid-flow.
- `sessionStorage` access is wrapped in try/catch; in private mode the gate fails closed, which means the buyer returns to review.
- This PR does not implement the other checkout-polish bullets in #39: progress indicator, mock-payment form polish, confirmation-page refresh, or email preview.

Addresses the order-review subitem of #39.
