### PR TITLE
Persist MCP OAuth2 clients and authorizations to Postgres

### DIFF
--- a/backend/src/main/java/com/mockhub/lifecycle/LifecycleCleanupService.java
+++ b/backend/src/main/java/com/mockhub/lifecycle/LifecycleCleanupService.java
@@ -1,11 +1,13 @@
 package com.mockhub.lifecycle;
 
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,17 +34,20 @@ public class LifecycleCleanupService {
     private final NotificationRepository notificationRepository;
     private final PaymentCredentialRepository paymentCredentialRepository;
     private final AgentPurchaseApprovalRepository approvalRepository;
+    private final JdbcTemplate jdbcTemplate;
 
     public LifecycleCleanupService(ListingRepository listingRepository,
                                    EventRepository eventRepository,
                                    NotificationRepository notificationRepository,
                                    PaymentCredentialRepository paymentCredentialRepository,
-                                   AgentPurchaseApprovalRepository approvalRepository) {
+                                   AgentPurchaseApprovalRepository approvalRepository,
+                                   JdbcTemplate jdbcTemplate) {
         this.listingRepository = listingRepository;
         this.eventRepository = eventRepository;
         this.notificationRepository = notificationRepository;
         this.paymentCredentialRepository = paymentCredentialRepository;
         this.approvalRepository = approvalRepository;
+        this.jdbcTemplate = jdbcTemplate;
     }
 
     @Scheduled(fixedRateString = "${mockhub.lifecycle.cleanup-interval:900000}")
@@ -56,14 +61,15 @@ public class LifecycleCleanupService {
         int deletedNotifications = deleteOldReadNotifications(now);
         int expiredPaymentCredentials = expirePaymentCredentials(now);
         int expiredApprovals = expireProposedApprovals(now);
+        int deletedOAuth2Authorizations = deleteExpiredOAuth2Authorizations(now);
 
         if (expiredByDeadline + expiredByEvent + completedEvents + deletedNotifications
-                + expiredPaymentCredentials + expiredApprovals > 0) {
+                + expiredPaymentCredentials + expiredApprovals + deletedOAuth2Authorizations > 0) {
             log.info("Lifecycle cleanup: expired {} listings (deadline), {} listings (past events), "
                     + "completed {} events, deleted {} old notifications, expired {} payment credentials, "
-                    + "expired {} purchase approvals",
+                    + "expired {} purchase approvals, deleted {} expired OAuth2 authorizations",
                     expiredByDeadline, expiredByEvent, completedEvents, deletedNotifications,
-                    expiredPaymentCredentials, expiredApprovals);
+                    expiredPaymentCredentials, expiredApprovals, deletedOAuth2Authorizations);
         }
     }
 
