### PR TITLE
Harden agent-facing tool contracts: categories, search semantics, bounded price history

### DIFF
--- a/backend/src/main/java/com/mockhub/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/mockhub/common/exception/GlobalExceptionHandler.java
@@ -48,6 +48,8 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ProblemDetail> handleIllegalArgument(IllegalArgumentException ex) {
+        log.warn("Invalid argument rejected: {}", ex.getMessage());
+
         ProblemDetail problem = ProblemDetail.forStatusAndDetail(
                 HttpStatus.BAD_REQUEST, ex.getMessage());
         problem.setTitle("Bad Request");

--- a/backend/src/main/java/com/mockhub/common/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/mockhub/common/exception/GlobalExceptionHandler.java
@@ -46,6 +46,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.CONFLICT).body(problem);
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ProblemDetail> handleIllegalArgument(IllegalArgumentException ex) {
+        ProblemDetail problem = ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST, ex.getMessage());
+        problem.setTitle("Bad Request");
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(problem);
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ProblemDetail> handleValidation(MethodArgumentNotValidException ex) {
         ProblemDetail problem = ProblemDetail.forStatusAndDetail(

--- a/backend/src/main/java/com/mockhub/mandate/service/MandateService.java
+++ b/backend/src/main/java/com/mockhub/mandate/service/MandateService.java
@@ -17,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.mockhub.common.exception.ResourceNotFoundException;
 import com.mockhub.common.exception.UnauthorizedException;
+import com.mockhub.event.entity.Category;
+import com.mockhub.event.repository.CategoryRepository;
 import com.mockhub.mandate.dto.CreateMandateRequest;
 import com.mockhub.mandate.dto.MandateDto;
 import com.mockhub.mandate.entity.Mandate;
@@ -33,9 +35,11 @@ public class MandateService {
     private static final String APPROVAL_MODE_APPROVAL_REQUIRED = "APPROVAL_REQUIRED";
 
     private final MandateRepository mandateRepository;
+    private final CategoryRepository categoryRepository;
 
-    public MandateService(MandateRepository mandateRepository) {
+    public MandateService(MandateRepository mandateRepository, CategoryRepository categoryRepository) {
         this.mandateRepository = mandateRepository;
+        this.categoryRepository = categoryRepository;
     }
 
     @Transactional
@@ -48,7 +52,7 @@ public class MandateService {
         mandate.setMaxSpendPerTransaction(request.maxSpendPerTransaction());
         mandate.setMaxSpendTotal(request.maxSpendTotal());
         mandate.setTotalSpent(BigDecimal.ZERO);
-        mandate.setAllowedCategories(request.allowedCategories());
+        mandate.setAllowedCategories(normalizeAndValidateCategories(request.allowedCategories()));
         mandate.setAllowedEvents(request.allowedEvents());
         mandate.setAllowedSections(request.allowedSections());
         mandate.setApprovalMode(normalizeApprovalMode(request.approvalMode()));
@@ -279,6 +283,40 @@ public class MandateService {
             return true;
         }
         return grantedScope.equals(requiredScope);
+    }
+
+    /**
+     * Normalizes a comma-separated category list (trim, lowercase, drop blanks)
+     * and validates each slug against the categories table. Agents frequently
+     * pass genres like "jazz" here; rejecting unknown slugs at creation time
+     * prevents mandates that can never authorize anything.
+     */
+    private String normalizeAndValidateCategories(String allowedCategories) {
+        if (allowedCategories == null || allowedCategories.isBlank()) {
+            return null;
+        }
+        List<String> requested = Arrays.stream(allowedCategories.split(","))
+                .map(String::strip)
+                .map(String::toLowerCase)
+                .filter(slug -> !slug.isEmpty())
+                .distinct()
+                .toList();
+        if (requested.isEmpty()) {
+            return null;
+        }
+        Set<String> validSlugs = categoryRepository.findAll().stream()
+                .map(Category::getSlug)
+                .collect(Collectors.toSet());
+        List<String> unknown = requested.stream()
+                .filter(slug -> !validSlugs.contains(slug))
+                .toList();
+        if (!unknown.isEmpty()) {
+            throw new IllegalArgumentException("Unknown category slug(s): " + unknown
+                    + ". Valid category slugs: " + validSlugs.stream().sorted()
+                            .collect(Collectors.joining(", "))
+                    + ". Categories are event types, not genres.");
+        }
+        return String.join(",", requested);
     }
 
     private Set<String> parseCommaSeparated(String value) {

--- a/backend/src/main/java/com/mockhub/mandate/service/MandateService.java
+++ b/backend/src/main/java/com/mockhub/mandate/service/MandateService.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -297,7 +298,7 @@ public class MandateService {
         }
         List<String> requested = Arrays.stream(allowedCategories.split(","))
                 .map(String::strip)
-                .map(String::toLowerCase)
+                .map(slug -> slug.toLowerCase(Locale.ROOT))
                 .filter(slug -> !slug.isEmpty())
                 .distinct()
                 .toList();
@@ -322,7 +323,7 @@ public class MandateService {
     private Set<String> parseCommaSeparated(String value) {
         return Arrays.stream(value.split(","))
                 .map(String::strip)
-                .map(String::toLowerCase)
+                .map(slug -> slug.toLowerCase(Locale.ROOT))
                 .collect(Collectors.toSet());
     }
 

--- a/backend/src/main/java/com/mockhub/mcp/tools/EventTools.java
+++ b/backend/src/main/java/com/mockhub/mcp/tools/EventTools.java
@@ -60,9 +60,9 @@ public class EventTools {
     @Tool(description = "Search and filter MockHub events by query text, category, city, and pagination. "
             + "Returns a paginated list of event summaries with name, artist, venue, date, and price.")
     public String searchEvents(
-            @ToolParam(description = "Search text matched against event name and artist name only "
-                    + "(substring match). There is no genre search — for a genre like jazz, "
-                    + "search by artist name or filter by category",
+            @ToolParam(description = "Full-text search over event name, artist name, and description "
+                    + "(word-based with stemming, not substring). There is no genre field — a genre "
+                    + "like 'jazz' matches only where those fields mention it",
                     required = false) String query,
             @ToolParam(description = "Category slug to filter by: 'concerts', 'sports', "
                     + "'theater', 'comedy', 'festivals'",

--- a/backend/src/main/java/com/mockhub/mcp/tools/EventTools.java
+++ b/backend/src/main/java/com/mockhub/mcp/tools/EventTools.java
@@ -60,7 +60,9 @@ public class EventTools {
     @Tool(description = "Search and filter MockHub events by query text, category, city, and pagination. "
             + "Returns a paginated list of event summaries with name, artist, venue, date, and price.")
     public String searchEvents(
-            @ToolParam(description = "Search query text to match event name or artist",
+            @ToolParam(description = "Search text matched against event name and artist name only "
+                    + "(substring match). There is no genre search — for a genre like jazz, "
+                    + "search by artist name or filter by category",
                     required = false) String query,
             @ToolParam(description = "Category slug to filter by: 'concerts', 'sports', "
                     + "'theater', 'comedy', 'festivals'",
@@ -187,7 +189,9 @@ public class EventTools {
             + "For broad queries, ask the user to narrow by city, category, or date range "
             + "before calling — this produces faster, more relevant results.")
     public String findTickets(
-            @ToolParam(description = "Search query text to match event name or artist",
+            @ToolParam(description = "Search text matched against event name and artist name only "
+                    + "(substring match). There is no genre search — for a genre like jazz, "
+                    + "search by artist name or filter by category",
                     required = false) String query,
             @ToolParam(description = "Category slug to filter by: 'concerts', 'sports', "
                     + "'theater', 'comedy', 'festivals'",
@@ -240,7 +244,9 @@ public class EventTools {
             + "and price plausibility warnings. Objective listing fields are returned separately from "
             + "heuristic judgment fields.")
     public String compareTickets(
-            @ToolParam(description = "Search query text to match event name or artist",
+            @ToolParam(description = "Search text matched against event name and artist name only "
+                    + "(substring match). There is no genre search — for a genre like jazz, "
+                    + "search by artist name or filter by category",
                     required = false) String query,
             @ToolParam(description = "Category slug to filter by: 'concerts', 'sports', "
                     + "'theater', 'comedy', 'festivals'",

--- a/backend/src/main/java/com/mockhub/mcp/tools/MandateTools.java
+++ b/backend/src/main/java/com/mockhub/mcp/tools/MandateTools.java
@@ -40,7 +40,10 @@ public class MandateTools {
             @ToolParam(description = "Scope of the mandate: BROWSE or PURCHASE", required = true) String scope,
             @ToolParam(description = "Maximum spend per transaction (optional)") BigDecimal maxSpendPerTransaction,
             @ToolParam(description = "Maximum cumulative spend limit (optional)") BigDecimal maxSpendTotal,
-            @ToolParam(description = "Comma-separated category slugs (optional, null = all)") String allowedCategories,
+            @ToolParam(description = "Comma-separated event category slugs the agent may buy from: "
+                    + "concerts, sports, theater, comedy, festivals (optional, null = all). "
+                    + "These are event categories, not genres — a genre like 'jazz' is rejected")
+                    String allowedCategories,
             @ToolParam(description = "Comma-separated event slugs (optional, null = all)") String allowedEvents,
             @ToolParam(description = "Comma-separated section names (optional, null = all sections)") String allowedSections,
             @ToolParam(description = "AUTO_PURCHASE or APPROVAL_REQUIRED (optional, defaults to AUTO_PURCHASE)")

--- a/backend/src/main/java/com/mockhub/mcp/tools/PricingTools.java
+++ b/backend/src/main/java/com/mockhub/mcp/tools/PricingTools.java
@@ -1,7 +1,5 @@
 package com.mockhub.mcp.tools;
 
-import java.util.List;
-
 import org.jspecify.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,13 +10,14 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mockhub.ai.dto.PricePredictionDto;
 import com.mockhub.ai.service.PricePredictionService;
-import com.mockhub.pricing.dto.PriceHistoryDto;
+import com.mockhub.pricing.dto.PriceHistoryPageDto;
 import com.mockhub.pricing.service.PriceHistoryService;
 
 @Component
 public class PricingTools {
 
     private static final Logger log = LoggerFactory.getLogger(PricingTools.class);
+    private static final int DEFAULT_HISTORY_LIMIT = 50;
 
     private final PriceHistoryService priceHistoryService;
     private final PricePredictionService pricePredictionService;
@@ -32,15 +31,22 @@ public class PricingTools {
         this.objectMapper = objectMapper;
     }
 
-    @Tool(description = "Get MockHub price history for an event showing how ticket prices have changed over time. "
-            + "Returns a list of price snapshots with price, multiplier, supply ratio, and demand score.")
+    @Tool(description = "Get recent MockHub price history snapshots for an event, newest first. "
+            + "Returns { snapshots, returned, totalSnapshots, limit }. Snapshots may be stale — "
+            + "check the newest recordedAt before treating the series as current. "
+            + "Events can have thousands of snapshots; use the limit parameter, not repeated calls, "
+            + "to control response size.")
     public String getPriceHistory(
-            @ToolParam(description = "Event URL slug to get price history for", required = true) String eventSlug) {
+            @ToolParam(description = "Event URL slug to get price history for", required = true) String eventSlug,
+            @ToolParam(description = "Maximum snapshots to return, newest first (default 50, max 500)",
+                    required = false) Integer limit) {
         try {
             if (eventSlug == null || eventSlug.isBlank()) {
                 return errorJson("Event slug is required");
             }
-            List<PriceHistoryDto> history = priceHistoryService.getByEventSlug(eventSlug.strip());
+            int effectiveLimit = limit != null ? limit : DEFAULT_HISTORY_LIMIT;
+            PriceHistoryPageDto history =
+                    priceHistoryService.getRecentByEventSlug(eventSlug.strip(), effectiveLimit);
             return objectMapper.writeValueAsString(history);
         } catch (Exception e) {
             log.error("Error getting price history for '{}': {}", eventSlug, e.getMessage(), e);

--- a/backend/src/main/java/com/mockhub/pricing/dto/PriceHistoryPageDto.java
+++ b/backend/src/main/java/com/mockhub/pricing/dto/PriceHistoryPageDto.java
@@ -1,0 +1,16 @@
+package com.mockhub.pricing.dto;
+
+import java.util.List;
+
+/**
+ * Bounded price-history response for agent-facing tools. Snapshots are
+ * newest-first; totalSnapshots tells the caller how much history exists
+ * beyond the returned window.
+ */
+public record PriceHistoryPageDto(
+        List<PriceHistoryDto> snapshots,
+        int returned,
+        long totalSnapshots,
+        int limit
+) {
+}

--- a/backend/src/main/java/com/mockhub/pricing/repository/PriceHistoryRepository.java
+++ b/backend/src/main/java/com/mockhub/pricing/repository/PriceHistoryRepository.java
@@ -3,6 +3,7 @@ package com.mockhub.pricing.repository;
 import java.time.Instant;
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.mockhub.pricing.entity.PriceHistory;
@@ -10,6 +11,10 @@ import com.mockhub.pricing.entity.PriceHistory;
 public interface PriceHistoryRepository extends JpaRepository<PriceHistory, Long> {
 
     List<PriceHistory> findByEventIdOrderByRecordedAtDesc(Long eventId);
+
+    List<PriceHistory> findByEventIdOrderByRecordedAtDesc(Long eventId, Pageable pageable);
+
+    long countByEventId(Long eventId);
 
     List<PriceHistory> findByEventIdAndRecordedAtBetween(Long eventId, Instant start, Instant end);
 }

--- a/backend/src/main/java/com/mockhub/pricing/service/PriceHistoryService.java
+++ b/backend/src/main/java/com/mockhub/pricing/service/PriceHistoryService.java
@@ -2,6 +2,7 @@ package com.mockhub.pricing.service;
 
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -9,11 +10,14 @@ import com.mockhub.common.exception.ResourceNotFoundException;
 import com.mockhub.event.entity.Event;
 import com.mockhub.event.repository.EventRepository;
 import com.mockhub.pricing.dto.PriceHistoryDto;
+import com.mockhub.pricing.dto.PriceHistoryPageDto;
 import com.mockhub.pricing.entity.PriceHistory;
 import com.mockhub.pricing.repository.PriceHistoryRepository;
 
 @Service
 public class PriceHistoryService {
+
+    public static final int MAX_SNAPSHOT_LIMIT = 500;
 
     private final PriceHistoryRepository priceHistoryRepository;
     private final EventRepository eventRepository;
@@ -31,6 +35,24 @@ public class PriceHistoryService {
 
         return toHistoryDtos(priceHistoryRepository
                 .findByEventIdOrderByRecordedAtDesc(event.getId()));
+    }
+
+    /**
+     * Bounded variant for agent-facing tools: newest {@code limit} snapshots
+     * plus the total count. Limit is clamped to [1, MAX_SNAPSHOT_LIMIT] —
+     * popular events accumulate thousands of 5-minute snapshots, which blows
+     * agent context windows if returned unbounded.
+     */
+    @Transactional(readOnly = true)
+    public PriceHistoryPageDto getRecentByEventSlug(String eventSlug, int limit) {
+        Event event = eventRepository.findBySlug(eventSlug)
+                .orElseThrow(() -> new ResourceNotFoundException("Event", "slug", eventSlug));
+
+        int clampedLimit = Math.clamp(limit, 1, MAX_SNAPSHOT_LIMIT);
+        List<PriceHistoryDto> snapshots = toHistoryDtos(priceHistoryRepository
+                .findByEventIdOrderByRecordedAtDesc(event.getId(), PageRequest.of(0, clampedLimit)));
+        long total = priceHistoryRepository.countByEventId(event.getId());
+        return new PriceHistoryPageDto(snapshots, snapshots.size(), total, clampedLimit);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/test/java/com/mockhub/common/exception/GlobalExceptionHandlerTest.java
+++ b/backend/src/test/java/com/mockhub/common/exception/GlobalExceptionHandlerTest.java
@@ -133,6 +133,22 @@ class GlobalExceptionHandlerTest {
     }
 
     @Test
+    @DisplayName("handleIllegalArgument - returns 400 ProblemDetail with exception message")
+    void handleIllegalArgument_returns400ProblemDetail() {
+        IllegalArgumentException ex =
+                new IllegalArgumentException("Unknown category slug(s): [jazz]");
+
+        ResponseEntity<ProblemDetail> response = handler.handleIllegalArgument(ex);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        ProblemDetail body = response.getBody();
+        assertNotNull(body);
+        assertEquals(400, body.getStatus());
+        assertEquals("Bad Request", body.getTitle());
+        assertEquals("Unknown category slug(s): [jazz]", body.getDetail());
+    }
+
+    @Test
     @DisplayName("handleOptimisticLock - returns 409 ProblemDetail with retry message")
     void handleOptimisticLock_returns409ProblemDetail() {
         OptimisticLockingFailureException ex =

--- a/backend/src/test/java/com/mockhub/mandate/service/MandateServiceTest.java
+++ b/backend/src/test/java/com/mockhub/mandate/service/MandateServiceTest.java
@@ -15,6 +15,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.mockhub.common.exception.ResourceNotFoundException;
+import com.mockhub.event.entity.Category;
+import com.mockhub.event.repository.CategoryRepository;
 import com.mockhub.mandate.dto.CreateMandateRequest;
 import com.mockhub.mandate.dto.MandateDto;
 import com.mockhub.mandate.entity.Mandate;
@@ -23,6 +25,7 @@ import com.mockhub.mandate.repository.MandateRepository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -33,11 +36,26 @@ class MandateServiceTest {
     @Mock
     private MandateRepository mandateRepository;
 
+    @Mock
+    private CategoryRepository categoryRepository;
+
     private MandateService mandateService;
 
     @BeforeEach
     void setUp() {
-        mandateService = new MandateService(mandateRepository);
+        mandateService = new MandateService(mandateRepository, categoryRepository);
+    }
+
+    private void stubCategorySlugs() {
+        when(categoryRepository.findAll()).thenReturn(List.of(
+                category("concerts"), category("sports"), category("theater"),
+                category("comedy"), category("festivals")));
+    }
+
+    private Category category(String slug) {
+        Category category = new Category();
+        category.setSlug(slug);
+        return category;
     }
 
     @Test
@@ -48,6 +66,7 @@ class MandateServiceTest {
                 new BigDecimal("100.00"), new BigDecimal("500.00"),
                 "concerts,sports", null, null, null, null);
 
+        stubCategorySlugs();
         when(mandateRepository.save(any(Mandate.class))).thenAnswer(invocation -> {
             Mandate mandate = invocation.getArgument(0);
             mandate.setId(1L);
@@ -71,6 +90,55 @@ class MandateServiceTest {
         ArgumentCaptor<Mandate> captor = ArgumentCaptor.forClass(Mandate.class);
         verify(mandateRepository).save(captor.capture());
         assertThat(captor.getValue().getMandateId()).hasSize(36);
+    }
+
+    @Test
+    @DisplayName("createMandate rejects unknown category slugs with valid slugs in message")
+    void createMandate_givenUnknownCategorySlug_throwsIllegalArgumentException() {
+        CreateMandateRequest request = new CreateMandateRequest(
+                "agent-1", "user@example.com", "PURCHASE",
+                new BigDecimal("100.00"), new BigDecimal("500.00"),
+                "jazz,classical", null, null, null, null);
+
+        stubCategorySlugs();
+
+        assertThatThrownBy(() -> mandateService.createMandate(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("jazz")
+                .hasMessageContaining("classical")
+                .hasMessageContaining("concerts");
+    }
+
+    @Test
+    @DisplayName("createMandate normalizes category slug case and whitespace")
+    void createMandate_givenMixedCaseCategoriesWithSpaces_storesNormalizedSlugs() {
+        CreateMandateRequest request = new CreateMandateRequest(
+                "agent-1", "user@example.com", "PURCHASE",
+                new BigDecimal("100.00"), new BigDecimal("500.00"),
+                " Concerts, SPORTS ", null, null, null, null);
+
+        stubCategorySlugs();
+        when(mandateRepository.save(any(Mandate.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        MandateDto result = mandateService.createMandate(request);
+
+        assertThat(result.allowedCategories()).isEqualTo("concerts,sports");
+    }
+
+    @Test
+    @DisplayName("createMandate stores null for blank category list")
+    void createMandate_givenBlankCategories_storesNullWithoutValidation() {
+        CreateMandateRequest request = new CreateMandateRequest(
+                "agent-1", "user@example.com", "PURCHASE",
+                new BigDecimal("100.00"), new BigDecimal("500.00"),
+                " , ", null, null, null, null);
+
+        when(mandateRepository.save(any(Mandate.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        MandateDto result = mandateService.createMandate(request);
+
+        assertThat(result.allowedCategories()).isNull();
+        verify(categoryRepository, never()).findAll();
     }
 
     @Test

--- a/backend/src/test/java/com/mockhub/mcp/tools/PricingToolsTest.java
+++ b/backend/src/test/java/com/mockhub/mcp/tools/PricingToolsTest.java
@@ -15,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.mockhub.ai.dto.PricePredictionDto;
 import com.mockhub.ai.service.PricePredictionService;
+import com.mockhub.pricing.dto.PriceHistoryPageDto;
 import com.mockhub.pricing.service.PriceHistoryService;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -50,30 +51,45 @@ class PricingToolsTest {
         }
 
         @Test
-        @DisplayName("given valid event slug - returns price history JSON")
+        @DisplayName("given valid event slug - returns bounded price history JSON with default limit")
         void givenValidEventSlug_returnsPriceHistoryJson() {
-            when(priceHistoryService.getByEventSlug("rock-festival")).thenReturn(List.of());
+            when(priceHistoryService.getRecentByEventSlug("rock-festival", 50))
+                    .thenReturn(new PriceHistoryPageDto(List.of(), 0, 0, 50));
 
-            String result = pricingTools.getPriceHistory("rock-festival");
+            String result = pricingTools.getPriceHistory("rock-festival", null);
 
-            assertTrue(result.startsWith("["), "Result should be a JSON array");
-            verify(priceHistoryService).getByEventSlug("rock-festival");
+            assertTrue(result.contains("\"snapshots\""), "Result should contain snapshots field");
+            assertTrue(result.contains("\"totalSnapshots\""), "Result should contain totalSnapshots field");
+            verify(priceHistoryService).getRecentByEventSlug("rock-festival", 50);
+        }
+
+        @Test
+        @DisplayName("given explicit limit - passes limit through to service")
+        void givenExplicitLimit_passesLimitToService() {
+            when(priceHistoryService.getRecentByEventSlug("rock-festival", 10))
+                    .thenReturn(new PriceHistoryPageDto(List.of(), 0, 3495, 10));
+
+            String result = pricingTools.getPriceHistory("rock-festival", 10);
+
+            assertTrue(result.contains("3495"), "Result should carry the total snapshot count");
+            verify(priceHistoryService).getRecentByEventSlug("rock-festival", 10);
         }
 
         @Test
         @DisplayName("given slug with whitespace - strips whitespace before lookup")
         void givenSlugWithWhitespace_stripsWhitespace() {
-            when(priceHistoryService.getByEventSlug("rock-festival")).thenReturn(List.of());
+            when(priceHistoryService.getRecentByEventSlug("rock-festival", 50))
+                    .thenReturn(new PriceHistoryPageDto(List.of(), 0, 0, 50));
 
-            pricingTools.getPriceHistory("  rock-festival  ");
+            pricingTools.getPriceHistory("  rock-festival  ", null);
 
-            verify(priceHistoryService).getByEventSlug("rock-festival");
+            verify(priceHistoryService).getRecentByEventSlug("rock-festival", 50);
         }
 
         @Test
         @DisplayName("given null slug - returns error JSON")
         void givenNullSlug_returnsErrorJson() {
-            String result = pricingTools.getPriceHistory(null);
+            String result = pricingTools.getPriceHistory(null, null);
 
             assertTrue(result.contains("\"error\""), "Result should contain error field");
             assertTrue(result.contains("Event slug is required"), "Result should indicate slug is required");
@@ -82,7 +98,7 @@ class PricingToolsTest {
         @Test
         @DisplayName("given blank slug - returns error JSON")
         void givenBlankSlug_returnsErrorJson() {
-            String result = pricingTools.getPriceHistory("   ");
+            String result = pricingTools.getPriceHistory("   ", null);
 
             assertTrue(result.contains("\"error\""), "Result should contain error field");
         }
@@ -90,10 +106,10 @@ class PricingToolsTest {
         @Test
         @DisplayName("given service throws exception - returns error JSON")
         void givenServiceThrowsException_returnsErrorJson() {
-            when(priceHistoryService.getByEventSlug("bad-slug"))
+            when(priceHistoryService.getRecentByEventSlug("bad-slug", 50))
                     .thenThrow(new RuntimeException("DB error"));
 
-            String result = pricingTools.getPriceHistory("bad-slug");
+            String result = pricingTools.getPriceHistory("bad-slug", null);
 
             assertTrue(result.contains("\"error\""), "Result should contain error field");
             assertTrue(result.contains("Failed to get price history"), "Result should contain failure message");

--- a/backend/src/test/java/com/mockhub/pricing/service/PriceHistoryServiceTest.java
+++ b/backend/src/test/java/com/mockhub/pricing/service/PriceHistoryServiceTest.java
@@ -12,11 +12,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
 
 import com.mockhub.common.exception.ResourceNotFoundException;
 import com.mockhub.event.entity.Event;
 import com.mockhub.event.repository.EventRepository;
 import com.mockhub.pricing.dto.PriceHistoryDto;
+import com.mockhub.pricing.dto.PriceHistoryPageDto;
 import com.mockhub.pricing.entity.PriceHistory;
 import com.mockhub.pricing.repository.PriceHistoryRepository;
 
@@ -99,6 +101,48 @@ class PriceHistoryServiceTest {
         assertEquals(10L, secondDto.id(), "Second entry ID should match");
         assertEquals(new BigDecimal("120.00"), secondDto.price(), "Second entry price should match");
         assertEquals(14, secondDto.daysToEvent(), "Second entry days to event should match");
+    }
+
+    @Test
+    @DisplayName("getRecentByEventSlug - given limit - returns bounded page with total count")
+    void getRecentByEventSlug_givenLimit_returnsBoundedPage() {
+        when(eventRepository.findBySlug("test-event")).thenReturn(Optional.of(testEvent));
+        when(priceHistoryRepository.findByEventIdOrderByRecordedAtDesc(1L, PageRequest.of(0, 1)))
+                .thenReturn(List.of(historyEntry2));
+        when(priceHistoryRepository.countByEventId(1L)).thenReturn(3495L);
+
+        PriceHistoryPageDto result = priceHistoryService.getRecentByEventSlug("test-event", 1);
+
+        assertEquals(1, result.returned(), "Should return one snapshot");
+        assertEquals(3495L, result.totalSnapshots(), "Should report full history size");
+        assertEquals(1, result.limit(), "Should echo the applied limit");
+        assertEquals(11L, result.snapshots().get(0).id(), "Should return the newest snapshot");
+    }
+
+    @Test
+    @DisplayName("getRecentByEventSlug - given oversized limit - clamps to maximum")
+    void getRecentByEventSlug_givenOversizedLimit_clampsToMax() {
+        when(eventRepository.findBySlug("test-event")).thenReturn(Optional.of(testEvent));
+        when(priceHistoryRepository.findByEventIdOrderByRecordedAtDesc(
+                1L, PageRequest.of(0, PriceHistoryService.MAX_SNAPSHOT_LIMIT)))
+                .thenReturn(List.of());
+        when(priceHistoryRepository.countByEventId(1L)).thenReturn(0L);
+
+        PriceHistoryPageDto result = priceHistoryService.getRecentByEventSlug("test-event", 10_000);
+
+        assertEquals(PriceHistoryService.MAX_SNAPSHOT_LIMIT, result.limit(),
+                "Limit should be clamped to the maximum");
+    }
+
+    @Test
+    @DisplayName("getRecentByEventSlug - given non-existent slug - throws ResourceNotFoundException")
+    void getRecentByEventSlug_givenNonExistentSlug_throwsResourceNotFoundException() {
+        when(eventRepository.findBySlug("missing")).thenReturn(Optional.empty());
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> priceHistoryService.getRecentByEventSlug("missing", 50),
+                "Should throw ResourceNotFoundException for unknown slug");
+        verifyNoInteractions(priceHistoryRepository);
     }
 
     @Test

--- a/backend/src/test/java/com/mockhub/pricing/service/PriceHistoryServiceTest.java
+++ b/backend/src/test/java/com/mockhub/pricing/service/PriceHistoryServiceTest.java
@@ -135,6 +135,20 @@ class PriceHistoryServiceTest {
     }
 
     @Test
+    @DisplayName("getRecentByEventSlug - given zero or negative limit - clamps to one")
+    void getRecentByEventSlug_givenZeroLimit_clampsToOne() {
+        when(eventRepository.findBySlug("test-event")).thenReturn(Optional.of(testEvent));
+        when(priceHistoryRepository.findByEventIdOrderByRecordedAtDesc(1L, PageRequest.of(0, 1)))
+                .thenReturn(List.of(historyEntry2));
+        when(priceHistoryRepository.countByEventId(1L)).thenReturn(2L);
+
+        PriceHistoryPageDto result = priceHistoryService.getRecentByEventSlug("test-event", 0);
+
+        assertEquals(1, result.limit(), "Zero limit should be clamped to one");
+        assertEquals(1, result.returned(), "Should return a single snapshot");
+    }
+
+    @Test
     @DisplayName("getRecentByEventSlug - given non-existent slug - throws ResourceNotFoundException")
     void getRecentByEventSlug_givenNonExistentSlug_throwsResourceNotFoundException() {
         when(eventRepository.findBySlug("missing")).thenReturn(Optional.empty());


### PR DESCRIPTION
Fixes two failure modes discovered by a live agent session (Claude Desktop against the production MCP connector, 2026-07-24), plus a response-size hazard found the same way:

**1. Genre-vs-category confusion (closes #273)**
- `findTickets`/`compareTickets` query descriptions now state the contract: substring match on event/artist names, no genre search
- `searchEvents` description corrected separately — it actually uses PostgreSQL tsvector full-text over name/artist/description
- `createMandate` validates `allowedCategories` against real category slugs. Previously `allowedCategories: "jazz,classical"` silently created a mandate that could never authorize any purchase. Unknown slugs are now rejected with the valid list in the error; stored lists are normalized (trim/lowercase/dedupe, blank → null)
- `IllegalArgumentException` now maps to a 400 Problem Detail (was falling through to the 500 catch-all)

**2. Unbounded `getPriceHistory` (agent context blowout)**
- The MCP tool returned every snapshot — 624KB / 3,495 rows on a real event. Now bounded: newest-first, `limit` param (default 50, max 500), envelope `{ snapshots, returned, totalSnapshots, limit }`, and the description warns agents to check the newest `recordedAt` for staleness
- Web REST endpoints unchanged (frontend charts keep full series)

**Notes from Codex review** (run pre-push): the hardcoded slug list in the tool description can drift if a migration adds a category — accepted, the taxonomy is fixed seed data; the broad IAE→400 mapping reclassifies any controller-path IAE as a client error — accepted as an improvement over 500, message content is ours.

Follow-ups filed separately: #274 (genre taxonomy on events). Coverage on changed classes: 93–100% line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)