### PR TITLE
Lint cleanup and Spring Boot 4.1.0

### DIFF
--- a/backend/gradle/libs.versions.toml
+++ b/backend/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Plugins
-spring-boot = "4.0.3"
+spring-boot = "4.1.0"
 spring-dependency-management = "1.1.7"
 sonarqube = "7.2.3.7755"
 spotless = "7.0.2"

--- a/backend/src/main/java/com/mockhub/auth/repository/OAuthAccountRepository.java
+++ b/backend/src/main/java/com/mockhub/auth/repository/OAuthAccountRepository.java
@@ -4,11 +4,9 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.auth.entity.OAuthAccount;
 
-@Repository
 public interface OAuthAccountRepository extends JpaRepository<OAuthAccount, Long> {
 
     Optional<OAuthAccount> findByProviderAndProviderAccountId(String provider, String providerAccountId);

--- a/backend/src/main/java/com/mockhub/auth/repository/RoleRepository.java
+++ b/backend/src/main/java/com/mockhub/auth/repository/RoleRepository.java
@@ -3,11 +3,9 @@ package com.mockhub.auth.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.auth.entity.Role;
 
-@Repository
 public interface RoleRepository extends JpaRepository<Role, Long> {
 
     Optional<Role> findByName(String name);

--- a/backend/src/main/java/com/mockhub/auth/repository/UserRepository.java
+++ b/backend/src/main/java/com/mockhub/auth/repository/UserRepository.java
@@ -8,11 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.auth.entity.User;
 
-@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);

--- a/backend/src/main/java/com/mockhub/auth/security/OAuth2AuthenticationSuccessHandler.java
+++ b/backend/src/main/java/com/mockhub/auth/security/OAuth2AuthenticationSuccessHandler.java
@@ -224,7 +224,6 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
         };
     }
 