@@ -96,6 +102,24 @@ public class LifecycleCleanupService {
     int expireProposedApprovals(Instant now) {
         return approvalRepository.expireProposedApprovals(
                 now, AgentPurchaseApprovalStatus.PROPOSED, AgentPurchaseApprovalStatus.EXPIRED);
+    }
+
+    /**
+     * Deletes MCP OAuth2 authorizations whose latest token expiry has passed, so the
+     * table doesn't grow forever now that authorizations are persisted (issue #266).
+     *
+     * <p>Postgres {@code GREATEST} ignores NULLs, so a row is deleted once every token
+     * it actually has (authorization code, access token, refresh token) is expired.
+     * Rows with no expiries at all (abandoned in-flight authorize requests) are left
+     * alone — they carry no tokens and are replaced on the next login attempt.</p>
+     */
+    int deleteExpiredOAuth2Authorizations(Instant now) {
+        return jdbcTemplate.update("""
+                DELETE FROM oauth2_authorization
+                WHERE GREATEST(authorization_code_expires_at,
+                               access_token_expires_at,
+                               refresh_token_expires_at) < ?
+                """, Timestamp.from(now));
     }
 
     private void expireListingsAndReleaseTickets(List<Listing> listings) {

--- a/backend/src/main/java/com/mockhub/lifecycle/LifecycleCleanupService.java
+++ b/backend/src/main/java/com/mockhub/lifecycle/LifecycleCleanupService.java
@@ -26,6 +26,7 @@ public class LifecycleCleanupService {
 
     private static final Logger log = LoggerFactory.getLogger(LifecycleCleanupService.class);
     private static final int NOTIFICATION_RETENTION_DAYS = 30;
+    private static final int DCR_CLIENT_RETENTION_DAYS = 30;
     private static final String STATUS_EXPIRED = "EXPIRED";
     private static final String TICKET_AVAILABLE = "AVAILABLE";
 
@@ -62,14 +63,18 @@ public class LifecycleCleanupService {
         int expiredPaymentCredentials = expirePaymentCredentials(now);
         int expiredApprovals = expireProposedApprovals(now);
         int deletedOAuth2Authorizations = deleteExpiredOAuth2Authorizations(now);
+        int deletedOAuth2Clients = deleteStaleUnauthorizedOAuth2Clients(now);
 
         if (expiredByDeadline + expiredByEvent + completedEvents + deletedNotifications
-                + expiredPaymentCredentials + expiredApprovals + deletedOAuth2Authorizations > 0) {
+                + expiredPaymentCredentials + expiredApprovals + deletedOAuth2Authorizations
+                + deletedOAuth2Clients > 0) {
             log.info("Lifecycle cleanup: expired {} listings (deadline), {} listings (past events), "
                     + "completed {} events, deleted {} old notifications, expired {} payment credentials, "
-                    + "expired {} purchase approvals, deleted {} expired OAuth2 authorizations",
+                    + "expired {} purchase approvals, deleted {} expired OAuth2 authorizations, "
+                    + "deleted {} stale OAuth2 clients",
                     expiredByDeadline, expiredByEvent, completedEvents, deletedNotifications,
-                    expiredPaymentCredentials, expiredApprovals, deletedOAuth2Authorizations);
+                    expiredPaymentCredentials, expiredApprovals, deletedOAuth2Authorizations,
+                    deletedOAuth2Clients);
         }
     }
 
@@ -109,7 +114,7 @@ public class LifecycleCleanupService {
      * table doesn't grow forever now that authorizations are persisted (issue #266).
      *
      * <p>Postgres {@code GREATEST} ignores NULLs, so a row is deleted once every token
-     * it actually has (authorization code, access token, refresh token) is expired.
+     * it actually has (across all grant types the schema supports) is expired.
      * Rows with no expiries at all (abandoned in-flight authorize requests) are left
      * alone — they carry no tokens and are replaced on the next login attempt.</p>
      */
@@ -118,8 +123,30 @@ public class LifecycleCleanupService {
                 DELETE FROM oauth2_authorization
                 WHERE GREATEST(authorization_code_expires_at,
                                access_token_expires_at,
-                               refresh_token_expires_at) < ?
+                               refresh_token_expires_at,
+                               oidc_id_token_expires_at,
+                               user_code_expires_at,
+                               device_code_expires_at) < ?
                 """, Timestamp.from(now));
+    }
+
+    /**
+     * Deletes DCR-registered OAuth2 clients that were never authorized (or whose
+     * authorizations have all been cleaned up) after 30 days. The DCR endpoint is
+     * intentionally open, so without this an attacker could accumulate unbounded
+     * permanent rows. Clients with any live authorization are kept — an idle-but-valid
+     * connector still has its refresh-token authorization row. The pre-registered
+     * Claude client is excluded (and re-seeded on startup regardless).
+     */
+    int deleteStaleUnauthorizedOAuth2Clients(Instant now) {
+        Instant cutoff = now.minus(DCR_CLIENT_RETENTION_DAYS, ChronoUnit.DAYS);
+        return jdbcTemplate.update("""
+                DELETE FROM oauth2_registered_client c
+                WHERE c.client_id_issued_at < ?
+                  AND c.client_id <> 'claude-mcp-client'
+                  AND NOT EXISTS (SELECT 1 FROM oauth2_authorization a
+                                  WHERE a.registered_client_id = c.id)
+                """, Timestamp.from(cutoff));
     }
 
     private void expireListingsAndReleaseTickets(List<Listing> listings) {

--- a/backend/src/main/java/com/mockhub/mcp/config/McpOAuth2SecurityConfig.java
+++ b/backend/src/main/java/com/mockhub/mcp/config/McpOAuth2SecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.Customizer;
@@ -244,7 +245,13 @@ public class McpOAuth2SecurityConfig {
     @DependsOnDatabaseInitialization
     public RegisteredClientRepository registeredClientRepository(JdbcTemplate jdbcTemplate) {
         JdbcRegisteredClientRepository repository = new JdbcRegisteredClientRepository(jdbcTemplate);
-        repository.save(claudeRegisteredClient());
+        try {
+            repository.save(claudeRegisteredClient());
+        } catch (DuplicateKeyException e) {
+            // Two instances starting against a fresh database can race the initial
+            // insert; the row exists either way, so the loser just moves on.
+            log.info("Claude MCP client already seeded by a concurrent instance");
+        }
         return repository;
     }
 

--- a/backend/src/main/java/com/mockhub/mcp/config/McpOAuth2SecurityConfig.java
+++ b/backend/src/main/java/com/mockhub/mcp/config/McpOAuth2SecurityConfig.java
@@ -11,12 +11,14 @@ import java.util.UUID;
 import org.slf4j.Logger;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.sql.init.dependency.DependsOnDatabaseInitialization;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -24,9 +26,13 @@ import org.springframework.security.config.annotation.web.configurers.oauth2.ser
 import org.springframework.security.web.util.matcher.OrRequestMatcher;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationConsentService;
+import org.springframework.security.oauth2.server.authorization.JdbcOAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationConsentService;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.OAuth2ClientRegistration;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientRegistrationAuthenticationProvider;
-import org.springframework.security.oauth2.server.authorization.client.InMemoryRegisteredClientRepository;
+import org.springframework.security.oauth2.server.authorization.client.JdbcRegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.converter.OAuth2ClientRegistrationRegisteredClientConverter;
@@ -224,15 +230,33 @@ public class McpOAuth2SecurityConfig {
     }
 
     /**
+     * JDBC-backed client repository so DCR registrations survive Railway redeploys.
+     *
+     * <p>Claude and Codex register via DCR. With the previous in-memory repository,
+     * every redeploy forgot their {@code client_id}, so token refresh failed with
+     * {@code invalid_client} and connectors demanded re-authentication daily.</p>
+     *
+     * <p>The pre-registered Claude client is seeded on startup with a fixed entity id,
+     * making {@code save()} an idempotent create-or-update — TTL config changes are
+     * re-applied on restart without duplicating rows.</p>
+     */
+    @Bean
+    @DependsOnDatabaseInitialization
+    public RegisteredClientRepository registeredClientRepository(JdbcTemplate jdbcTemplate) {
+        JdbcRegisteredClientRepository repository = new JdbcRegisteredClientRepository(jdbcTemplate);
+        repository.save(claudeRegisteredClient());
+        return repository;
+    }
+
+    /**
      * Pre-registered OAuth2 client for Claude's connector.
      *
      * <p>Claude's custom connector uses DCR to register dynamically, but having a
      * pre-registered client ensures the authorization server is functional even before
      * DCR occurs. The redirect URI matches Claude's expected callback endpoint.</p>
      */
-    @Bean
-    public RegisteredClientRepository registeredClientRepository() {
-        RegisteredClient claudeClient = RegisteredClient.withId(UUID.randomUUID().toString())
+    RegisteredClient claudeRegisteredClient() {
+        return RegisteredClient.withId("claude-mcp-client")
                 .clientId("claude-mcp-client")
                 .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
                 .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
@@ -243,7 +267,38 @@ public class McpOAuth2SecurityConfig {
                 .redirectUri("http://127.0.0.1:6274/oauth/callback")
                 .tokenSettings(mcpTokenSettings())
                 .build();
-        return new InMemoryRegisteredClientRepository(claudeClient);
+    }
+
+    /**
+     * JDBC-backed authorization service so refresh tokens survive Railway redeploys.
+     *
+     * <p>Refresh tokens are opaque server-side tokens — unlike the JWT access tokens
+     * (which only need the persisted signing key), they live in this store. Without
+     * persistence, the first silent refresh after a redeploy failed and Claude/Codex
+     * showed "Authentication expired. Reconnect."</p>
+     *
+     * <p>Wrapped in {@link PrincipalSanitizingOAuth2AuthorizationService} because the
+     * JDBC service serializes the login principal with Jackson's security allowlist,
+     * which rejects MockHub's custom {@code SecurityUser}.</p>
+     */
+    @Bean
+    @DependsOnDatabaseInitialization
+    public OAuth2AuthorizationService authorizationService(
+            JdbcTemplate jdbcTemplate, RegisteredClientRepository registeredClientRepository) {
+        return new PrincipalSanitizingOAuth2AuthorizationService(
+                new JdbcOAuth2AuthorizationService(jdbcTemplate, registeredClientRepository));
+    }
+
+    /**
+     * JDBC-backed consent service for completeness. MCP flows are consent-free (no
+     * scopes requested), so this table stays empty in practice, but if a client ever
+     * requests scopes the recorded consent survives redeploys like everything else.
+     */
+    @Bean
+    @DependsOnDatabaseInitialization
+    public OAuth2AuthorizationConsentService authorizationConsentService(
+            JdbcTemplate jdbcTemplate, RegisteredClientRepository registeredClientRepository) {
+        return new JdbcOAuth2AuthorizationConsentService(jdbcTemplate, registeredClientRepository);
     }
 
     private void customizeClientRegistrationProviders(

--- a/backend/src/main/java/com/mockhub/mcp/config/PrincipalSanitizingOAuth2AuthorizationService.java
+++ b/backend/src/main/java/com/mockhub/mcp/config/PrincipalSanitizingOAuth2AuthorizationService.java
@@ -1,0 +1,66 @@
+package com.mockhub.mcp.config;
+
+import java.security.Principal;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
+
+import com.mockhub.auth.security.SecurityUser;
+
+/**
+ * Delegating {@link OAuth2AuthorizationService} that replaces a {@link SecurityUser}
+ * principal with its plain email string before persisting.
+ *
+ * <p>{@code JdbcOAuth2AuthorizationService} serializes the {@code java.security.Principal}
+ * attribute to the {@code oauth2_authorization.attributes} column with Jackson, using
+ * Spring Security's class allowlist. {@link SecurityUser} is not on that allowlist and
+ * has no Jackson-friendly constructor, so persisting it fails. The token refresh flow
+ * only needs {@link Authentication#getName()} and the granted authorities to mint new
+ * access tokens, both of which survive the swap — so MCP connectors keep refreshing
+ * silently across redeploys without the authorization server ever needing the full
+ * user object back.</p>
+ */
+public class PrincipalSanitizingOAuth2AuthorizationService implements OAuth2AuthorizationService {
+
+    private final OAuth2AuthorizationService delegate;
+
+    public PrincipalSanitizingOAuth2AuthorizationService(OAuth2AuthorizationService delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public void save(OAuth2Authorization authorization) {
+        delegate.save(sanitize(authorization));
+    }
+
+    @Override
+    public void remove(OAuth2Authorization authorization) {
+        delegate.remove(authorization);
+    }
+
+    @Override
+    public OAuth2Authorization findById(String id) {
+        return delegate.findById(id);
+    }
+
+    @Override
+    public OAuth2Authorization findByToken(String token, OAuth2TokenType tokenType) {
+        return delegate.findByToken(token, tokenType);
+    }
+
+    private static OAuth2Authorization sanitize(OAuth2Authorization authorization) {
+        Authentication principal = authorization.getAttribute(Principal.class.getName());
+        if (principal instanceof UsernamePasswordAuthenticationToken token
+                && token.getPrincipal() instanceof SecurityUser securityUser) {
+            Authentication sanitized = UsernamePasswordAuthenticationToken.authenticated(
+                    securityUser.getEmail(), null, securityUser.getAuthorities());
+            return OAuth2Authorization.from(authorization)
+                    .attribute(Principal.class.getName(), sanitized)
+                    .build();
+        }
+        return authorization;
+    }
+}

--- a/backend/src/main/resources/db/migration/V36__create_oauth2_authorization_tables.sql
+++ b/backend/src/main/resources/db/migration/V36__create_oauth2_authorization_tables.sql
@@ -1,0 +1,68 @@
+-- Spring Authorization Server JDBC schema, Postgres-adapted per the notes in the
+-- shipped schema files (blob -> text, timestamp -> timestamptz).
+--
+-- Persists OAuth2 client registrations (including DCR clients) and authorizations
+-- (including refresh tokens) so MCP connector sessions survive Railway redeploys.
+-- Without these tables both stores are in-memory and every redeploy forces
+-- Claude/Codex connectors to re-authenticate (issue #266).
+
+CREATE TABLE oauth2_registered_client (
+    id varchar(100) NOT NULL,
+    client_id varchar(100) NOT NULL,
+    client_id_issued_at timestamptz DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    client_secret varchar(200) DEFAULT NULL,
+    client_secret_expires_at timestamptz DEFAULT NULL,
+    client_name varchar(200) NOT NULL,
+    client_authentication_methods varchar(1000) NOT NULL,
+    authorization_grant_types varchar(1000) NOT NULL,
+    redirect_uris varchar(1000) DEFAULT NULL,
+    post_logout_redirect_uris varchar(1000) DEFAULT NULL,
+    scopes varchar(1000) NOT NULL,
+    client_settings varchar(2000) NOT NULL,
+    token_settings varchar(2000) NOT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE oauth2_authorization (
+    id varchar(100) NOT NULL,
+    registered_client_id varchar(100) NOT NULL,
+    principal_name varchar(200) NOT NULL,
+    authorization_grant_type varchar(100) NOT NULL,
+    authorized_scopes varchar(1000) DEFAULT NULL,
+    attributes text DEFAULT NULL,
+    state varchar(500) DEFAULT NULL,
+    authorization_code_value text DEFAULT NULL,
+    authorization_code_issued_at timestamptz DEFAULT NULL,
+    authorization_code_expires_at timestamptz DEFAULT NULL,
+    authorization_code_metadata text DEFAULT NULL,
+    access_token_value text DEFAULT NULL,
+    access_token_issued_at timestamptz DEFAULT NULL,
+    access_token_expires_at timestamptz DEFAULT NULL,
+    access_token_metadata text DEFAULT NULL,
+    access_token_type varchar(100) DEFAULT NULL,
+    access_token_scopes varchar(1000) DEFAULT NULL,
+    oidc_id_token_value text DEFAULT NULL,
+    oidc_id_token_issued_at timestamptz DEFAULT NULL,
+    oidc_id_token_expires_at timestamptz DEFAULT NULL,
+    oidc_id_token_metadata text DEFAULT NULL,
+    refresh_token_value text DEFAULT NULL,
+    refresh_token_issued_at timestamptz DEFAULT NULL,
+    refresh_token_expires_at timestamptz DEFAULT NULL,
+    refresh_token_metadata text DEFAULT NULL,
+    user_code_value text DEFAULT NULL,
+    user_code_issued_at timestamptz DEFAULT NULL,
+    user_code_expires_at timestamptz DEFAULT NULL,
+    user_code_metadata text DEFAULT NULL,
+    device_code_value text DEFAULT NULL,
+    device_code_issued_at timestamptz DEFAULT NULL,
+    device_code_expires_at timestamptz DEFAULT NULL,
+    device_code_metadata text DEFAULT NULL,
+    PRIMARY KEY (id)
+);
+
+CREATE TABLE oauth2_authorization_consent (
+    registered_client_id varchar(100) NOT NULL,
+    principal_name varchar(200) NOT NULL,
+    authorities varchar(1000) NOT NULL,
+    PRIMARY KEY (registered_client_id, principal_name)
+);

--- a/backend/src/test/java/com/mockhub/lifecycle/LifecycleCleanupServiceTest.java
+++ b/backend/src/test/java/com/mockhub/lifecycle/LifecycleCleanupServiceTest.java
@@ -29,6 +29,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -89,7 +90,7 @@ class LifecycleCleanupServiceTest {
                 any(Instant.class), any(PaymentCredentialStatus.class), any(PaymentCredentialStatus.class));
         verify(approvalRepository).expireProposedApprovals(
                 any(Instant.class), any(AgentPurchaseApprovalStatus.class), any(AgentPurchaseApprovalStatus.class));
-        verify(jdbcTemplate).update(anyString(), any(Timestamp.class));
+        verify(jdbcTemplate, times(2)).update(anyString(), any(Timestamp.class));
     }
 
     @Test
@@ -181,6 +182,20 @@ class LifecycleCleanupServiceTest {
         assertEquals(7, result);
         verify(jdbcTemplate).update(contains("DELETE FROM oauth2_authorization"),
                 eq(Timestamp.from(now)));
+    }
+
+    @Test
+    @DisplayName("deleteStaleUnauthorizedOAuth2Clients - uses 30-day cutoff and spares Claude client")
+    void deleteStaleUnauthorizedOAuth2Clients_uses30DayCutoff() {
+        Instant now = Instant.now();
+        Instant expectedCutoff = now.minus(30, ChronoUnit.DAYS);
+        when(jdbcTemplate.update(anyString(), any(Timestamp.class))).thenReturn(2);
+
+        int result = cleanupService.deleteStaleUnauthorizedOAuth2Clients(now);
+
+        assertEquals(2, result);
+        verify(jdbcTemplate).update(contains("DELETE FROM oauth2_registered_client"),
+                eq(Timestamp.from(expectedCutoff)));
     }
 
     @Test

--- a/backend/src/test/java/com/mockhub/lifecycle/LifecycleCleanupServiceTest.java
+++ b/backend/src/test/java/com/mockhub/lifecycle/LifecycleCleanupServiceTest.java
@@ -1,5 +1,6 @@
 package com.mockhub.lifecycle;
 
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
 
 import com.mockhub.agentapproval.entity.AgentPurchaseApprovalStatus;
 import com.mockhub.agentapproval.repository.AgentPurchaseApprovalRepository;
@@ -24,6 +26,9 @@ import com.mockhub.ticket.repository.ListingRepository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -45,13 +50,16 @@ class LifecycleCleanupServiceTest {
     @Mock
     private AgentPurchaseApprovalRepository approvalRepository;
 
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
     private LifecycleCleanupService cleanupService;
 
     @BeforeEach
     void setUp() {
         cleanupService = new LifecycleCleanupService(
                 listingRepository, eventRepository, notificationRepository,
-                paymentCredentialRepository, approvalRepository);
+                paymentCredentialRepository, approvalRepository, jdbcTemplate);
     }
 
     @Test
@@ -69,6 +77,7 @@ class LifecycleCleanupServiceTest {
         when(approvalRepository.expireProposedApprovals(
                 any(Instant.class), any(AgentPurchaseApprovalStatus.class), any(AgentPurchaseApprovalStatus.class)))
                 .thenReturn(0);
+        when(jdbcTemplate.update(anyString(), any(Timestamp.class))).thenReturn(0);
 
         cleanupService.runCleanup();
 
@@ -80,6 +89,7 @@ class LifecycleCleanupServiceTest {
                 any(Instant.class), any(PaymentCredentialStatus.class), any(PaymentCredentialStatus.class));
         verify(approvalRepository).expireProposedApprovals(
                 any(Instant.class), any(AgentPurchaseApprovalStatus.class), any(AgentPurchaseApprovalStatus.class));
+        verify(jdbcTemplate).update(anyString(), any(Timestamp.class));
     }
 
     @Test
@@ -158,6 +168,19 @@ class LifecycleCleanupServiceTest {
         int result = cleanupService.expireProposedApprovals(now);
 
         assertEquals(2, result);
+    }
+
+    @Test
+    @DisplayName("deleteExpiredOAuth2Authorizations - deletes rows whose latest token expiry has passed")
+    void deleteExpiredOAuth2Authorizations_deletesRowsPastLatestExpiry() {
+        Instant now = Instant.now();
+        when(jdbcTemplate.update(anyString(), any(Timestamp.class))).thenReturn(7);
+
+        int result = cleanupService.deleteExpiredOAuth2Authorizations(now);
+
+        assertEquals(7, result);
+        verify(jdbcTemplate).update(contains("DELETE FROM oauth2_authorization"),
+                eq(Timestamp.from(now)));
     }
 
     @Test

--- a/backend/src/test/java/com/mockhub/mcp/config/McpOAuth2PersistenceIntegrationTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/config/McpOAuth2PersistenceIntegrationTest.java
@@ -1,0 +1,222 @@
+package com.mockhub.mcp.config;
+
+import java.security.Principal;
+import java.sql.Timestamp;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Set;
+import java.util.UUID;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import com.mockhub.auth.entity.Role;
+import com.mockhub.auth.entity.User;
+import com.mockhub.auth.security.SecurityUser;
+import com.mockhub.lifecycle.LifecycleCleanupService;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies that OAuth2 client registrations and authorizations are persisted to
+ * PostgreSQL rather than held in memory, so MCP connector sessions (Claude Desktop,
+ * Codex) survive Railway redeploys (issue #266).
+ */
+@SpringBootTest(
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+        properties = {
+                "mockhub.mcp.enabled=true",
+                "spring.autoconfigure.exclude=" +
+                        "org.springframework.ai.model.anthropic.autoconfigure.AnthropicChatAutoConfiguration," +
+                        "org.springframework.ai.model.openai.autoconfigure.OpenAiChatAutoConfiguration," +
+                        "org.springframework.ai.model.openai.autoconfigure.OpenAiEmbeddingAutoConfiguration," +
+                        "org.springframework.ai.model.openai.autoconfigure.OpenAiImageAutoConfiguration," +
+                        "org.springframework.ai.model.openai.autoconfigure.OpenAiAudioSpeechAutoConfiguration," +
+                        "org.springframework.ai.model.openai.autoconfigure.OpenAiAudioTranscriptionAutoConfiguration," +
+                        "org.springframework.ai.model.openai.autoconfigure.OpenAiModerationAutoConfiguration," +
+                        "org.springframework.ai.model.ollama.autoconfigure.OllamaChatAutoConfiguration," +
+                        "org.springframework.ai.model.ollama.autoconfigure.OllamaEmbeddingAutoConfiguration," +
+                        "org.springframework.ai.model.ollama.autoconfigure.OllamaApiAutoConfiguration," +
+                        "org.springframework.ai.model.chat.client.autoconfigure.ChatClientAutoConfiguration"
+        }
+)
+@ActiveProfiles({"test", "mock-payment", "mock-sms", "mock-email", "mcp-oauth2"})
+@AutoConfigureTestRestTemplate
+class McpOAuth2PersistenceIntegrationTest {
+
+    static final PostgreSQLContainer<?> POSTGRES;
+
+    static {
+        POSTGRES = new PostgreSQLContainer<>(DockerImageName.parse("postgres:17"))
+                .withDatabaseName("mockhub")
+                .withUsername("mockhub")
+                .withPassword("mockhub");
+        POSTGRES.start();
+    }
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", POSTGRES::getJdbcUrl);
+        registry.add("spring.datasource.username", POSTGRES::getUsername);
+        registry.add("spring.datasource.password", POSTGRES::getPassword);
+    }
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private OAuth2AuthorizationService authorizationService;
+
+    @Autowired
+    private RegisteredClientRepository registeredClientRepository;
+
+    @Autowired
+    private LifecycleCleanupService cleanupService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("pre-registered Claude client is seeded into the database")
+    void claudeClient_isSeededIntoDatabase() {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM oauth2_registered_client WHERE client_id = 'claude-mcp-client'",
+                Integer.class);
+
+        assertEquals(1, count, "Claude client must be persisted, not held in memory");
+    }
+
+    @Test
+    @DisplayName("DCR-registered clients are persisted to the database")
+    void dcrClient_isPersistedToDatabase() throws Exception {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        var request = objectMapper.createObjectNode();
+        request.put("client_name", "persistence-test-client");
+        request.put("token_endpoint_auth_method", "client_secret_basic");
+        request.putArray("grant_types").add("client_credentials");
+
+        ResponseEntity<String> response = restTemplate.postForEntity(
+                "/oauth2/register", new HttpEntity<>(request.toString(), headers), String.class);
+
+        assertTrue(response.getStatusCode().is2xxSuccessful(),
+                "DCR should succeed: " + response.getBody());
+        JsonNode registration = objectMapper.readTree(response.getBody());
+        String clientId = registration.get("client_id").asText();
+
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM oauth2_registered_client WHERE client_id = ?",
+                Integer.class, clientId);
+        assertEquals(1, count, "DCR client must survive a restart, so it must be in the database");
+    }
+
+    @Test
+    @DisplayName("authorization with SecurityUser principal and refresh token round-trips through Postgres")
+    void authorizationWithSecurityUserPrincipal_roundTripsThroughPostgres() {
+        String refreshTokenValue = "persistence-test-refresh-" + UUID.randomUUID();
+        OAuth2Authorization authorization = authorizationWithRefreshToken(
+                refreshTokenValue, Instant.now().plus(Duration.ofDays(60)));
+
+        authorizationService.save(authorization);
+
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM oauth2_authorization WHERE id = ?",
+                Integer.class, authorization.getId());
+        assertEquals(1, count, "Authorization must be persisted, not held in memory");
+
+        OAuth2Authorization loaded = authorizationService.findByToken(
+                refreshTokenValue, OAuth2TokenType.REFRESH_TOKEN);
+        assertNotNull(loaded, "Refresh token lookup must work after persistence round-trip");
+        assertEquals("student@mockhub.com", loaded.getPrincipalName());
+        Authentication principal = loaded.getAttribute(Principal.class.getName());
+        assertNotNull(principal, "Principal attribute must deserialize from the database");
+        assertEquals("student@mockhub.com", principal.getName(),
+                "Refresh flow reads the stored principal name to mint new tokens");
+
+        authorizationService.remove(loaded);
+        assertNull(authorizationService.findByToken(refreshTokenValue, OAuth2TokenType.REFRESH_TOKEN));
+    }
+
+    @Test
+    @DisplayName("lifecycle cleanup deletes expired authorizations but keeps live ones")
+    void lifecycleCleanup_deletesExpiredAuthorizations_keepsLiveOnes() {
+        String expiredToken = "expired-refresh-" + UUID.randomUUID();
+        String liveToken = "live-refresh-" + UUID.randomUUID();
+        OAuth2Authorization expired = authorizationWithRefreshToken(
+                expiredToken, Instant.now().minus(Duration.ofDays(1)));
+        OAuth2Authorization live = authorizationWithRefreshToken(
+                liveToken, Instant.now().plus(Duration.ofDays(60)));
+        authorizationService.save(expired);
+        authorizationService.save(live);
+        // Sanity check: JdbcOAuth2AuthorizationService stores expiry as timestamptz
+        Timestamp expiry = jdbcTemplate.queryForObject(
+                "SELECT refresh_token_expires_at FROM oauth2_authorization WHERE id = ?",
+                Timestamp.class, expired.getId());
+        assertNotNull(expiry);
+
+        cleanupService.runCleanup();
+
+        Integer expiredCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM oauth2_authorization WHERE id = ?",
+                Integer.class, expired.getId());
+        Integer liveCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM oauth2_authorization WHERE id = ?",
+                Integer.class, live.getId());
+        assertEquals(0, expiredCount, "Expired authorizations should be cleaned up");
+        assertEquals(1, liveCount, "Live authorizations must not be touched by cleanup");
+
+        authorizationService.remove(live);
+    }
+
+    private OAuth2Authorization authorizationWithRefreshToken(String tokenValue, Instant expiresAt) {
+        RegisteredClient claudeClient = registeredClientRepository.findByClientId("claude-mcp-client");
+        assertNotNull(claudeClient);
+        return OAuth2Authorization.withRegisteredClient(claudeClient)
+                .principalName("student@mockhub.com")
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .attribute(Principal.class.getName(), securityUserAuthentication())
+                .token(new OAuth2RefreshToken(tokenValue, expiresAt.minus(Duration.ofDays(60)), expiresAt))
+                .build();
+    }
+
+    private static Authentication securityUserAuthentication() {
+        User user = new User();
+        user.setEmail("student@mockhub.com");
+        user.setPasswordHash("$2a$10$hash");
+        user.setRoles(Set.of(new Role("ROLE_USER")));
+        SecurityUser securityUser = new SecurityUser(user);
+        return UsernamePasswordAuthenticationToken.authenticated(
+                securityUser, null, securityUser.getAuthorities());
+    }
+}

--- a/backend/src/test/java/com/mockhub/mcp/config/McpOAuth2PersistenceIntegrationTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/config/McpOAuth2PersistenceIntegrationTest.java
@@ -199,6 +199,32 @@ class McpOAuth2PersistenceIntegrationTest {
         authorizationService.remove(live);
     }
 
+    @Test
+    @DisplayName("lifecycle cleanup deletes stale never-authorized DCR clients but keeps the Claude client")
+    void lifecycleCleanup_deletesStaleUnauthorizedClients_keepsClaudeClient() {
+        String staleId = "stale-client-" + UUID.randomUUID();
+        Timestamp fortyDaysAgo = Timestamp.from(Instant.now().minus(Duration.ofDays(40)));
+        jdbcTemplate.update("""
+                INSERT INTO oauth2_registered_client
+                    (id, client_id, client_id_issued_at, client_name,
+                     client_authentication_methods, authorization_grant_types, scopes,
+                     client_settings, token_settings)
+                VALUES (?, ?, ?, 'stale test client', 'client_secret_basic',
+                        'client_credentials', 'openid', '{}', '{}')
+                """, staleId, staleId, fortyDaysAgo);
+
+        cleanupService.runCleanup();
+
+        Integer staleCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM oauth2_registered_client WHERE id = ?",
+                Integer.class, staleId);
+        Integer claudeCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM oauth2_registered_client WHERE client_id = 'claude-mcp-client'",
+                Integer.class);
+        assertEquals(0, staleCount, "Never-authorized DCR clients past retention should be deleted");
+        assertEquals(1, claudeCount, "Pre-registered Claude client must never be cleaned up");
+    }
+
     private OAuth2Authorization authorizationWithRefreshToken(String tokenValue, Instant expiresAt) {
         RegisteredClient claudeClient = registeredClientRepository.findByClientId("claude-mcp-client");
         assertNotNull(claudeClient);

--- a/backend/src/test/java/com/mockhub/mcp/config/McpOAuth2SecurityConfigTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/config/McpOAuth2SecurityConfigTest.java
@@ -102,8 +102,8 @@ class McpOAuth2SecurityConfigTest {
 
     @Test
     void claudeRegisteredClient_hasFixedEntityId_soSeedingIsIdempotent() {
-        // JdbcRegisteredClientRepository.save() updates when the id already exists;
-        // a random id would insert a duplicate client_id row on every startup.
+        // The JDBC repository's save is an update when the id already exists; with a
+        // random id every startup would insert a duplicate client_id row instead.
         assertEquals(config.claudeRegisteredClient().getId(),
                 config.claudeRegisteredClient().getId());
         assertEquals("claude-mcp-client", config.claudeRegisteredClient().getId());

--- a/backend/src/test/java/com/mockhub/mcp/config/McpOAuth2SecurityConfigTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/config/McpOAuth2SecurityConfigTest.java
@@ -12,6 +12,8 @@ import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.security.oauth2.server.authorization.OAuth2ClientRegistration;
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
 
@@ -69,6 +71,26 @@ class McpOAuth2SecurityConfigTest {
         assertNotNull(jwkSource);
         List<JWK> keys = jwkSource.get(RSA_SELECTOR, null);
         assertEquals(1, keys.size());
+    }
+
+    @Test
+    void registeredClientRepository_givenSeedingRace_swallowsDuplicateKeyException() {
+        JdbcTemplate jdbcTemplate = org.mockito.Mockito.mock(JdbcTemplate.class);
+        // save() first SELECTs by id (no row), then INSERTs — simulate a concurrent
+        // instance winning the insert race
+        org.mockito.Mockito.when(jdbcTemplate.query(
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.<org.springframework.jdbc.core.RowMapper<Object>>any(),
+                        org.mockito.ArgumentMatchers.any(Object[].class)))
+                .thenReturn(List.of());
+        org.mockito.Mockito.when(jdbcTemplate.update(
+                        org.mockito.ArgumentMatchers.anyString(),
+                        org.mockito.ArgumentMatchers.any(
+                                org.springframework.jdbc.core.PreparedStatementSetter.class)))
+                .thenThrow(new DuplicateKeyException("duplicate key value violates unique constraint"));
+
+        assertNotNull(config.registeredClientRepository(jdbcTemplate),
+                "Losing the seeding race must not fail startup");
     }
 
     @Test

--- a/backend/src/test/java/com/mockhub/mcp/config/McpOAuth2SecurityConfigTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/config/McpOAuth2SecurityConfigTest.java
@@ -76,8 +76,8 @@ class McpOAuth2SecurityConfigTest {
     @Test
     void registeredClientRepository_givenSeedingRace_swallowsDuplicateKeyException() {
         JdbcTemplate jdbcTemplate = org.mockito.Mockito.mock(JdbcTemplate.class);
-        // save() first SELECTs by id (no row), then INSERTs — simulate a concurrent
-        // instance winning the insert race
+        // Simulate a concurrent instance winning the insert race: the lookup by id
+        // finds no row, and the subsequent insert hits the unique constraint.
         org.mockito.Mockito.when(jdbcTemplate.query(
                         org.mockito.ArgumentMatchers.anyString(),
                         org.mockito.ArgumentMatchers.<org.springframework.jdbc.core.RowMapper<Object>>any(),

--- a/backend/src/test/java/com/mockhub/mcp/config/McpOAuth2SecurityConfigTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/config/McpOAuth2SecurityConfigTest.java
@@ -12,7 +12,6 @@ import com.nimbusds.jose.jwk.source.JWKSource;
 import com.nimbusds.jose.proc.SecurityContext;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
 import org.springframework.security.oauth2.server.authorization.OAuth2ClientRegistration;
 import org.springframework.security.oauth2.server.authorization.settings.AuthorizationServerSettings;
 
@@ -73,17 +72,24 @@ class McpOAuth2SecurityConfigTest {
     }
 
     @Test
-    void registeredClientRepository_containsClaudeClient() {
-        RegisteredClientRepository repository = config.registeredClientRepository();
+    void claudeRegisteredClient_hasClaudeClientId() {
+        var client = config.claudeRegisteredClient();
 
-        assertNotNull(repository.findByClientId("claude-mcp-client"));
+        assertEquals("claude-mcp-client", client.getClientId());
     }
 
     @Test
-    void registeredClientRepository_claudeClientHasCorrectRedirectUris() {
-        RegisteredClientRepository repository = config.registeredClientRepository();
+    void claudeRegisteredClient_hasFixedEntityId_soSeedingIsIdempotent() {
+        // JdbcRegisteredClientRepository.save() updates when the id already exists;
+        // a random id would insert a duplicate client_id row on every startup.
+        assertEquals(config.claudeRegisteredClient().getId(),
+                config.claudeRegisteredClient().getId());
+        assertEquals("claude-mcp-client", config.claudeRegisteredClient().getId());
+    }
 
-        var client = repository.findByClientId("claude-mcp-client");
+    @Test
+    void claudeRegisteredClient_hasCorrectRedirectUris() {
+        var client = config.claudeRegisteredClient();
         assertNotNull(client);
         assertFalse(client.getRedirectUris().isEmpty());
         // Claude's callback URI must be registered
@@ -103,54 +109,44 @@ class McpOAuth2SecurityConfigTest {
     }
 
     @Test
-    void registeredClientRepository_claudeClientHasRefreshTokenGrant() {
-        RegisteredClientRepository repository = config.registeredClientRepository();
+    void claudeRegisteredClient_hasRefreshTokenGrant() {
+        var client = config.claudeRegisteredClient();
 
-        var client = repository.findByClientId("claude-mcp-client");
-        assertNotNull(client);
         assertTrue(client.getAuthorizationGrantTypes()
                         .contains(AuthorizationGrantType.REFRESH_TOKEN),
                 "Client must support refresh_token grant type");
     }
 
     @Test
-    void registeredClientRepository_claudeClientUsesConfiguredAccessTokenTtl() {
-        RegisteredClientRepository repository = config.registeredClientRepository();
+    void claudeRegisteredClient_usesConfiguredAccessTokenTtl() {
+        var client = config.claudeRegisteredClient();
 
-        var client = repository.findByClientId("claude-mcp-client");
-        assertNotNull(client);
         Duration accessTokenTtl = client.getTokenSettings().getAccessTokenTimeToLive();
         assertEquals(DEFAULT_ACCESS_TTL, accessTokenTtl);
     }
 
     @Test
-    void registeredClientRepository_claudeClientUsesConfiguredRefreshTokenTtl() {
-        RegisteredClientRepository repository = config.registeredClientRepository();
+    void claudeRegisteredClient_usesConfiguredRefreshTokenTtl() {
+        var client = config.claudeRegisteredClient();
 
-        var client = repository.findByClientId("claude-mcp-client");
-        assertNotNull(client);
         Duration refreshTokenTtl = client.getTokenSettings().getRefreshTokenTimeToLive();
         assertEquals(DEFAULT_REFRESH_TTL, refreshTokenTtl);
     }
 
     @Test
-    void registeredClientRepository_customTtlsFlowThroughToTokenSettings() {
+    void claudeRegisteredClient_customTtlsFlowThroughToTokenSettings() {
         McpOAuth2SecurityConfig customConfig =
                 new McpOAuth2SecurityConfig(Duration.ofMinutes(5), Duration.ofDays(7));
-        RegisteredClientRepository repository = customConfig.registeredClientRepository();
 
-        var client = repository.findByClientId("claude-mcp-client");
-        assertNotNull(client);
+        var client = customConfig.claudeRegisteredClient();
         assertEquals(Duration.ofMinutes(5), client.getTokenSettings().getAccessTokenTimeToLive());
         assertEquals(Duration.ofDays(7), client.getTokenSettings().getRefreshTokenTimeToLive());
     }
 
     @Test
-    void registeredClientRepository_claudeClientDoesNotReuseRefreshTokens() {
-        RegisteredClientRepository repository = config.registeredClientRepository();
+    void claudeRegisteredClient_doesNotReuseRefreshTokens() {
+        var client = config.claudeRegisteredClient();
 
-        var client = repository.findByClientId("claude-mcp-client");
-        assertNotNull(client);
         assertFalse(client.getTokenSettings().isReuseRefreshTokens(),
                 "Refresh tokens should rotate on each use");
     }

--- a/backend/src/test/java/com/mockhub/mcp/config/PrincipalSanitizingOAuth2AuthorizationServiceTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/config/PrincipalSanitizingOAuth2AuthorizationServiceTest.java
@@ -1,0 +1,173 @@
+package com.mockhub.mcp.config;
+
+import java.security.Principal;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
+import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
+import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+
+import com.mockhub.auth.entity.Role;
+import com.mockhub.auth.entity.User;
+import com.mockhub.auth.security.SecurityUser;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class PrincipalSanitizingOAuth2AuthorizationServiceTest {
+
+    private static final String EMAIL = "alice@example.com";
+
+    @Mock
+    private OAuth2AuthorizationService delegate;
+
+    @Test
+    void save_givenSecurityUserPrincipal_replacesPrincipalWithEmailString() {
+        PrincipalSanitizingOAuth2AuthorizationService service =
+                new PrincipalSanitizingOAuth2AuthorizationService(delegate);
+        OAuth2Authorization authorization = authorizationWithPrincipal(securityUserAuthentication());
+
+        service.save(authorization);
+
+        ArgumentCaptor<OAuth2Authorization> captor = ArgumentCaptor.forClass(OAuth2Authorization.class);
+        verify(delegate).save(captor.capture());
+        Authentication saved = captor.getValue().getAttribute(Principal.class.getName());
+        assertNotNull(saved);
+        assertEquals(EMAIL, saved.getPrincipal(), "Principal should be the plain email string");
+        assertEquals(EMAIL, saved.getName());
+        assertTrue(saved.getAuthorities().contains(new SimpleGrantedAuthority("ROLE_USER")),
+                "Authorities must survive sanitization");
+    }
+
+    @Test
+    void save_givenSecurityUserPrincipal_preservesTokensAndPrincipalName() {
+        PrincipalSanitizingOAuth2AuthorizationService service =
+                new PrincipalSanitizingOAuth2AuthorizationService(delegate);
+        OAuth2Authorization authorization = authorizationWithPrincipal(securityUserAuthentication());
+
+        service.save(authorization);
+
+        ArgumentCaptor<OAuth2Authorization> captor = ArgumentCaptor.forClass(OAuth2Authorization.class);
+        verify(delegate).save(captor.capture());
+        OAuth2Authorization saved = captor.getValue();
+        assertEquals(EMAIL, saved.getPrincipalName());
+        assertNotNull(saved.getRefreshToken(), "Refresh token must survive sanitization");
+        assertEquals("refresh-token-value", saved.getRefreshToken().getToken().getTokenValue());
+    }
+
+    @Test
+    void save_givenNonSecurityUserPrincipal_passesAuthorizationThroughUnchanged() {
+        PrincipalSanitizingOAuth2AuthorizationService service =
+                new PrincipalSanitizingOAuth2AuthorizationService(delegate);
+        Authentication alreadySanitized = UsernamePasswordAuthenticationToken.authenticated(
+                EMAIL, null, Set.of(new SimpleGrantedAuthority("ROLE_USER")));
+        OAuth2Authorization authorization = authorizationWithPrincipal(alreadySanitized);
+
+        service.save(authorization);
+
+        ArgumentCaptor<OAuth2Authorization> captor = ArgumentCaptor.forClass(OAuth2Authorization.class);
+        verify(delegate).save(captor.capture());
+        assertSame(authorization, captor.getValue(),
+                "Already-serializable authorizations should not be rebuilt");
+    }
+
+    @Test
+    void save_givenNoPrincipalAttribute_passesAuthorizationThroughUnchanged() {
+        PrincipalSanitizingOAuth2AuthorizationService service =
+                new PrincipalSanitizingOAuth2AuthorizationService(delegate);
+        OAuth2Authorization authorization = OAuth2Authorization
+                .withRegisteredClient(registeredClient())
+                .principalName("client-credentials-client")
+                .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+                .build();
+
+        service.save(authorization);
+
+        ArgumentCaptor<OAuth2Authorization> captor = ArgumentCaptor.forClass(OAuth2Authorization.class);
+        verify(delegate).save(captor.capture());
+        assertSame(authorization, captor.getValue());
+    }
+
+    @Test
+    void remove_delegates() {
+        PrincipalSanitizingOAuth2AuthorizationService service =
+                new PrincipalSanitizingOAuth2AuthorizationService(delegate);
+        OAuth2Authorization authorization = authorizationWithPrincipal(securityUserAuthentication());
+
+        service.remove(authorization);
+
+        verify(delegate).remove(authorization);
+    }
+
+    @Test
+    void findById_delegates() {
+        PrincipalSanitizingOAuth2AuthorizationService service =
+                new PrincipalSanitizingOAuth2AuthorizationService(delegate);
+        OAuth2Authorization authorization = authorizationWithPrincipal(securityUserAuthentication());
+        when(delegate.findById("auth-id")).thenReturn(authorization);
+
+        assertSame(authorization, service.findById("auth-id"));
+    }
+
+    @Test
+    void findByToken_delegates() {
+        PrincipalSanitizingOAuth2AuthorizationService service =
+                new PrincipalSanitizingOAuth2AuthorizationService(delegate);
+        OAuth2Authorization authorization = authorizationWithPrincipal(securityUserAuthentication());
+        when(delegate.findByToken("refresh-token-value", OAuth2TokenType.REFRESH_TOKEN))
+                .thenReturn(authorization);
+
+        assertSame(authorization,
+                service.findByToken("refresh-token-value", OAuth2TokenType.REFRESH_TOKEN));
+    }
+
+    private static Authentication securityUserAuthentication() {
+        User user = new User();
+        user.setEmail(EMAIL);
+        user.setPasswordHash("$2a$10$hash");
+        user.setRoles(Set.of(new Role("ROLE_USER")));
+        SecurityUser securityUser = new SecurityUser(user);
+        return UsernamePasswordAuthenticationToken.authenticated(
+                securityUser, null, securityUser.getAuthorities());
+    }
+
+    private static OAuth2Authorization authorizationWithPrincipal(Authentication principal) {
+        Instant now = Instant.now();
+        return OAuth2Authorization.withRegisteredClient(registeredClient())
+                .principalName(EMAIL)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .attribute(Principal.class.getName(), principal)
+                .token(new OAuth2RefreshToken("refresh-token-value", now, now.plus(Duration.ofDays(60))))
+                .build();
+    }
+
+    private static RegisteredClient registeredClient() {
+        return RegisteredClient.withId("test-client")
+                .clientId("test-client")
+                .clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
+                .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+                .authorizationGrantType(AuthorizationGrantType.CLIENT_CREDENTIALS)
+                .authorizationGrantType(AuthorizationGrantType.REFRESH_TOKEN)
+                .redirectUri("https://claude.ai/api/mcp/auth_callback")
+                .build();
+    }
+}

--- a/docs/mcp-oauth2-jwk-setup.md
+++ b/docs/mcp-oauth2-jwk-setup.md
@@ -13,6 +13,14 @@ With the key persisted, the refresh-token sliding window (default 60 days, see
 `mockhub.mcp.oauth2.refresh-token-ttl`) works as designed: an actively-used
 connector never re-authenticates; an idle one expires on schedule.
 
+The signing key is only half of redeploy survival. Refresh tokens are opaque
+server-side tokens, and DCR client registrations are server-side state — both
+are persisted to Postgres (`oauth2_authorization` / `oauth2_registered_client`,
+Flyway V36) rather than held in memory. Before that migration, every redeploy
+wiped both stores and connectors demanded re-authentication daily even with the
+JWK persisted (issue #266). No extra configuration is needed; the tables ship
+with the schema.
+
 You can confirm which mode you are in from the startup logs:
 
 ```


### PR DESCRIPTION
Closes #266

## Problem

Claude Desktop and Codex showed "Reconnect mockhub — Authentication expired" almost daily. The persisted `MCP_OAUTH2_JWK` only made access-token *signatures* survive redeploys; refresh tokens (opaque, server-side) and DCR client registrations lived in in-memory stores that every Railway redeploy wiped. Since pushes to `main` auto-deploy, the 60-day refresh window never got a chance to matter.

## Changes

- **Flyway V36** — `oauth2_registered_client`, `oauth2_authorization`, `oauth2_authorization_consent` (Spring Authorization Server 7.0.3 shipped schema, Postgres-adapted: `blob` → `text`, `timestamp` → `timestamptz`)
- **`JdbcRegisteredClientRepository`** — DCR registrations persist; the pre-registered Claude client is seeded with a fixed entity id so startup seeding is an idempotent create-or-update (and re-applies TTL config changes). A `DuplicateKeyException` from a concurrent-instance seeding race is swallowed.
- **`JdbcOAuth2AuthorizationService`** wrapped in **`PrincipalSanitizingOAuth2AuthorizationService`** — the JDBC service serializes the login principal with Jackson's security allowlist, which rejects the custom `SecurityUser`. The sanitizer swaps it for the plain email string on save; the refresh flow only needs `getName()` + authorities.
- **`JdbcOAuth2AuthorizationConsentService`** — for completeness; MCP flows are consent-free so the table stays empty in practice.
- **`LifecycleCleanupService`** — deletes authorizations past their latest token expiry (all six expiry columns) and never-authorized DCR clients after 30 days, so the open DCR endpoint can't accumulate unbounded permanent rows.

## Codex review

Ran via `/codex-review` before pushing. Fixed: stale-DCR-client cleanup (Medium, partial — see below), extra expiry columns in cleanup (Low), seeding race guard (Low). Deferred:

- **DCR rate limiting** — the endpoint is intentionally open for connector self-registration; the 30-day cleanup bounds durable growth, but request-level throttling would need edge/app rate limiting. Follow-up candidate.
- **Full restart-and-refresh E2E test** — the integration tests cover the actual failure modes (rows in Postgres, `SecurityUser` serialization round-trip, refresh-token lookup). A context-restart test against the same container would be nice-to-have.

## Testing

- `PrincipalSanitizingOAuth2AuthorizationServiceTest` — sanitization, pass-through, delegation (100% coverage)
- `McpOAuth2PersistenceIntegrationTest` (Testcontainers) — Claude client seeded in DB, DCR client persisted to DB, authorization with `SecurityUser` principal + refresh token round-trips through Postgres, cleanup deletes expired/stale rows and keeps live ones
- Existing `McpOAuth2IntegrationTest` now exercises the JDBC path end-to-end (DCR + client_credentials token issuance writes through the new store)
- Full backend suite: 1232 tests, 0 failures. New-code line coverage: 100% / 100% / 95% (sanitizer / cleanup / config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)