### PR TITLE
Upgrade Spring AI to 2.0.0 GA

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ MockHub is a secondary concert ticket marketplace (like StubHub) built as a teac
 
 - **Backend:** Spring Boot 4, Java 25, Gradle 9.4.0 (Kotlin DSL)
 - **Database:** PostgreSQL 17 (standard — pgvector removed, all search uses tsvector full-text)
-- **AI:** Spring AI 2.0.0-M3 (milestone — requires Spring Milestones repo in Gradle)
+- **AI:** Spring AI 2.0.0
 - **Frontend:** React 19, TypeScript, Vite, Tailwind CSS, shadcn/ui, TanStack React Query, Zustand
 - **Testing:** JUnit 5 + Mockito + Testcontainers (backend), Vitest + React Testing Library + MSW (frontend), Playwright (E2E, 3 browsers, sharded CI)
 - **Payments:** Stripe test mode + mock fallback via Spring profiles
@@ -51,7 +51,7 @@ The codebase uses Java DOP patterns where they add value:
 - **Conditional activation:** AI services use `@ConditionalOnProperty(name = "spring.ai.anthropic.api-key")` (NOT `@ConditionalOnBean` — that evaluates before auto-config creates the beans). The `AiController` injects `Optional<ChatService>` etc. and returns 503 when no AI provider is active.
 - **Profile activation:** `SPRING_PROFILES_ACTIVE=dev,ai-anthropic` — just add the AI provider to dev.
 - **Services:** `ChatService` (chat assistant with 10-message `MessageWindowChatMemory`), `PricePredictionService` (price trend analysis), `RecommendationService` (AI-ranked event recommendations).
-- **ChatClient has function-calling tools.** `EventTools` and `PricingTools` are wired into the ChatClient via `.defaultToolCallbacks(ToolCallbacks.from(...))`. The same `@Tool`-annotated classes serve both the MCP server (external agents) and the chat endpoint (users on the website).
+- **ChatClient has function-calling tools.** `EventTools` and `PricingTools` are wired into the ChatClient via `.defaultTools(...)`. The same `@Tool`-annotated classes serve both the MCP server (external agents) and the chat endpoint (users on the website).
 - **AI responses are parsed from JSON.** Services prompt the LLM for JSON output and parse with Jackson. Fallback logic returns safe defaults if parsing fails.
 - **Circular dependency:** MCP tool registration → PricingTools → PricePredictionService → ChatClient creates a cycle. Broken with `@Lazy` on the `ChatClient` parameter in `PricePredictionService`.
 - **ChatContext email enforcement:** Website chat tool calls use `ChatContext` (ThreadLocal) to override the LLM-provided `userEmail` with the authenticated user's email. Prevents prompt injection from operating as a different user. External MCP calls don't set the context, so `userEmail` is honored as-is. All tool classes use `ChatContext.resolveEmail(paramEmail)` for consistent resolution.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ MockHub is a secondary concert ticket marketplace (like StubHub) built as a teac
 
 - **Backend:** Spring Boot 4, Java 25, Gradle 9.4.0 (Kotlin DSL)
 - **Database:** PostgreSQL 17 (standard — pgvector removed, all search uses tsvector full-text)
-- **AI:** Spring AI 2.0.0-M4 (milestone — requires Spring Milestones repo in Gradle)
+- **AI:** Spring AI 2.0.0
 - **Frontend:** React 19, TypeScript, Vite, Tailwind CSS, shadcn/ui, TanStack React Query, Zustand
 - **Testing:** JUnit 5 + Mockito + Testcontainers (backend), Vitest + React Testing Library + MSW (frontend), Playwright (E2E, 3 browsers, sharded CI)
 - **Payments:** Stripe test mode + mock fallback via Spring profiles
@@ -52,7 +52,7 @@ The codebase uses Java DOP patterns where they add value:
 - **Conditional activation:** AI services use `@ConditionalOnProperty(name = "spring.ai.anthropic.api-key")` (NOT `@ConditionalOnBean` — that evaluates before auto-config creates the beans). The `AiController` injects `Optional<ChatService>` etc. and returns 503 when no AI provider is active.
 - **Profile activation:** `SPRING_PROFILES_ACTIVE=dev,ai-anthropic` — just add the AI provider to dev.
 - **Services:** `ChatService` (chat assistant with 10-message `MessageWindowChatMemory`), `PricePredictionService` (price trend analysis), `RecommendationService` (AI-ranked event recommendations).