-    @SuppressWarnings("unchecked")
     private String extractAvatarUrl(OAuth2User user, String provider) {
         return switch (provider) {
             case PROVIDER_GOOGLE -> user.getAttribute("picture");

--- a/backend/src/main/java/com/mockhub/cart/repository/CartItemRepository.java
+++ b/backend/src/main/java/com/mockhub/cart/repository/CartItemRepository.java
@@ -3,11 +3,9 @@ package com.mockhub.cart.repository;
 import java.time.Instant;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.cart.entity.CartItem;
 
-@Repository
 public interface CartItemRepository extends JpaRepository<CartItem, Long> {
 
     void deleteByCartIdAndId(Long cartId, Long id);

--- a/backend/src/main/java/com/mockhub/cart/repository/CartRepository.java
+++ b/backend/src/main/java/com/mockhub/cart/repository/CartRepository.java
@@ -3,12 +3,10 @@ package com.mockhub.cart.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.auth.entity.User;
 import com.mockhub.cart.entity.Cart;
 
-@Repository
 public interface CartRepository extends JpaRepository<Cart, Long> {
 
     Optional<Cart> findByUserId(Long userId);

--- a/backend/src/main/java/com/mockhub/event/repository/CategoryRepository.java
+++ b/backend/src/main/java/com/mockhub/event/repository/CategoryRepository.java
@@ -4,11 +4,9 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.event.entity.Category;
 
-@Repository
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
     Optional<Category> findBySlug(String slug);

--- a/backend/src/main/java/com/mockhub/event/repository/EventRepository.java
+++ b/backend/src/main/java/com/mockhub/event/repository/EventRepository.java
@@ -9,11 +9,9 @@ import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.event.entity.Event;
 
-@Repository
 public interface EventRepository extends JpaRepository<Event, Long>, JpaSpecificationExecutor<Event> {
 
     Optional<Event> findBySlug(String slug);

--- a/backend/src/main/java/com/mockhub/event/repository/TagRepository.java
+++ b/backend/src/main/java/com/mockhub/event/repository/TagRepository.java
@@ -4,11 +4,9 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.event.entity.Tag;
 
-@Repository
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
     Optional<Tag> findBySlug(String slug);

--- a/backend/src/main/java/com/mockhub/favorite/repository/FavoriteRepository.java
+++ b/backend/src/main/java/com/mockhub/favorite/repository/FavoriteRepository.java
@@ -5,11 +5,9 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.favorite.entity.Favorite;
 
-@Repository
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 
     List<Favorite> findByUserId(Long userId);

--- a/backend/src/main/java/com/mockhub/image/repository/ImageRepository.java
+++ b/backend/src/main/java/com/mockhub/image/repository/ImageRepository.java
@@ -4,11 +4,9 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.image.entity.Image;
 
-@Repository
 public interface ImageRepository extends JpaRepository<Image, Long> {
 
     List<Image> findByEventIdOrderBySortOrderAsc(Long eventId);

--- a/backend/src/main/java/com/mockhub/notification/repository/NotificationRepository.java
+++ b/backend/src/main/java/com/mockhub/notification/repository/NotificationRepository.java
@@ -8,11 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.notification.entity.Notification;
 
-@Repository
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     Page<Notification> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);

--- a/backend/src/main/java/com/mockhub/order/repository/OrderItemRepository.java
+++ b/backend/src/main/java/com/mockhub/order/repository/OrderItemRepository.java
@@ -7,12 +7,10 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.event.entity.Event;
 import com.mockhub.order.entity.OrderItem;
 
-@Repository
 public interface OrderItemRepository extends JpaRepository<OrderItem, Long> {
 
     @Query("""

--- a/backend/src/main/java/com/mockhub/order/repository/OrderRepository.java
+++ b/backend/src/main/java/com/mockhub/order/repository/OrderRepository.java
@@ -10,11 +10,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.order.entity.Order;
 
-@Repository
 public interface OrderRepository extends JpaRepository<Order, Long> {
 
     Page<Order> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);

--- a/backend/src/main/java/com/mockhub/order/service/OrderService.java
+++ b/backend/src/main/java/com/mockhub/order/service/OrderService.java
@@ -28,7 +28,6 @@ import com.mockhub.common.dto.PagedResponse;
 import com.mockhub.common.exception.ConflictException;
 import com.mockhub.common.exception.ResourceNotFoundException;
 import com.mockhub.common.exception.UnauthorizedException;
-import com.mockhub.event.entity.Event;
 import com.mockhub.event.repository.EventRepository;
 import com.mockhub.mandate.service.MandateService;
 import com.mockhub.order.dto.CheckoutRequest;

--- a/backend/src/main/java/com/mockhub/payment/repository/TransactionLogRepository.java
+++ b/backend/src/main/java/com/mockhub/payment/repository/TransactionLogRepository.java
@@ -3,11 +3,9 @@ package com.mockhub.payment.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.payment.entity.TransactionLog;
 
-@Repository
 public interface TransactionLogRepository extends JpaRepository<TransactionLog, Long> {
 
     List<TransactionLog> findByOrderId(Long orderId);

--- a/backend/src/main/java/com/mockhub/pricing/repository/PriceHistoryRepository.java
+++ b/backend/src/main/java/com/mockhub/pricing/repository/PriceHistoryRepository.java
@@ -4,11 +4,9 @@ import java.time.Instant;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.pricing.entity.PriceHistory;
 
-@Repository
 public interface PriceHistoryRepository extends JpaRepository<PriceHistory, Long> {
 
     List<PriceHistory> findByEventIdOrderByRecordedAtDesc(Long eventId);

--- a/backend/src/main/java/com/mockhub/spotify/repository/SpotifyListeningCacheRepository.java
+++ b/backend/src/main/java/com/mockhub/spotify/repository/SpotifyListeningCacheRepository.java
@@ -3,11 +3,9 @@ package com.mockhub.spotify.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.spotify.entity.SpotifyListeningCache;
 
-@Repository
 public interface SpotifyListeningCacheRepository extends JpaRepository<SpotifyListeningCache, Long> {
 
     Optional<SpotifyListeningCache> findByUserId(Long userId);

--- a/backend/src/main/java/com/mockhub/spotify/service/SpotifyDataCleanupScheduler.java
+++ b/backend/src/main/java/com/mockhub/spotify/service/SpotifyDataCleanupScheduler.java
@@ -1,7 +1,5 @@
 package com.mockhub.spotify.service;
 
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import org.slf4j.Logger;

--- a/backend/src/main/java/com/mockhub/ticket/repository/ListingRepository.java
+++ b/backend/src/main/java/com/mockhub/ticket/repository/ListingRepository.java
@@ -8,11 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.ticket.entity.Listing;
 
-@Repository
 public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpecificationExecutor<Listing> {
 
     @Query("""

--- a/backend/src/main/java/com/mockhub/ticket/repository/TicketRepository.java
+++ b/backend/src/main/java/com/mockhub/ticket/repository/TicketRepository.java
@@ -6,11 +6,9 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.ticket.entity.Ticket;
 
-@Repository
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
     List<Ticket> findByEventId(Long eventId);

--- a/backend/src/main/java/com/mockhub/ticketmaster/service/TicketmasterEventMapper.java
+++ b/backend/src/main/java/com/mockhub/ticketmaster/service/TicketmasterEventMapper.java
@@ -13,7 +13,6 @@ import java.time.ZonedDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/backend/src/main/java/com/mockhub/venue/repository/VenueRepository.java
+++ b/backend/src/main/java/com/mockhub/venue/repository/VenueRepository.java
@@ -6,11 +6,9 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 
 import com.mockhub.venue.entity.Venue;
 
-@Repository
 public interface VenueRepository extends JpaRepository<Venue, Long> {
 
     Optional<Venue> findBySlug(String slug);

--- a/backend/src/test/java/com/mockhub/AbstractIntegrationTest.java
+++ b/backend/src/test/java/com/mockhub/AbstractIntegrationTest.java
@@ -1,6 +1,7 @@
 package com.mockhub;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.http.client.HttpCookieHandling;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.resttestclient.TestRestTemplate;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
@@ -58,8 +59,15 @@ public abstract class AbstractIntegrationTest {
         registry.add("spring.datasource.password", POSTGRES::getPassword);
     }
 
-    @Autowired
     protected TestRestTemplate restTemplate;
+
+    // Spring Boot 4.1 lets the HTTP client keep a cookie jar by default (gh-49261),
+    // which leaks the refresh_token cookie between tests. Tests assume independent
+    // requests, so restore the pre-4.1 behavior of ignoring cookies.
+    @Autowired
+    void configureRestTemplate(TestRestTemplate restTemplate) {
+        this.restTemplate = restTemplate.withCookieHandling(HttpCookieHandling.DISABLE);
+    }
 
     /**
      * Registers a new user and returns the auth response containing a JWT token.

--- a/backend/src/test/java/com/mockhub/OAuth2IntegrationTest.java
+++ b/backend/src/test/java/com/mockhub/OAuth2IntegrationTest.java
@@ -10,7 +10,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;

--- a/backend/src/test/java/com/mockhub/acp/controller/AcpControllerTest.java
+++ b/backend/src/test/java/com/mockhub/acp/controller/AcpControllerTest.java
@@ -31,7 +31,6 @@ import com.mockhub.common.dto.PagedResponse;
 import com.mockhub.config.SecurityConfig;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;

--- a/backend/src/test/java/com/mockhub/admin/service/AdminEventServiceTest.java
+++ b/backend/src/test/java/com/mockhub/admin/service/AdminEventServiceTest.java
@@ -24,8 +24,6 @@ import org.springframework.data.domain.Pageable;
 import com.mockhub.admin.dto.AdminEventDto;
 import com.mockhub.common.dto.PagedResponse;
 import com.mockhub.common.exception.ResourceNotFoundException;
-import com.mockhub.event.dto.EventCreateRequest;
-import com.mockhub.event.dto.EventDto;
 import com.mockhub.event.entity.Category;
 import com.mockhub.event.entity.Event;
 import com.mockhub.event.repository.EventRepository;

--- a/backend/src/test/java/com/mockhub/admin/service/AdminOrderServiceTest.java
+++ b/backend/src/test/java/com/mockhub/admin/service/AdminOrderServiceTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;

--- a/backend/src/test/java/com/mockhub/ai/service/RecommendationServiceTest.java
+++ b/backend/src/test/java/com/mockhub/ai/service/RecommendationServiceTest.java
@@ -5,7 +5,6 @@ import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -30,7 +29,6 @@ import com.mockhub.eval.dto.EvalSummary;
 import com.mockhub.eval.service.EvalRunner;
 import com.mockhub.event.entity.Category;
 import com.mockhub.event.entity.Event;
-import com.mockhub.event.entity.Tag;
 import com.mockhub.event.repository.EventRepository;
 import com.mockhub.favorite.entity.Favorite;
 import com.mockhub.favorite.repository.FavoriteRepository;
@@ -364,7 +362,6 @@ class RecommendationServiceTest {
         Event spotifyEvent = createTestEvent(1L, "Beyoncé Concert", "beyonce", "Arena", "LA");
         spotifyEvent.setSpotifyArtistId("6vWDO969PvNqNYHIOW5v0m");
 
-        @SuppressWarnings("unchecked")
         SpotifyListeningService mockListeningService =
                 org.mockito.Mockito.mock(SpotifyListeningService.class);
         RecommendationService serviceWithSpotify = new RecommendationService(
@@ -434,7 +431,6 @@ class RecommendationServiceTest {
     @Test
     @DisplayName("getRecommendations with Spotify - includes Spotify artists in prompt")
     void getRecommendations_withSpotify_includesSpotifyArtistsInPrompt() {
-        @SuppressWarnings("unchecked")
         SpotifyListeningService mockListeningService =
                 org.mockito.Mockito.mock(SpotifyListeningService.class);
         RecommendationService serviceWithSpotify = new RecommendationService(

--- a/backend/src/test/java/com/mockhub/mandate/controller/MandateControllerTest.java
+++ b/backend/src/test/java/com/mockhub/mandate/controller/MandateControllerTest.java
@@ -28,9 +28,7 @@ import com.mockhub.config.SecurityConfig;
 import com.mockhub.mandate.dto.MandateDto;
 import com.mockhub.mandate.service.MandateService;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;

--- a/backend/src/test/java/com/mockhub/mcp/McpSessionRecoveryFilterTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/McpSessionRecoveryFilterTest.java
@@ -5,7 +5,6 @@ import java.io.PrintWriter;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.junit.jupiter.api.DisplayName;

--- a/backend/src/test/java/com/mockhub/mcp/config/McpOAuth2SecurityConfigTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/config/McpOAuth2SecurityConfigTest.java
@@ -3,7 +3,6 @@ package com.mockhub.mcp.config;
 import java.security.interfaces.RSAPublicKey;
 import java.util.List;
 
-import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.jwk.JWK;
 import com.nimbusds.jose.jwk.JWKMatcher;
 import com.nimbusds.jose.jwk.JWKSelector;

--- a/backend/src/test/java/com/mockhub/order/service/CalendarServiceTest.java
+++ b/backend/src/test/java/com/mockhub/order/service/CalendarServiceTest.java
@@ -1,7 +1,6 @@
 package com.mockhub.order.service;
 
 import java.math.BigDecimal;
-import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;

--- a/backend/src/test/java/com/mockhub/ticketmaster/service/TicketmasterSyncServiceTest.java
+++ b/backend/src/test/java/com/mockhub/ticketmaster/service/TicketmasterSyncServiceTest.java
@@ -1,6 +1,5 @@
 package com.mockhub.ticketmaster.service;
 
-import java.math.BigDecimal;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -23,7 +23,6 @@
     "types": ["vitest/globals"],
 
     /* Aliases */
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
## Summary
- Remove IDE-flagged dead code: redundant `@Repository` on 19 Spring Data interfaces, 17 unused imports, 3 unnecessary `@SuppressWarnings("unchecked")`, and the deprecated `baseUrl` in `frontend/tsconfig.json` (paths are already relative)
- Bump Spring Boot 4.0.3 → 4.1.0

## Spring Boot 4.1 behavior change
Spring Boot 4.1 no longer force-disables `TestRestTemplate` cookie handling (spring-boot#49261), so the HTTP client's cookie jar leaked the `refresh_token` cookie between integration tests, breaking the "refresh without cookie returns 401" test. `AbstractIntegrationTest` now calls `withCookieHandling(HttpCookieHandling.DISABLE)` to keep test requests independent.

## Verification
- Full backend suite: 1232 tests, 0 failures (includes Testcontainers integration tests)
- Pre-push gate: Prettier, ESLint, tsc, Vitest coverage all green
- Headless Codex review: no findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)