### PR TITLE
test: extract duplicated email literals into constants (SonarCloud S1192)

### DIFF
--- a/backend/src/test/java/com/mockhub/mcp/McpAuthenticatedEmailFilterTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/McpAuthenticatedEmailFilterTest.java
@@ -30,6 +30,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class McpAuthenticatedEmailFilterTest {
 
+    private static final String BUYER_EMAIL = "buyer@test.com";
+
     @Mock
     private UserRepository userRepository;
 
@@ -55,17 +57,17 @@ class McpAuthenticatedEmailFilterTest {
     @Test
     @DisplayName("doFilterInternal - given authenticated known user - pins email for the request and clears after")
     void doFilterInternal_givenAuthenticatedKnownUser_pinsEmailThenClears() throws Exception {
-        authenticateAs("buyer@test.com");
+        authenticateAs(BUYER_EMAIL);
         User user = new User();
-        user.setEmail("buyer@test.com");
-        when(userRepository.findByEmail("buyer@test.com")).thenReturn(Optional.of(user));
+        user.setEmail(BUYER_EMAIL);
+        when(userRepository.findByEmail(BUYER_EMAIL)).thenReturn(Optional.of(user));
 
         AtomicReference<String> emailDuringChain = new AtomicReference<>();
         FilterChain chain = (req, res) -> emailDuringChain.set(ChatContext.getAuthenticatedEmail());
 
         filter.doFilterInternal(request, response, chain);
 
-        assertEquals("buyer@test.com", emailDuringChain.get(),
+        assertEquals(BUYER_EMAIL, emailDuringChain.get(),
                 "Tool calls should see the authenticated user's email");
         assertNull(ChatContext.getAuthenticatedEmail(), "Context must be cleared after the request");
     }

--- a/backend/src/test/java/com/mockhub/mcp/tools/MandateToolsTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/tools/MandateToolsTest.java
@@ -31,6 +31,8 @@ import static org.mockito.Mockito.when;
 @ExtendWith(MockitoExtension.class)
 class MandateToolsTest {
 
+    private static final String OWNER_EMAIL = "owner@real.com";
+
     @Mock
     private MandateService mandateService;
 
@@ -55,9 +57,9 @@ class MandateToolsTest {
         // Simulates the OAuth2 MCP path: McpAuthenticatedEmailFilter has pinned the
         // token subject. An agent passing a different userEmail must not be able to
         // create a mandate for someone else.
-        ChatContext.setAuthenticatedEmail("owner@real.com");
+        ChatContext.setAuthenticatedEmail(OWNER_EMAIL);
         MandateDto mandateDto = new MandateDto(
-                1L, "mandate-xyz", "agent-1", "owner@real.com", "PURCHASE",
+                1L, "mandate-xyz", "agent-1", OWNER_EMAIL, "PURCHASE",
                 new BigDecimal("100.00"), null, BigDecimal.ZERO, null, null, null, null,
                 "AUTO_PURCHASE", "ACTIVE", null, Instant.now());
         when(mandateService.createMandate(any(CreateMandateRequest.class))).thenReturn(mandateDto);
@@ -68,7 +70,7 @@ class MandateToolsTest {
 
         ArgumentCaptor<CreateMandateRequest> captor = ArgumentCaptor.forClass(CreateMandateRequest.class);
         verify(mandateService).createMandate(captor.capture());
-        assertEquals("owner@real.com", captor.getValue().userEmail(),
+        assertEquals(OWNER_EMAIL, captor.getValue().userEmail(),
                 "Mandate must be created for the authenticated user, not the spoofed parameter");
     }
 


### PR DESCRIPTION
## Summary

Follow-up cleanup to #254. SonarCloud's Quality Gate passed there, but the analysis raised new issues on the added test code. The confidently-identifiable ones are **S1192 (duplicated string literal)**, which fires at 3+ identical literals:

- `McpAuthenticatedEmailFilterTest`: `"buyer@test.com"` appears 4× → extracted to `BUYER_EMAIL`.
- `MandateToolsTest`: `"owner@real.com"` appears 3× → extracted to `OWNER_EMAIL`.

The A2A test's `https://test.mockhub.example/...` strings are distinct literals (different suffixes), so they don't trip S1192 and were left alone.

## Note on scope

The SonarQube MCP server isn't reachable from the authoring environment and the SonarCloud issues API returns 403 for anonymous access, so I couldn't enumerate the full new-issue list from #254 — these two are the high-confidence S1192 hits identified by inspecting the diff. This PR's own SonarCloud run will confirm whether the new-issue count drops; if other smells remain, they can be addressed once the list is visible.

No behavior change; both affected test classes pass locally.

https://claude.ai/code/session_01E15uxiGxny4AFaSYB3fYkQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01E15uxiGxny4AFaSYB3fYkQ)_