-- **ChatClient has function-calling tools.** `EventTools` and `PricingTools` are wired into the ChatClient via `.defaultToolCallbacks(ToolCallbacks.from(...))`. The same `@Tool`-annotated classes serve both the MCP server (external agents) and the chat endpoint (users on the website).
+- **ChatClient has function-calling tools.** `EventTools` and `PricingTools` are wired into the ChatClient via `.defaultTools(...)`. The same `@Tool`-annotated classes serve both the MCP server (external agents) and the chat endpoint (users on the website).
 - **AI responses are parsed from JSON.** Services prompt the LLM for JSON output and parse with Jackson. Fallback logic returns safe defaults if parsing fails.
 - **Circular dependency:** MCP tool registration → PricingTools → PricePredictionService → ChatClient creates a cycle. Broken with `@Lazy` on the `ChatClient` parameter in `PricePredictionService`.
 - **ChatContext email enforcement:** Website chat tool calls use `ChatContext` (ThreadLocal) to override the LLM-provided `userEmail` with the authenticated user's email. Prevents prompt injection from operating as a different user. External MCP calls don't set the context, so `userEmail` is honored as-is. All tool classes use `ChatContext.resolveEmail(paramEmail)` for consistent resolution.

--- a/PROJECT_JOURNAL.md
+++ b/PROJECT_JOURNAL.md
@@ -14,7 +14,7 @@ MockHub is a secondary concert ticket marketplace (like StubHub) built as a teac
 |-------|-----------|
 | Backend | Spring Boot 4, Java 25, Gradle 9.4.0 (Kotlin DSL) |
 | Database | PostgreSQL 17 (tsvector full-text search) |
-| AI | Spring AI 2.0.0-M3 (Anthropic, OpenAI, Ollama profiles) |
+| AI | Spring AI 2.0.0 (Anthropic, OpenAI, Ollama profiles) |
 | Frontend | React 19, TypeScript, Vite, Tailwind CSS, shadcn/ui |
 | State Management | TanStack React Query (server), Zustand (client) |
 | Payments | Stripe test mode + mock fallback via Spring profiles |

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ MockHub mimics the functionality of sites like StubHub and TicketNetwork — reg
 
 | Layer | Technology |
 |-------|-----------|
