### PR TITLE
Validate agent checkout inputs

### DIFF
--- a/backend/src/main/java/com/mockhub/acp/service/AcpCheckoutService.java
+++ b/backend/src/main/java/com/mockhub/acp/service/AcpCheckoutService.java
@@ -40,6 +40,7 @@ import com.mockhub.order.dto.CheckoutRequest;
 import com.mockhub.order.dto.OrderDto;
 import com.mockhub.order.dto.OrderItemDto;
 import com.mockhub.order.service.OrderService;
+import com.mockhub.order.service.PaymentMethodSupport;
 import com.mockhub.payment.dto.PaymentIntentDto;
 import com.mockhub.payment.service.PaymentService;
 import com.mockhub.paymentcredential.service.PaymentCredentialService;
@@ -97,7 +98,7 @@ public class AcpCheckoutService {
         String agentId = request.agentId().strip();
         String mandateId = request.mandateId().strip();
 
-        String paymentMethod = request.paymentMethod() != null ? request.paymentMethod() : "mock";
+        String paymentMethod = PaymentMethodSupport.normalizeOrMock(request.paymentMethod());
 
         // Note: On idempotent retries, cart mutations below are harmless —
         // OrderService.checkout() returns the existing order before reading the cart.
@@ -174,8 +175,8 @@ public class AcpCheckoutService {
         }
         validateCartForAgent(user, request.agentId(), request.mandateId());
 
-        // Create new order
-        CheckoutRequest checkoutRequest = new CheckoutRequest("mock");
+        // Create new order with the original payment method preserved.
+        CheckoutRequest checkoutRequest = new CheckoutRequest(PaymentMethodSupport.normalizeOrMock(order.getPaymentMethod()));
         OrderDto newOrderDto = orderService.checkout(
                 user, checkoutRequest, null, request.agentId(), request.mandateId());
 

--- a/backend/src/main/java/com/mockhub/agentrisk/service/AgentRiskService.java
+++ b/backend/src/main/java/com/mockhub/agentrisk/service/AgentRiskService.java
@@ -29,6 +29,14 @@ import com.mockhub.eval.dto.EvalSummary;
 public class AgentRiskService {
 
     private static final int RECENT_SIGNAL_LIMIT = 20;
+    private static final int USER_EMAIL_MAX_LENGTH = 255;
+    private static final int AGENT_ID_MAX_LENGTH = 255;
+    private static final int ACTION_TYPE_MAX_LENGTH = 50;
+    private static final int RESOURCE_TYPE_MAX_LENGTH = 50;
+    private static final int RESOURCE_ID_MAX_LENGTH = 100;
+    private static final int ORDER_NUMBER_MAX_LENGTH = 30;
+    private static final int MANDATE_ID_MAX_LENGTH = 100;
+    private static final int MESSAGE_MAX_LENGTH = 500;
     private static final String MANDATE_CONDITION = "mandate-authorization";
     private static final String AGENT_RISK_CONDITION = "agent-risk";
 
@@ -63,17 +71,17 @@ public class AgentRiskService {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public AgentRiskSignalDto recordSignal(RecordAgentRiskSignalRequest request) {
         AgentRiskSignal signal = new AgentRiskSignal();
-        signal.setUserEmail(normalizeRequired(request.userEmail(), "User email"));
-        signal.setAgentId(normalizeRequired(request.agentId(), "Agent ID"));
+        signal.setUserEmail(normalizeRequired(request.userEmail(), "User email", USER_EMAIL_MAX_LENGTH));
+        signal.setAgentId(normalizeRequired(request.agentId(), "Agent ID", AGENT_ID_MAX_LENGTH));
         signal.setSignalType(requireNonNull(request.signalType(), "Signal type"));
         signal.setSeverity(request.severity() != null ? request.severity() : EvalSeverity.WARNING);
-        signal.setActionType(normalizeOptional(request.actionType()));
-        signal.setResourceType(normalizeOptional(request.resourceType()));
-        signal.setResourceId(normalizeOptional(request.resourceId()));
-        signal.setOrderNumber(normalizeOptional(request.orderNumber()));
-        signal.setMandateId(normalizeOptional(request.mandateId()));
+        signal.setActionType(normalizeOptional(request.actionType(), ACTION_TYPE_MAX_LENGTH));
+        signal.setResourceType(normalizeOptional(request.resourceType(), RESOURCE_TYPE_MAX_LENGTH));
+        signal.setResourceId(normalizeOptional(request.resourceId(), RESOURCE_ID_MAX_LENGTH));
+        signal.setOrderNumber(normalizeOptional(request.orderNumber(), ORDER_NUMBER_MAX_LENGTH));
+        signal.setMandateId(normalizeOptional(request.mandateId(), MANDATE_ID_MAX_LENGTH));
         signal.setAmount(normalizeAmount(request.amount()));
-        signal.setMessage(normalizeRequired(request.message(), "Message"));
+        signal.setMessage(limitLength(normalizeRequired(request.message(), "Message"), MESSAGE_MAX_LENGTH));
         return toDto(agentRiskSignalRepository.save(signal));
     }
 
@@ -221,7 +229,7 @@ public class AgentRiskService {
                 orderNumber,
                 null,
                 amount,
-                message));
+                messageOrDefault(message, "Checkout failed")));
     }
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
@@ -257,13 +265,13 @@ public class AgentRiskService {
                 orderNumber,
                 null,
                 amount,
-                message));
+                messageOrDefault(message, "Payment credential validation failed")));
     }
 
     @Transactional(readOnly = true)
     public AgentRiskSummaryDto summarizeRisk(String userEmail, String agentId) {
-        String normalizedUserEmail = normalizeRequired(userEmail, "User email");
-        String normalizedAgentId = normalizeRequired(agentId, "Agent ID");
+        String normalizedUserEmail = normalizeRequired(userEmail, "User email", USER_EMAIL_MAX_LENGTH);
+        String normalizedAgentId = normalizeRequired(agentId, "Agent ID", AGENT_ID_MAX_LENGTH);
         Instant since = Instant.now().minus(riskWindow);
         List<AgentRiskSignal> recentSignals = agentRiskSignalRepository.findRecent(
                 normalizedUserEmail, normalizedAgentId, since, PageRequest.of(0, RECENT_SIGNAL_LIMIT));
@@ -357,8 +365,26 @@ public class AgentRiskService {
         return value.strip();
     }
 
-    private String normalizeOptional(String value) {
-        return isBlank(value) ? null : value.strip();
+    private String normalizeRequired(String value, String fieldName, int maxLength) {
+        return limitLength(normalizeRequired(value, fieldName), maxLength);
+    }
+
+    private String normalizeOptional(String value, int maxLength) {
+        if (isBlank(value)) {
+            return null;
+        }
+        return limitLength(value.strip(), maxLength);
+    }
+
+    private String limitLength(String value, int maxLength) {
+        if (value.length() <= maxLength) {
+            return value;
+        }
+        return value.substring(0, maxLength);
+    }
+
+    private String messageOrDefault(String message, String fallback) {
+        return isBlank(message) ? fallback : message;
     }
 
     private BigDecimal normalizeAmount(BigDecimal amount) {

--- a/backend/src/main/java/com/mockhub/mcp/tools/OrderTools.java
+++ b/backend/src/main/java/com/mockhub/mcp/tools/OrderTools.java
@@ -37,7 +37,9 @@ import com.mockhub.order.dto.OrderSummaryDto;
 import com.mockhub.order.entity.Order;
 import com.mockhub.order.entity.OrderItem;
 import com.mockhub.order.service.CalendarService;
+import com.mockhub.order.service.OrderNumberSupport;
 import com.mockhub.order.service.OrderService;
+import com.mockhub.order.service.PaymentMethodSupport;
 import com.mockhub.payment.dto.PaymentIntentDto;
 import com.mockhub.payment.service.PaymentService;
 import com.mockhub.paymentcredential.service.PaymentCredentialService;
@@ -105,6 +107,7 @@ public class OrderTools {
             if (mandateId == null || mandateId.isBlank()) {
                 return errorJson("Mandate ID is required");
             }
+            String normalizedPaymentMethod = PaymentMethodSupport.normalize(paymentMethod);
             User user = resolveUser(userEmail);
             CartDto cartDto = cartService.getCartDto(user);
             List<String> warnings = new ArrayList<>();
@@ -131,7 +134,7 @@ public class OrderTools {
                         "CHECKOUT", "CART", null, cartDto.subtotal(), authorizationFailure);
                 return errorJson("Cannot checkout: " + authorizationFailure);
             }
-            CheckoutRequest request = new CheckoutRequest(paymentMethod.strip());
+            CheckoutRequest request = new CheckoutRequest(normalizedPaymentMethod);
             OrderDto order = orderService.checkout(user, request, null, agentId.strip(), mandateId.strip());
             if (!warnings.isEmpty()) {
                 return responseWithWarnings("order", order, warnings);
@@ -196,10 +199,14 @@ public class OrderTools {
                     required = false) String paymentCredentialId,
             @ToolParam(description = "Optional approved purchase approval ID for audit linkage",
                     required = false) String approvalId) {
+        String trimmedOrderNumber;
         try {
-            if (orderNumber == null || orderNumber.isBlank()) {
-                return errorJson(ORDER_NUMBER_REQUIRED);
-            }
+            trimmedOrderNumber = OrderNumberSupport.normalizeGeneratedOrderNumber(orderNumber);
+        } catch (IllegalArgumentException e) {
+            return errorJson(e.getMessage());
+        }
+
+        try {
             if (agentId == null || agentId.isBlank()) {
                 return errorJson("Agent ID is required");
             }
@@ -207,7 +214,6 @@ public class OrderTools {
                 return errorJson("Mandate ID is required");
             }
             User user = resolveUser(userEmail);
-            String trimmedOrderNumber = orderNumber.strip();
             // Verify ownership before confirming — getOrder throws UnauthorizedException if mismatch
             orderService.getOrder(user, trimmedOrderNumber);
             Order order = orderService.getOrderEntity(trimmedOrderNumber);

--- a/backend/src/main/java/com/mockhub/order/dto/CheckoutRequest.java
+++ b/backend/src/main/java/com/mockhub/order/dto/CheckoutRequest.java
@@ -2,11 +2,15 @@ package com.mockhub.order.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 
 @Schema(description = "Request to checkout the current cart")
 public record CheckoutRequest(
         @NotBlank(message = "Payment method is required")
-        @Schema(description = "Payment method identifier", example = "stripe")
+        @Size(max = 30, message = "Payment method must not exceed 30 characters")
+        @Pattern(regexp = "(?i)\\s*(mock|stripe)\\s*", message = "Payment method must be one of: mock, stripe")
+        @Schema(description = "Payment method identifier", example = "mock", allowableValues = {"mock", "stripe"})
         String paymentMethod
 ) {
 }

--- a/backend/src/main/java/com/mockhub/order/service/OrderNumberSupport.java
+++ b/backend/src/main/java/com/mockhub/order/service/OrderNumberSupport.java
@@ -1,0 +1,23 @@
+package com.mockhub.order.service;
+
+import java.util.regex.Pattern;
+
+public final class OrderNumberSupport {
+
+    private static final Pattern GENERATED_ORDER_NUMBER = Pattern.compile("MH-\\d{8}-\\d{4,8}");
+    private static final String FORMAT_MESSAGE = "Order number must use format MH-YYYYMMDD-0001";
+
+    private OrderNumberSupport() {
+    }
+
+    public static String normalizeGeneratedOrderNumber(String orderNumber) {
+        if (orderNumber == null || orderNumber.isBlank()) {
+            throw new IllegalArgumentException("Order number is required");
+        }
+        String normalized = orderNumber.strip();
+        if (!GENERATED_ORDER_NUMBER.matcher(normalized).matches()) {
+            throw new IllegalArgumentException(FORMAT_MESSAGE);
+        }
+        return normalized;
+    }
+}

--- a/backend/src/main/java/com/mockhub/order/service/OrderService.java
+++ b/backend/src/main/java/com/mockhub/order/service/OrderService.java
@@ -95,8 +95,10 @@ public class OrderService {
             }
         }
 
+        String normalizedPaymentMethod = PaymentMethodSupport.normalize(request.paymentMethod());
         List<CartItem> cartItems = validateAndReserveTickets(user);
-        Order order = createOrder(user, request, cartItems, idempotencyKey, agentId, mandateId);
+        Order order = createOrder(user, cartItems, idempotencyKey, agentId,
+                mandateId, normalizedPaymentMethod);
 
         Order savedOrder = orderRepository.save(order);
         log.info("Created order {} for user {} with {} items, total={}",
@@ -313,8 +315,9 @@ public class OrderService {
         return cartItems;
     }
 
-    private Order createOrder(User user, CheckoutRequest request, List<CartItem> cartItems,
-                               String idempotencyKey, String agentId, String mandateId) {
+    private Order createOrder(User user, List<CartItem> cartItems,
+                               String idempotencyKey, String agentId, String mandateId,
+                               String paymentMethod) {
         BigDecimal subtotal = BigDecimal.ZERO;
         for (CartItem cartItem : cartItems) {
             subtotal = subtotal.add(cartItem.getListing().getComputedPrice());
@@ -329,7 +332,7 @@ public class OrderService {
         order.setSubtotal(subtotal);
         order.setServiceFee(serviceFee);
         order.setTotal(total);
-        order.setPaymentMethod(request.paymentMethod());
+        order.setPaymentMethod(paymentMethod);
         order.setAgentId(normalize(agentId));
         order.setMandateId(normalize(mandateId));
         if (idempotencyKey != null && !idempotencyKey.isBlank()) {

--- a/backend/src/main/java/com/mockhub/order/service/PaymentMethodSupport.java
+++ b/backend/src/main/java/com/mockhub/order/service/PaymentMethodSupport.java
@@ -1,0 +1,49 @@
+package com.mockhub.order.service;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+
+import com.mockhub.common.exception.ConflictException;
+
+public final class PaymentMethodSupport {
+
+    private static final String MOCK = "mock";
+    private static final List<String> SUPPORTED_METHODS = List.of(MOCK, "stripe");
+    private static final Set<String> SUPPORTED_METHOD_SET = Set.copyOf(SUPPORTED_METHODS);
+    private static final int DISPLAY_LIMIT = 80;
+
+    private PaymentMethodSupport() {
+    }
+
+    public static String normalize(String paymentMethod) {
+        if (paymentMethod == null || paymentMethod.isBlank()) {
+            throw new ConflictException("Payment method is required");
+        }
+
+        String normalized = paymentMethod.strip().toLowerCase(Locale.ROOT);
+        if (!SUPPORTED_METHOD_SET.contains(normalized)) {
+            throw new ConflictException("Unsupported payment method '" + abbreviate(paymentMethod.strip())
+                    + "'. Supported payment methods are: " + supportedValues());
+        }
+        return normalized;
+    }
+
+    public static String normalizeOrMock(String paymentMethod) {
+        if (paymentMethod == null) {
+            return MOCK;
+        }
+        return normalize(paymentMethod);
+    }
+
+    public static String supportedValues() {
+        return String.join(", ", SUPPORTED_METHODS);
+    }
+
+    private static String abbreviate(String value) {
+        if (value.length() <= DISPLAY_LIMIT) {
+            return value;
+        }
+        return value.substring(0, DISPLAY_LIMIT - 3) + "...";
+    }
+}

--- a/backend/src/main/resources/static/llms.txt
+++ b/backend/src/main/resources/static/llms.txt
@@ -73,7 +73,7 @@ GET /api/v1/my/owned-tickets — Tickets from confirmed orders available to reli
 GET /api/v1/my/earnings — Seller earnings summary with recent sales
 
 ## Checkout (requires auth)
-POST /api/v1/orders/checkout — Create order from cart. JSON body: {"paymentMethod": "string"}. Optional header: Idempotency-Key
+POST /api/v1/orders/checkout — Create order from cart. JSON body: {"paymentMethod": "mock"|"stripe"}. Optional header: Idempotency-Key
 
 ## Orders (requires auth)
 GET /api/v1/orders — List user's orders (paginated)
@@ -132,7 +132,7 @@ Sessions are in-memory — after server redeploys, clients must re-initialize.
 - removeFromCart(userEmail, itemId) — remove cart item
 - clearCart(userEmail) — empty cart
 - refreshCart(userEmail) — reset cart 15-minute TTL without modifying contents
-- checkout(userEmail, paymentMethod, agentId, mandateId) — create order from cart. May include agent-risk warnings.
+- checkout(userEmail, paymentMethod, agentId, mandateId) — create order from cart. paymentMethod must be exactly "mock" or "stripe"; use "mock" for MockHub's built-in mock-payment flow. May include agent-risk warnings.
 - confirmOrder(userEmail, orderNumber, agentId, mandateId, paymentIntentId?, paymentCredentialId?, approvalId?) — complete payment; non-mock payments require paymentIntentId. Optional paymentCredentialId validates scoped payment authority before payment. Optional approvalId links the purchase to an approved audit record. May include agent-risk warnings.
 - getOrder(userEmail, orderNumber) — order details
 - listOrders(userEmail, page?, size?) — order history with pagination
@@ -154,7 +154,7 @@ Sessions are in-memory — after server redeploys, clients must re-initialize.
 
 ## ACP Endpoints (Agentic Commerce Protocol, requires API key: X-API-Key header)
 ACP-compatible checkout endpoints at /acp/v1/:
-POST /acp/v1/checkout — Create checkout. JSON body: {"buyerEmail", "lineItems": [{"listingId", "quantity"}], "agentId", "mandateId", "paymentMethod", "idempotencyKey"}
+POST /acp/v1/checkout — Create checkout. JSON body: {"buyerEmail", "lineItems": [{"listingId", "quantity"}], "agentId", "mandateId", "paymentMethod": "mock"|"stripe", "idempotencyKey"}. If omitted, paymentMethod defaults to "mock".
 GET /acp/v1/checkout/{checkoutId} — Get checkout status. Header: X-Buyer-Email
 PUT /acp/v1/checkout/{checkoutId} — Update checkout (PENDING only). JSON body: {"agentId", "mandateId", "addItems", "removeListingIds"}. Header: X-Buyer-Email
 POST /acp/v1/checkout/{checkoutId}/complete — Complete checkout. JSON body: {"agentId", "mandateId", "paymentIntentId", "approvalId", "paymentCredentialId"}. Header: X-Buyer-Email
@@ -215,7 +215,7 @@ Email/SMS provider delivery receipts are not persisted; the evidence record mark
 
 ### Purchase Flow with Mandates
 
-findTickets(query, filters) → getBestMandate(agentId, userEmail, eventSlug, categorySlug?, amount?, sectionName?) → addToCart(userEmail, listingId, agentId, mandateId) → checkout(userEmail, paymentMethod, agentId, mandateId) → confirmOrder(userEmail, orderNumber, agentId, mandateId)
+findTickets(query, filters) → getBestMandate(agentId, userEmail, eventSlug, categorySlug?, amount?, sectionName?) → addToCart(userEmail, listingId, agentId, mandateId) → checkout(userEmail, paymentMethod="mock", agentId, mandateId) → confirmOrder(userEmail, orderNumber, agentId, mandateId)
 
 Each step validates the mandate via eval conditions. Spend is recorded on confirmation. If the order is later cancelled, spend is reversed.
 

--- a/backend/src/test/java/com/mockhub/acp/service/AcpCheckoutServiceTest.java
+++ b/backend/src/test/java/com/mockhub/acp/service/AcpCheckoutServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -225,7 +226,8 @@ class AcpCheckoutServiceTest {
         when(userRepository.findByEmail("buyer@test.com")).thenReturn(Optional.of(testUser));
         when(cartService.addToCart(testUser, 10L)).thenReturn(
                 new CartDto(1L, 1L, List.of(), BigDecimal.ZERO, 1, null));
-        when(orderService.checkout(eq(testUser), any(CheckoutRequest.class), eq("idem-123"), eq(AGENT_ID), eq(MANDATE_ID)))
+        when(orderService.checkout(
+                eq(testUser), any(CheckoutRequest.class), eq("idem-123"), eq(AGENT_ID), eq(MANDATE_ID)))
                 .thenReturn(testOrderDto);
 
         AcpCheckoutResponse response = acpCheckoutService.createCheckout(request);
@@ -243,6 +245,51 @@ class AcpCheckoutServiceTest {
         verify(cartService).clearCart(testUser);
         verify(cartService).addToCart(testUser, 10L);
         verify(orderService).checkout(eq(testUser), any(CheckoutRequest.class), eq("idem-123"), eq(AGENT_ID), eq(MANDATE_ID));
+    }
+
+    @Test
+    @DisplayName("createCheckout - uppercase payment method - normalizes before checkout")
+    void createCheckout_uppercasePaymentMethod_normalizesBeforeCheckout() {
+        AcpCheckoutRequest request = createCheckoutRequest(
+                "buyer@test.com",
+                List.of(new AcpLineItem(10L, 1)),
+                "STRIPE",
+                "idem-123"
+        );
+
+        when(userRepository.findByEmail("buyer@test.com")).thenReturn(Optional.of(testUser));
+        when(cartService.addToCart(testUser, 10L)).thenReturn(
+                new CartDto(1L, 1L, List.of(), BigDecimal.ZERO, 1, null));
+        when(orderService.checkout(eq(testUser), any(CheckoutRequest.class), eq("idem-123"), eq(AGENT_ID), eq(MANDATE_ID)))
+                .thenReturn(testOrderDto);
+
+        acpCheckoutService.createCheckout(request);
+
+        ArgumentCaptor<CheckoutRequest> requestCaptor = ArgumentCaptor.forClass(CheckoutRequest.class);
+        verify(orderService).checkout(
+                eq(testUser), requestCaptor.capture(), eq("idem-123"), eq(AGENT_ID), eq(MANDATE_ID));
+        assertEquals("stripe", requestCaptor.getValue().paymentMethod());
+    }
+
+    @Test
+    @DisplayName("createCheckout - verbose payment method - rejects before cart mutation")
+    void createCheckout_verbosePaymentMethod_rejectsBeforeCartMutation() {
+        AcpCheckoutRequest request = createCheckoutRequest(
+                "buyer@test.com",
+                List.of(new AcpLineItem(10L, 1)),
+                "use the mock payment fallback for this purchase",
+                "idem-123"
+        );
+
+        when(userRepository.findByEmail("buyer@test.com")).thenReturn(Optional.of(testUser));
+
+        ConflictException exception = assertThrows(ConflictException.class, () ->
+                acpCheckoutService.createCheckout(request));
+
+        assertEquals("Unsupported payment method 'use the mock payment fallback for this purchase'. "
+                + "Supported payment methods are: mock, stripe", exception.getMessage());
+        verify(cartService, never()).clearCart(any());
+        verify(orderService, never()).checkout(any(), any(), any(), any(), any());
     }
 
     @Test
@@ -621,6 +668,39 @@ class AcpCheckoutServiceTest {
         verify(cartService).addToCart(testUser, 10L);
         // Added new listing 30L
         verify(cartService).addToCart(testUser, 30L);
+    }
+
+    @Test
+    @DisplayName("updateCheckout - stripe order - preserves original payment method")
+    void updateCheckout_givenStripeOrder_preservesOriginalPaymentMethod() {
+        List<OrderItemDto> existingItems = List.of(
+                new OrderItemDto(1L, 10L, 100L, "Concert A", "concert-a",
+                        "Floor", "A", "1", "GENERAL", new BigDecimal("50.00")));
+        OrderDto pendingOrder = new OrderDto(
+                1L, "MH-20260323-0001", "PENDING",
+                new BigDecimal("50.00"), new BigDecimal("5.00"), new BigDecimal("55.00"),
+                "stripe", null, Instant.now(), existingItems, null, null);
+        OrderDto newOrder = new OrderDto(
+                2L, "MH-20260323-0002", "PENDING",
+                new BigDecimal("50.00"), new BigDecimal("5.00"), new BigDecimal("55.00"),
+                "stripe", null, Instant.now(), existingItems, null, null);
+
+        when(userRepository.findByEmail("buyer@test.com")).thenReturn(Optional.of(testUser));
+        when(orderService.getOrder(testUser, "MH-20260323-0001")).thenReturn(pendingOrder);
+        when(orderService.getOrderEntity("MH-20260323-0001"))
+                .thenReturn(createAgentOrder("MH-20260323-0001", "stripe"));
+        when(cartService.addToCart(eq(testUser), any(Long.class))).thenReturn(
+                new CartDto(1L, 1L, List.of(), BigDecimal.ZERO, 1, null));
+        when(orderService.checkout(eq(testUser), any(CheckoutRequest.class), eq(null), eq(AGENT_ID), eq(MANDATE_ID)))
+                .thenReturn(newOrder);
+
+        acpCheckoutService.updateCheckout(
+                "MH-20260323-0001", createUpdateRequest(null, null), "buyer@test.com");
+
+        ArgumentCaptor<CheckoutRequest> requestCaptor = ArgumentCaptor.forClass(CheckoutRequest.class);
+        verify(orderService).checkout(
+                eq(testUser), requestCaptor.capture(), eq(null), eq(AGENT_ID), eq(MANDATE_ID));
+        assertEquals("stripe", requestCaptor.getValue().paymentMethod());
     }
 
     @Test

--- a/backend/src/test/java/com/mockhub/agentrisk/service/AgentRiskServiceTest.java
+++ b/backend/src/test/java/com/mockhub/agentrisk/service/AgentRiskServiceTest.java
@@ -79,6 +79,106 @@ class AgentRiskServiceTest {
     }
 
     @Test
+    @DisplayName("recordCheckoutFailure - oversized audit fields - truncates before persist")
+    void recordCheckoutFailure_givenOversizedAuditFields_truncatesBeforePersist() {
+        when(agentRiskSignalRepository.save(any(AgentRiskSignal.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        String oversizedOrderNumber = "MH-20260319-0001-" + "x".repeat(120);
+        String oversizedMessage = "x".repeat(600);
+
+        agentRiskService.recordCheckoutFailure(
+                "buyer@example.com", "agent-1", oversizedOrderNumber, null, oversizedMessage);
+
+        ArgumentCaptor<AgentRiskSignal> captor = ArgumentCaptor.forClass(AgentRiskSignal.class);
+        verify(agentRiskSignalRepository).save(captor.capture());
+        AgentRiskSignal saved = captor.getValue();
+        assertThat(saved.getOrderNumber()).hasSize(30);
+        assertThat(saved.getResourceId()).hasSize(100);
+        assertThat(saved.getMessage()).hasSize(500);
+    }
+
+    @Test
+    @DisplayName("recordSignal - oversized identity fields - truncates before persist")
+    void recordSignal_givenOversizedIdentityFields_truncatesBeforePersist() {
+        when(agentRiskSignalRepository.save(any(AgentRiskSignal.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        agentRiskService.recordSignal(new RecordAgentRiskSignalRequest(
+                "u".repeat(300),
+                "a".repeat(300),
+                AgentRiskSignalType.FAILED_CHECKOUT,
+                EvalSeverity.WARNING,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "message"));
+
+        ArgumentCaptor<AgentRiskSignal> captor = ArgumentCaptor.forClass(AgentRiskSignal.class);
+        verify(agentRiskSignalRepository).save(captor.capture());
+        AgentRiskSignal saved = captor.getValue();
+        assertThat(saved.getUserEmail()).hasSize(255);
+        assertThat(saved.getAgentId()).hasSize(255);
+    }
+
+    @Test
+    @DisplayName("recordSignal - oversized optional audit fields - truncates before persist")
+    void recordSignal_givenOversizedOptionalAuditFields_truncatesBeforePersist() {
+        when(agentRiskSignalRepository.save(any(AgentRiskSignal.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        agentRiskService.recordSignal(new RecordAgentRiskSignalRequest(
+                "buyer@example.com",
+                "agent-1",
+                AgentRiskSignalType.FAILED_CHECKOUT,
+                EvalSeverity.WARNING,
+                "a".repeat(80),
+                "r".repeat(80),
+                "resource-1",
+                null,
+                "m".repeat(120),
+                null,
+                "message"));
+
+        ArgumentCaptor<AgentRiskSignal> captor = ArgumentCaptor.forClass(AgentRiskSignal.class);
+        verify(agentRiskSignalRepository).save(captor.capture());
+        AgentRiskSignal saved = captor.getValue();
+        assertThat(saved.getActionType()).hasSize(50);
+        assertThat(saved.getResourceType()).hasSize(50);
+        assertThat(saved.getMandateId()).hasSize(100);
+    }
+
+    @Test
+    @DisplayName("recordCheckoutFailure - null message - records fallback message")
+    void recordCheckoutFailure_givenNullMessage_recordsFallbackMessage() {
+        when(agentRiskSignalRepository.save(any(AgentRiskSignal.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        agentRiskService.recordCheckoutFailure(
+                "buyer@example.com", "agent-1", "MH-20260319-0001", null, null);
+
+        ArgumentCaptor<AgentRiskSignal> captor = ArgumentCaptor.forClass(AgentRiskSignal.class);
+        verify(agentRiskSignalRepository).save(captor.capture());
+        assertThat(captor.getValue().getMessage()).isEqualTo("Checkout failed");
+    }
+
+    @Test
+    @DisplayName("recordPaymentCredentialFailure - blank message - records fallback message")
+    void recordPaymentCredentialFailure_givenBlankMessage_recordsFallbackMessage() {
+        when(agentRiskSignalRepository.save(any(AgentRiskSignal.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        agentRiskService.recordPaymentCredentialFailure(
+                "buyer@example.com", "agent-1", "MH-20260319-0001", null, " ");
+
+        ArgumentCaptor<AgentRiskSignal> captor = ArgumentCaptor.forClass(AgentRiskSignal.class);
+        verify(agentRiskSignalRepository).save(captor.capture());
+        assertThat(captor.getValue().getMessage()).isEqualTo("Payment credential validation failed");
+    }
+
+    @Test
     @DisplayName("recordSignal - missing user email - rejects request")
     void recordSignal_givenMissingUserEmail_rejectsRequest() {
         RecordAgentRiskSignalRequest request = new RecordAgentRiskSignalRequest(
@@ -177,6 +277,32 @@ class AgentRiskServiceTest {
         assertThat(summary.highestSeverity()).isEqualTo("CRITICAL");
         assertThat(summary.reasons()).anySatisfy(reason -> assertThat(reason).contains("Repeated mandate"));
         assertThat(summary.recentSignals()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("summarizeRisk - oversized identity fields - queries with truncated values")
+    void summarizeRisk_givenOversizedIdentityFields_queriesWithTruncatedValues() {
+        String longUserEmail = "u".repeat(300);
+        String longAgentId = "a".repeat(300);
+        String truncatedUserEmail = "u".repeat(255);
+        String truncatedAgentId = "a".repeat(255);
+
+        when(agentRiskSignalRepository.findRecent(
+                eq(truncatedUserEmail), eq(truncatedAgentId), any(Instant.class), any(Pageable.class)))
+                .thenReturn(List.of());
+        when(agentRiskSignalRepository.countByUserEmailAndAgentIdAndCreatedAtAfter(
+                eq(truncatedUserEmail), eq(truncatedAgentId), any())).thenReturn(0L);
+        when(agentRiskSignalRepository.countByUserEmailAndAgentIdAndSeverityAndCreatedAtAfter(
+                eq(truncatedUserEmail), eq(truncatedAgentId), any(EvalSeverity.class), any())).thenReturn(0L);
+        when(agentRiskSignalRepository.countByUserEmailAndAgentIdAndSignalTypeAndCreatedAtAfter(
+                eq(truncatedUserEmail), eq(truncatedAgentId), any(AgentRiskSignalType.class), any())).thenReturn(0L);
+
+        AgentRiskSummaryDto summary = agentRiskService.summarizeRisk(longUserEmail, longAgentId);
+
+        assertThat(summary.userEmail()).isEqualTo(truncatedUserEmail);
+        assertThat(summary.agentId()).isEqualTo(truncatedAgentId);
+        verify(agentRiskSignalRepository).findRecent(
+                eq(truncatedUserEmail), eq(truncatedAgentId), any(Instant.class), any(Pageable.class));
     }
 
     private AgentRiskSignal signal(AgentRiskSignalType type, EvalSeverity severity) {

--- a/backend/src/test/java/com/mockhub/mcp/tools/OrderToolsTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/tools/OrderToolsTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -43,6 +44,7 @@ import com.mockhub.ticket.entity.Ticket;
 import com.mockhub.event.entity.Event;
 import com.mockhub.event.entity.Category;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -180,7 +182,8 @@ class OrderToolsTest {
                     .thenReturn(true);
             OrderDto orderDto = new OrderDto(
                     null, null, null, null, null, null, null, null, null, null, null, null);
-            when(orderService.checkout(eq(testUser), any(CheckoutRequest.class), any(), eq(AGENT_ID), eq(MANDATE_ID)))
+            when(orderService.checkout(
+                    eq(testUser), any(CheckoutRequest.class), any(), eq(AGENT_ID), eq(MANDATE_ID)))
                     .thenReturn(orderDto);
 
             String result = orderTools.checkout("buyer@example.com", "mock", AGENT_ID, MANDATE_ID);
@@ -189,6 +192,40 @@ class OrderToolsTest {
             verify(mandateService).validateAction(AGENT_ID, "buyer@example.com", "PURCHASE",
                     java.math.BigDecimal.TEN, null, "test-event", MANDATE_ID, "Floor");
             assertTrue(!result.contains("\"error\""), "Result should not contain error field");
+        }
+
+        @Test
+        @DisplayName("given uppercase payment method - normalizes before checkout")
+        void givenUppercasePaymentMethod_normalizesBeforeCheckout() {
+            stubUserLookup("buyer@example.com");
+            when(cartService.getCartDto(testUser)).thenReturn(createCartWithFloorTicket());
+            stubPassingEval();
+            when(mandateService.validateAction(AGENT_ID, "buyer@example.com", "PURCHASE",
+                    java.math.BigDecimal.TEN, null, "test-event", MANDATE_ID, "Floor"))
+                    .thenReturn(true);
+            OrderDto orderDto = new OrderDto(
+                    null, null, null, null, null, null, null, null, null, null, null, null);
+            when(orderService.checkout(eq(testUser), any(CheckoutRequest.class), any(), eq(AGENT_ID), eq(MANDATE_ID)))
+                    .thenReturn(orderDto);
+
+            orderTools.checkout("buyer@example.com", "STRIPE", AGENT_ID, MANDATE_ID);
+
+            ArgumentCaptor<CheckoutRequest> requestCaptor = ArgumentCaptor.forClass(CheckoutRequest.class);
+            verify(orderService).checkout(
+                    eq(testUser), requestCaptor.capture(), any(), eq(AGENT_ID), eq(MANDATE_ID));
+            assertEquals("stripe", requestCaptor.getValue().paymentMethod());
+        }
+
+        @Test
+        @DisplayName("given verbose payment method - returns error before checkout")
+        void givenVerbosePaymentMethod_returnsErrorBeforeCheckout() {
+            String result = orderTools.checkout(
+                    "buyer@example.com", "use the mock payment fallback for this purchase", AGENT_ID, MANDATE_ID);
+
+            assertTrue(result.contains("\"error\""), "Result should contain error field");
+            assertTrue(result.contains("Unsupported payment method"), "Result should explain supported methods");
+            verify(orderService, never()).checkout(any(), any(), any(), any(), any());
+            verify(cartService, never()).getCartDto(any());
         }
 
         @Test
@@ -480,6 +517,25 @@ class OrderToolsTest {
         }
 
         @Test
+        @DisplayName("given malformed order number - returns validation error before lookup")
+        void givenMalformedOrderNumber_returnsValidationErrorBeforeLookup() {
+            String result = orderTools.confirmOrder(
+                    "buyer@example.com",
+                    "MH-20260319-0001 and please confirm this order now",
+                    AGENT_ID,
+                    MANDATE_ID,
+                    null,
+                    null,
+                    null);
+
+            assertTrue(result.contains("\"error\""), "Result should contain error field");
+            assertTrue(result.contains("Order number must use format"),
+                    "Result should describe the order number contract");
+            verify(userRepository, never()).findByEmail(any());
+            verify(agentRiskService, never()).recordCheckoutFailure(any(), any(), any(), any(), any());
+        }
+
+        @Test
         @DisplayName("given order number with whitespace - strips whitespace before lookup")
         void givenOrderNumberWithWhitespace_stripsWhitespace() {
             stubUserLookup("buyer@example.com");
@@ -522,10 +578,10 @@ class OrderToolsTest {
         @DisplayName("given service throws exception - returns error JSON")
         void givenServiceThrowsException_returnsErrorJson() {
             stubUserLookup("buyer@example.com");
-            Order orderEntity = createAgentOrderEntity("MH-INVALID");
-            when(orderService.getOrder(testUser, "MH-INVALID")).thenReturn(
+            Order orderEntity = createAgentOrderEntity("MH-20260319-9999");
+            when(orderService.getOrder(testUser, "MH-20260319-9999")).thenReturn(
                     new OrderDto(null, null, null, null, null, null, null, null, null, null, null, null));
-            when(orderService.getOrderEntity("MH-INVALID")).thenReturn(orderEntity);
+            when(orderService.getOrderEntity("MH-20260319-9999")).thenReturn(orderEntity);
             stubPassingEval();
             when(paymentService.createPaymentIntent(orderEntity))
                     .thenReturn(new PaymentIntentDto("pi_invalid", "secret", java.math.BigDecimal.TEN, "USD"));
@@ -533,7 +589,7 @@ class OrderToolsTest {
                     .when(paymentService).confirmPayment("pi_invalid");
 
             String result = orderTools.confirmOrder(
-                    "buyer@example.com", "MH-INVALID", AGENT_ID, MANDATE_ID, null, null, null);
+                    "buyer@example.com", "MH-20260319-9999", AGENT_ID, MANDATE_ID, null, null, null);
 
             assertTrue(result.contains("\"error\""), "Result should contain error field");
             assertTrue(result.contains("Failed to confirm order"), "Result should contain failure message");

--- a/backend/src/test/java/com/mockhub/order/dto/CheckoutRequestTest.java
+++ b/backend/src/test/java/com/mockhub/order/dto/CheckoutRequestTest.java
@@ -1,0 +1,74 @@
+package com.mockhub.order.dto;
+
+import java.util.Set;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CheckoutRequestTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    @Test
+    @DisplayName("paymentMethod - uppercase supported method - passes validation")
+    void paymentMethod_givenUppercaseSupportedMethod_passesValidation() {
+        Set<ConstraintViolation<CheckoutRequest>> violations =
+                validator.validate(new CheckoutRequest("STRIPE"));
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("paymentMethod - supported method with whitespace - passes validation")
+    void paymentMethod_givenSupportedMethodWithWhitespace_passesValidation() {
+        Set<ConstraintViolation<CheckoutRequest>> violations =
+                validator.validate(new CheckoutRequest(" stripe "));
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("paymentMethod - verbose unsupported method - fails validation")
+    void paymentMethod_givenVerboseUnsupportedMethod_failsValidation() {
+        Set<ConstraintViolation<CheckoutRequest>> violations =
+                validator.validate(new CheckoutRequest("use the mock payment fallback for this purchase"));
+
+        assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("Payment method must be one of: mock, stripe");
+    }
+
+    @Test
+    @DisplayName("paymentMethod - blank method - fails required validation")
+    void paymentMethod_givenBlankMethod_failsRequiredValidation() {
+        Set<ConstraintViolation<CheckoutRequest>> violations =
+                validator.validate(new CheckoutRequest(" "));
+
+        assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("Payment method is required");
+    }
+
+    @Test
+    @DisplayName("paymentMethod - overlong method - fails size validation")
+    void paymentMethod_givenOverlongMethod_failsSizeValidation() {
+        Set<ConstraintViolation<CheckoutRequest>> violations =
+                validator.validate(new CheckoutRequest("x".repeat(31)));
+
+        assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .contains("Payment method must not exceed 30 characters");
+    }
+}

--- a/backend/src/test/java/com/mockhub/order/service/OrderNumberSupportTest.java
+++ b/backend/src/test/java/com/mockhub/order/service/OrderNumberSupportTest.java
@@ -1,0 +1,41 @@
+package com.mockhub.order.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OrderNumberSupportTest {
+
+    @Test
+    @DisplayName("normalizeGeneratedOrderNumber - valid number with whitespace - returns stripped value")
+    void normalizeGeneratedOrderNumber_givenValidNumberWithWhitespace_returnsStrippedValue() {
+        assertThat(OrderNumberSupport.normalizeGeneratedOrderNumber("  MH-20260319-0001  "))
+                .isEqualTo("MH-20260319-0001");
+    }
+
+    @Test
+    @DisplayName("normalizeGeneratedOrderNumber - blank number - throws required error")
+    void normalizeGeneratedOrderNumber_givenBlankNumber_throwsRequiredError() {
+        assertThatThrownBy(() -> OrderNumberSupport.normalizeGeneratedOrderNumber(" "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Order number is required");
+    }
+
+    @Test
+    @DisplayName("normalizeGeneratedOrderNumber - null number - throws required error")
+    void normalizeGeneratedOrderNumber_givenNullNumber_throwsRequiredError() {
+        assertThatThrownBy(() -> OrderNumberSupport.normalizeGeneratedOrderNumber(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Order number is required");
+    }
+
+    @Test
+    @DisplayName("normalizeGeneratedOrderNumber - malformed number - throws format error")
+    void normalizeGeneratedOrderNumber_givenMalformedNumber_throwsFormatError() {
+        assertThatThrownBy(() -> OrderNumberSupport.normalizeGeneratedOrderNumber("MH-INVALID"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Order number must use format MH-YYYYMMDD-0001");
+    }
+}

--- a/backend/src/test/java/com/mockhub/order/service/OrderServiceTest.java
+++ b/backend/src/test/java/com/mockhub/order/service/OrderServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
@@ -199,6 +200,57 @@ class OrderServiceTest {
     }
 
     @Test
+    @DisplayName("checkout - given uppercase payment method - stores normalized value")
+    void checkout_givenUppercasePaymentMethod_storesNormalizedValue() {
+        CheckoutRequest request = new CheckoutRequest("STRIPE");
+
+        when(cartRepository.findByUser(testUser)).thenReturn(Optional.of(testCart));
+        when(orderRepository.findMaxOrderNumberByPrefix(anyString())).thenReturn(Optional.empty());
+        when(orderRepository.save(any(Order.class))).thenAnswer(invocation -> {
+            Order order = invocation.getArgument(0);
+            order.setId(1L);
+            order.setCreatedAt(Instant.now());
+            return order;
+        });
+
+        OrderDto result = orderService.checkout(testUser, request, null);
+
+        ArgumentCaptor<Order> orderCaptor = ArgumentCaptor.forClass(Order.class);
+        verify(orderRepository).save(orderCaptor.capture());
+        assertEquals("stripe", orderCaptor.getValue().getPaymentMethod());
+        assertEquals("stripe", result.paymentMethod());
+    }
+
+    @Test
+    @DisplayName("checkout - given unsupported payment method - rejects before reserving tickets")
+    void checkout_givenUnsupportedPaymentMethod_rejectsBeforeReservingTickets() {
+        CheckoutRequest request = new CheckoutRequest("use the mock payment fallback for this purchase");
+
+        ConflictException exception = assertThrows(ConflictException.class,
+                () -> orderService.checkout(testUser, request, null));
+
+        assertEquals("Unsupported payment method 'use the mock payment fallback for this purchase'. "
+                + "Supported payment methods are: mock, stripe", exception.getMessage());
+        verify(cartRepository, never()).findByUser(any());
+        verify(ticketService, never()).reserveTicket(anyLong());
+        verify(orderRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("checkout - given blank payment method - rejects before reserving tickets")
+    void checkout_givenBlankPaymentMethod_rejectsBeforeReservingTickets() {
+        CheckoutRequest request = new CheckoutRequest("   ");
+
+        ConflictException exception = assertThrows(ConflictException.class,
+                () -> orderService.checkout(testUser, request, null));
+
+        assertEquals("Payment method is required", exception.getMessage());
+        verify(cartRepository, never()).findByUser(any());
+        verify(ticketService, never()).reserveTicket(anyLong());
+        verify(orderRepository, never()).save(any());
+    }
+
+    @Test
     @DisplayName("checkout - given empty cart - throws ConflictException")
     void checkout_givenEmptyCart_throwsConflictException() {
         testCart.setItems(new ArrayList<>());
@@ -248,6 +300,34 @@ class OrderServiceTest {
         assertNotNull(result);
         assertEquals("MH-20260319-0001", result.orderNumber());
         verify(cartRepository, org.mockito.Mockito.never()).findByUser(any());
+    }
+
+    @Test
+    @DisplayName("checkout - given duplicate idempotency key with invalid payment method - returns existing order")
+    void checkout_givenDuplicateIdempotencyKeyWithInvalidPaymentMethod_returnsExistingOrder() {
+        Order existingOrder = new Order();
+        existingOrder.setId(99L);
+        existingOrder.setUser(testUser);
+        existingOrder.setOrderNumber("MH-20260319-0001");
+        existingOrder.setStatus(OrderStatus.PENDING);
+        existingOrder.setSubtotal(new BigDecimal("75.00"));
+        existingOrder.setServiceFee(new BigDecimal("7.50"));
+        existingOrder.setTotal(new BigDecimal("82.50"));
+        existingOrder.setPaymentMethod("mock");
+        existingOrder.setIdempotencyKey("idem-key-123");
+        existingOrder.setItems(new ArrayList<>());
+        existingOrder.setCreatedAt(Instant.now());
+
+        when(orderRepository.findByIdempotencyKey("idem-key-123"))
+                .thenReturn(Optional.of(existingOrder));
+
+        CheckoutRequest request = new CheckoutRequest("verbose invalid payment method");
+        OrderDto result = orderService.checkout(testUser, request, "idem-key-123");
+
+        assertNotNull(result);
+        assertEquals("MH-20260319-0001", result.orderNumber());
+        verify(cartRepository, never()).findByUser(any());
+        verify(orderRepository, never()).save(any());
     }
 
     @Test

--- a/backend/src/test/java/com/mockhub/order/service/PaymentMethodSupportTest.java
+++ b/backend/src/test/java/com/mockhub/order/service/PaymentMethodSupportTest.java
@@ -1,0 +1,51 @@
+package com.mockhub.order.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.mockhub.common.exception.ConflictException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PaymentMethodSupportTest {
+
+    @Test
+    @DisplayName("normalize - uppercase supported method - returns lowercase value")
+    void normalize_givenUppercaseSupportedMethod_returnsLowercaseValue() {
+        assertThat(PaymentMethodSupport.normalize(" STRIPE ")).isEqualTo("stripe");
+    }
+
+    @Test
+    @DisplayName("normalize - blank method - throws required error")
+    void normalize_givenBlankMethod_throwsRequiredError() {
+        assertThatThrownBy(() -> PaymentMethodSupport.normalize(" "))
+                .isInstanceOf(ConflictException.class)
+                .hasMessage("Payment method is required");
+    }
+
+    @Test
+    @DisplayName("normalize - null method - throws required error")
+    void normalize_givenNullMethod_throwsRequiredError() {
+        assertThatThrownBy(() -> PaymentMethodSupport.normalize(null))
+                .isInstanceOf(ConflictException.class)
+                .hasMessage("Payment method is required");
+    }
+
+    @Test
+    @DisplayName("normalize - long unsupported method - abbreviates error value")
+    void normalize_givenLongUnsupportedMethod_abbreviatesErrorValue() {
+        String unsupported = "x".repeat(100);
+
+        assertThatThrownBy(() -> PaymentMethodSupport.normalize(unsupported))
+                .isInstanceOf(ConflictException.class)
+                .hasMessageContaining("x".repeat(77) + "...")
+                .hasMessageContaining("Supported payment methods are: mock, stripe");
+    }
+
+    @Test
+    @DisplayName("normalizeOrMock - null method - defaults to mock")
+    void normalizeOrMock_givenNullMethod_defaultsToMock() {
+        assertThat(PaymentMethodSupport.normalizeOrMock(null)).isEqualTo("mock");
+    }
+}

--- a/docs/acp-openapi.yaml
+++ b/docs/acp-openapi.yaml
@@ -322,7 +322,10 @@ components:
           minItems: 1
         paymentMethod:
           type: string
-          description: Payment method (default "mock")
+          description: Payment method. Defaults to "mock" when omitted.
+          enum:
+            - mock
+            - stripe
           default: mock
         idempotencyKey:
           type: string

--- a/docs/agentic-commerce.md
+++ b/docs/agentic-commerce.md
@@ -60,6 +60,7 @@ An agent can now execute a full purchase on behalf of a user:
 3. checkout(userEmail="buyer@example.com", paymentMethod="mock",
             agentId="shopping-agent-1", mandateId="abc-123")
    → Validates listings, reserves tickets, creates PENDING order
+   → Requires paymentMethod to be exactly "mock" or "stripe"; use "mock" for the built-in mock-payment flow
    → AgentRiskCondition checks recent agent risk signals before the order is created
    → Records checkout attempts and returns OrderDto with any warnings
 
@@ -364,6 +365,7 @@ The listing search endpoint is a MockHub offer-discovery extension around the pi
      "paymentMethod": "mock"
    }
    → Returns AcpCheckoutResponse with status CREATED and commercePolicy
+   → paymentMethod is optional for ACP checkout; when present it must be exactly "mock" or "stripe"
 
 3. Agent completes checkout
    POST /acp/v1/checkout/MH-20260323-0001/complete


### PR DESCRIPTION
## Summary
- Validate and normalize agent checkout payment methods before persistence
- Validate generated order numbers before MCP confirmation/audit logging
- Truncate agent-risk audit fields and preserve ACP payment method on checkout updates
- Update MCP/ACP docs for the `mock`/`stripe` payment method contract

## Verification
- `./gradlew test --tests com.mockhub.agentrisk.service.AgentRiskServiceTest --tests com.mockhub.acp.service.AcpCheckoutServiceTest --tests com.mockhub.order.dto.CheckoutRequestTest --tests com.mockhub.order.service.PaymentMethodSupportTest --tests com.mockhub.order.service.OrderNumberSupportTest --tests com.mockhub.order.service.OrderServiceTest --tests com.mockhub.mcp.tools.OrderToolsTest`
- `./gradlew test jacocoTestReport`
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('../docs/acp-openapi.yaml')"`\n\nCloses #250