-| Backend | Spring Boot 4, Java 25, Spring AI 2.0.0-M4 |
+| Backend | Spring Boot 4, Java 25, Spring AI 2.0.0 |
 | Database | PostgreSQL 17 (full-text search via tsvector) |
 | Frontend | React 19, TypeScript, Tailwind CSS, shadcn/ui |
 | Build | Gradle 9.4.0, Vite |

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -18,7 +18,6 @@ java {
 
 repositories {
     mavenCentral()
-    maven { url = uri("https://repo.spring.io/milestone") }
 }
 
 dependencyManagement {

--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ sonarqube = "7.2.3.7755"
 spotless = "7.0.2"
 
 # Spring AI BOM
-spring-ai = "2.0.0-M4"
+spring-ai = "2.0.0"
 
 # MCP Security
 mcp-security = "0.1.5"

--- a/backend/src/main/java/com/mockhub/config/AiConfig.java
+++ b/backend/src/main/java/com/mockhub/config/AiConfig.java
@@ -5,7 +5,6 @@ import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.ai.chat.client.advisor.MessageChatMemoryAdvisor;
 import org.springframework.ai.chat.memory.ChatMemory;
 import org.springframework.ai.chat.memory.MessageWindowChatMemory;
-import org.springframework.ai.support.ToolCallbacks;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -70,8 +69,7 @@ public class AiConfig {
                         When mentioning the events page, link to [Browse Events](/events). \
                         Keep responses concise and helpful.""")
                 .defaultAdvisors(MessageChatMemoryAdvisor.builder(chatMemory).build())
-                .defaultToolCallbacks(ToolCallbacks.from(eventTools, pricingTools,
-                        cartTools, orderTools, mandateTools))
+                .defaultTools(eventTools, pricingTools, cartTools, orderTools, mandateTools)
                 .build();
     }
 }

--- a/backend/src/main/java/com/mockhub/eval/config/EvalConfig.java
+++ b/backend/src/main/java/com/mockhub/eval/config/EvalConfig.java
@@ -1,5 +1,6 @@
 package com.mockhub.eval.config;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.ai.anthropic.AnthropicChatModel;
 import org.springframework.ai.chat.client.ChatClient;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -8,7 +9,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
-import org.springframework.lang.Nullable;
 
 import com.mockhub.eval.condition.GroundingEvalCondition;
 

--- a/backend/src/main/java/com/mockhub/mcp/McpSessionRecoveryFilter.java
+++ b/backend/src/main/java/com/mockhub/mcp/McpSessionRecoveryFilter.java
@@ -19,8 +19,8 @@ import org.springframework.web.util.ContentCachingResponseWrapper;
 /**
  * Converts Spring AI's "Session not found" JSON-RPC errors to HTTP 404 responses.
  *
- * Spring AI 2.0.0-M3 returns session-not-found errors as HTTP 200 with a JSON-RPC
- * error body. MCP clients (like mcp-remote) can't recover from this because they
+ * Spring AI's MCP server can return session-not-found errors as HTTP 200 with a JSON-RPC
+ * error body. MCP clients can't recover from this because they
  * see a successful HTTP response with an opaque error payload.
  *
  * Per the MCP spec, an unknown session ID should return HTTP 404, which signals
@@ -63,7 +63,8 @@ public class McpSessionRecoveryFilter extends OncePerRequestFilter {
                 wrappedResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
                 wrappedResponse.setContentType("application/json");
                 wrappedResponse.getWriter().write(
-                        "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32600,\"message\":\"Session expired. Please reconnect.\"}}");
+                        "{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32600,"
+                                + "\"message\":\"Session expired. Please reconnect.\"}}");
                 wrappedResponse.copyBodyToResponse();
                 return;
             }

--- a/backend/src/main/resources/application-ai-anthropic.yml
+++ b/backend/src/main/resources/application-ai-anthropic.yml
@@ -3,8 +3,7 @@ spring:
     anthropic:
       api-key: ${ANTHROPIC_API_KEY}
       chat:
-        options:
-          model: claude-sonnet-4-6
+        model: claude-sonnet-4-6
 
   # Override base exclusions: keep Anthropic, exclude everything else
   autoconfigure:

--- a/backend/src/main/resources/application-ai-ollama.yml
+++ b/backend/src/main/resources/application-ai-ollama.yml
@@ -3,8 +3,6 @@ spring:
     ollama:
       base-url: http://localhost:11434
       chat:
-        options:
-          model: llama3.2
+        model: llama3.2
       embedding:
-        options:
-          model: nomic-embed-text
+        model: nomic-embed-text

--- a/backend/src/main/resources/application-ai-openai.yml
+++ b/backend/src/main/resources/application-ai-openai.yml
@@ -3,8 +3,6 @@ spring:
     openai:
       api-key: ${OPENAI_API_KEY}
       chat:
-        options:
-          model: gpt-4o
+        model: gpt-4o
       embedding:
-        options:
-          model: text-embedding-3-small
+        model: text-embedding-3-small

--- a/backend/src/test/java/com/mockhub/config/AiConfigTest.java
+++ b/backend/src/test/java/com/mockhub/config/AiConfigTest.java
@@ -1,0 +1,44 @@
+package com.mockhub.config;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.ai.anthropic.AnthropicChatModel;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.chat.memory.ChatMemory;
+
+import com.mockhub.mcp.tools.CartTools;
+import com.mockhub.mcp.tools.EventTools;
+import com.mockhub.mcp.tools.MandateTools;
+import com.mockhub.mcp.tools.OrderTools;
+import com.mockhub.mcp.tools.PricingTools;
+
+@DisplayName("AiConfig")
+class AiConfigTest {
+
+    private final AiConfig config = new AiConfig();
+
+    @Test
+    @DisplayName("chatMemory - returns configured memory")
+    void chatMemory_returnsConfiguredMemory() {
+        ChatMemory chatMemory = config.chatMemory();
+
+        Assertions.assertNotNull(chatMemory);
+    }
+
+    @Test
+    @DisplayName("chatClient - given model and tools - builds chat client")
+    void chatClient_givenModelAndTools_buildsChatClient() {
+        ChatClient chatClient = config.chatClient(
+                Mockito.mock(AnthropicChatModel.class),
+                config.chatMemory(),
+                Mockito.mock(EventTools.class),
+                Mockito.mock(PricingTools.class),
+                Mockito.mock(CartTools.class),
+                Mockito.mock(OrderTools.class),
+                Mockito.mock(MandateTools.class));
+
+        Assertions.assertNotNull(chatClient);
+    }
+}


### PR DESCRIPTION
## Summary
- Upgrade the Spring AI BOM from 2.0.0-M4 to 2.0.0 GA and remove the Spring Milestones repository.
- Migrate AI profile YAML model properties to the Spring AI 2.0 flattened shape.
- Replace deprecated ChatClient `.defaultToolCallbacks(...)` registration with `.defaultTools(...)`.
- Clean up related nullable/deprecation usage and update current docs/instructions.
- Add AiConfig coverage for the ChatClient/tool-registration configuration path.

Closes #259

## Local validation
- `./gradlew clean compileJava`
- `./gradlew test jacocoTestReport`
- `./gradlew test --tests com.mockhub.McpProtocolIntegrationTest --tests com.mockhub.config.McpConfigTest --tests com.mockhub.mcp.config.McpOAuth2IntegrationTest`
- `./gradlew test --tests com.mockhub.config.AiConfigTest --tests com.mockhub.mcp.McpSessionRecoveryFilterTest`
- `./gradlew compileJava` with `-Xlint:deprecation` via temporary init script
- `./gradlew checkstyleMain checkstyleTest` still fails on existing unrelated repo-wide warnings; touched Java files are clean in the refreshed Checkstyle XML reports.
- `spotlessCheck` is currently blocked locally by google-java-format `NoSuchMethodError` under the Java 25 toolchain across the repo.

## Review
- `claude -p` Opus review timed out after 240s with no output.
- Gemini piped-diff fallback returned findings that were verified as false or non-blocking.
- `claude ultrareview origin/main --json --timeout 10` returned `[]` verified findings.