### PR TITLE
Block purchases of cancelled events end to end

### DIFF
--- a/backend/src/main/java/com/mockhub/cart/service/CartService.java
+++ b/backend/src/main/java/com/mockhub/cart/service/CartService.java
@@ -76,6 +76,11 @@ public class CartService {
             throw new ConflictException("Listing is not available");
         }
 
+        if (!"ACTIVE".equals(listing.getEvent().getStatus())) {
+            throw new ConflictException("Event is no longer available (status: "
+                    + listing.getEvent().getStatus() + ")");
+        }
+
         Cart cart = getOrCreateCart(user);
 
         // Check if expired — if so, clear items and reuse cart

--- a/backend/src/main/java/com/mockhub/lifecycle/LifecycleCleanupService.java
+++ b/backend/src/main/java/com/mockhub/lifecycle/LifecycleCleanupService.java
@@ -58,6 +58,7 @@ public class LifecycleCleanupService {
 
         int expiredByDeadline = expireListingsPastDeadline(now);
         int expiredByEvent = expireListingsForPastEvents(now);
+        int expiredByInactiveEvent = expireListingsForInactiveEvents();
         int completedEvents = markPastEventsAsCompleted(now);
         int deletedNotifications = deleteOldReadNotifications(now);
         int expiredPaymentCredentials = expirePaymentCredentials(now);
@@ -65,16 +66,17 @@ public class LifecycleCleanupService {
         int deletedOAuth2Authorizations = deleteExpiredOAuth2Authorizations(now);
         int deletedOAuth2Clients = deleteStaleUnauthorizedOAuth2Clients(now);
 
-        if (expiredByDeadline + expiredByEvent + completedEvents + deletedNotifications
-                + expiredPaymentCredentials + expiredApprovals + deletedOAuth2Authorizations
-                + deletedOAuth2Clients > 0) {
+        if (expiredByDeadline + expiredByEvent + expiredByInactiveEvent + completedEvents
+                + deletedNotifications + expiredPaymentCredentials + expiredApprovals
+                + deletedOAuth2Authorizations + deletedOAuth2Clients > 0) {
             log.info("Lifecycle cleanup: expired {} listings (deadline), {} listings (past events), "
+                    + "{} listings (cancelled/inactive events), "
                     + "completed {} events, deleted {} old notifications, expired {} payment credentials, "
                     + "expired {} purchase approvals, deleted {} expired OAuth2 authorizations, "
                     + "deleted {} stale OAuth2 clients",
-                    expiredByDeadline, expiredByEvent, completedEvents, deletedNotifications,
-                    expiredPaymentCredentials, expiredApprovals, deletedOAuth2Authorizations,
-                    deletedOAuth2Clients);
+                    expiredByDeadline, expiredByEvent, expiredByInactiveEvent, completedEvents,
+                    deletedNotifications, expiredPaymentCredentials, expiredApprovals,
+                    deletedOAuth2Authorizations, deletedOAuth2Clients);
         }
     }
 
@@ -86,6 +88,18 @@ public class LifecycleCleanupService {
 
     int expireListingsForPastEvents(Instant now) {
         List<Listing> listings = listingRepository.findActiveListingsForPastEvents(now);
+        expireListingsAndReleaseTickets(listings);
+        return listings.size();
+    }
+
+    /**
+     * Cancelled (or otherwise deactivated) future events keep their listings
+     * ACTIVE until this runs — e.g. the Ticketmaster sync honoring a "cancelled"
+     * status from upstream. Search already filters these out; this releases the
+     * inventory so it stops appearing anywhere.
+     */
+    int expireListingsForInactiveEvents() {
+        List<Listing> listings = listingRepository.findActiveListingsForInactiveEvents();
         expireListingsAndReleaseTickets(listings);
         return listings.size();
     }

--- a/backend/src/main/java/com/mockhub/order/service/OrderService.java
+++ b/backend/src/main/java/com/mockhub/order/service/OrderService.java
@@ -122,6 +122,17 @@ public class OrderService {
             throw new ConflictException("Cannot confirm " + order.getStatus().name().toLowerCase() + " order " + orderNumber);
         }
 
+        // Events can be cancelled between checkout and confirmation (e.g. by the
+        // Ticketmaster status sync) — never complete a sale for a dead event
+        for (OrderItem item : order.getItems()) {
+            String eventStatus = item.getListing().getEvent().getStatus();
+            if (!"ACTIVE".equals(eventStatus)) {
+                throw new ConflictException("Cannot confirm order " + orderNumber + ": event "
+                        + item.getListing().getEvent().getName()
+                        + " is no longer available (status: " + eventStatus + ")");
+            }
+        }
+
         order.transitionTo(OrderStatus.CONFIRMED);
         order.setConfirmedAt(Instant.now());
         markTicketsAsSold(order);
@@ -294,6 +305,12 @@ public class OrderService {
             if (!"ACTIVE".equals(listing.getStatus())) {
                 throw new ConflictException(
                         "Listing for " + listing.getEvent().getName() + " is no longer available");
+            }
+
+            if (!"ACTIVE".equals(listing.getEvent().getStatus())) {
+                throw new ConflictException(
+                        "Event " + listing.getEvent().getName() + " is no longer available (status: "
+                                + listing.getEvent().getStatus() + ")");
             }
 
             Ticket ticket = listing.getTicket();

--- a/backend/src/main/java/com/mockhub/ticket/repository/ListingRepository.java
+++ b/backend/src/main/java/com/mockhub/ticket/repository/ListingRepository.java
@@ -105,4 +105,11 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
             )
             """)
     List<Listing> findActiveListingsForPastEvents(@Param("now") Instant now);
+
+    @Query("""
+            SELECT l FROM Listing l
+            JOIN FETCH l.ticket t
+            WHERE l.status = 'ACTIVE' AND l.event.status <> 'ACTIVE'
+            """)
+    List<Listing> findActiveListingsForInactiveEvents();
 }

--- a/backend/src/main/java/com/mockhub/ticket/repository/ListingRepository.java
+++ b/backend/src/main/java/com/mockhub/ticket/repository/ListingRepository.java
@@ -110,6 +110,7 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
             SELECT l FROM Listing l
             JOIN FETCH l.ticket t
             WHERE l.status = 'ACTIVE' AND l.event.status <> 'ACTIVE'
+                AND t.status = 'LISTED'
             """)
     List<Listing> findActiveListingsForInactiveEvents();
 }

--- a/backend/src/main/java/com/mockhub/ticket/specification/ListingSearchSpecification.java
+++ b/backend/src/main/java/com/mockhub/ticket/specification/ListingSearchSpecification.java
@@ -31,6 +31,9 @@ public final class ListingSearchSpecification {
             predicates.add(cb.equal(root.get("status"), "ACTIVE"));
 
             Join<Object, Object> event = root.join("event");
+            // Cancelled/completed events keep their listings until lifecycle
+            // cleanup runs — never surface them to buyers or agents
+            predicates.add(cb.equal(event.get("status"), "ACTIVE"));
             Join<Object, Object> venue = event.join("venue");
             Join<Object, Object> category = event.join("category");
             Join<Object, Object> ticket = root.join("ticket");

--- a/backend/src/test/java/com/mockhub/cart/service/CartServiceTest.java
+++ b/backend/src/test/java/com/mockhub/cart/service/CartServiceTest.java
@@ -33,6 +33,7 @@ import com.mockhub.venue.entity.Section;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -79,6 +80,7 @@ class CartServiceTest {
         testEvent.setId(1L);
         testEvent.setName("Test Event");
         testEvent.setSlug("test-event");
+        testEvent.setStatus("ACTIVE");
 
         Section testSection = new Section();
         testSection.setId(1L);
@@ -161,6 +163,19 @@ class CartServiceTest {
         assertThrows(ConflictException.class,
                 () -> cartService.addToCart(testUser, 1L),
                 "Should throw ConflictException for inactive listing");
+    }
+
+    @Test
+    @DisplayName("addToCart - given cancelled event - throws ConflictException")
+    void addToCart_givenCancelledEvent_throwsConflictException() {
+        testListing.getEvent().setStatus("CANCELLED");
+        when(listingRepository.findById(1L)).thenReturn(Optional.of(testListing));
+
+        ConflictException ex = assertThrows(ConflictException.class,
+                () -> cartService.addToCart(testUser, 1L),
+                "Should throw ConflictException for cancelled event");
+        assertTrue(ex.getMessage().contains("CANCELLED"),
+                "Message should include the event status");
     }
 
     @Test

--- a/backend/src/test/java/com/mockhub/lifecycle/LifecycleCleanupServiceTest.java
+++ b/backend/src/test/java/com/mockhub/lifecycle/LifecycleCleanupServiceTest.java
@@ -70,6 +70,8 @@ class LifecycleCleanupServiceTest {
                 .thenReturn(Collections.emptyList());
         when(listingRepository.findActiveListingsForPastEvents(any(Instant.class)))
                 .thenReturn(Collections.emptyList());
+        when(listingRepository.findActiveListingsForInactiveEvents())
+                .thenReturn(Collections.emptyList());
         when(eventRepository.markPastEventsAsCompleted(any(Instant.class))).thenReturn(0);
         when(notificationRepository.deleteReadNotificationsOlderThan(any(Instant.class))).thenReturn(0);
         when(paymentCredentialRepository.expireActiveCredentials(
@@ -84,6 +86,7 @@ class LifecycleCleanupServiceTest {
 
         verify(listingRepository).findActiveListingsPastDeadline(any(Instant.class));
         verify(listingRepository).findActiveListingsForPastEvents(any(Instant.class));
+        verify(listingRepository).findActiveListingsForInactiveEvents();
         verify(eventRepository).markPastEventsAsCompleted(any(Instant.class));
         verify(notificationRepository).deleteReadNotificationsOlderThan(any(Instant.class));
         verify(paymentCredentialRepository).expireActiveCredentials(
@@ -115,6 +118,19 @@ class LifecycleCleanupServiceTest {
         when(listingRepository.findActiveListingsForPastEvents(now)).thenReturn(List.of(listing));
 
         int result = cleanupService.expireListingsForPastEvents(now);
+
+        assertEquals(1, result);
+        assertEquals("EXPIRED", listing.getStatus());
+        assertEquals("AVAILABLE", listing.getTicket().getStatus());
+    }
+
+    @Test
+    @DisplayName("expireListingsForInactiveEvents - expires listings and releases tickets")
+    void expireListingsForInactiveEvents_expiresListingsAndReleasesTickets() {
+        Listing listing = createActiveListingWithTicket();
+        when(listingRepository.findActiveListingsForInactiveEvents()).thenReturn(List.of(listing));
+
+        int result = cleanupService.expireListingsForInactiveEvents();
 
         assertEquals(1, result);
         assertEquals("EXPIRED", listing.getStatus());

--- a/backend/src/test/java/com/mockhub/order/service/OrderServiceTest.java
+++ b/backend/src/test/java/com/mockhub/order/service/OrderServiceTest.java
@@ -117,6 +117,7 @@ class OrderServiceTest {
         testEvent.setId(1L);
         testEvent.setName("Test Event");
         testEvent.setSlug("test-event");
+        testEvent.setStatus("ACTIVE");
         testEvent.setAvailableTickets(10);
         testEvent.setEventDate(java.time.Instant.parse("2026-09-15T20:00:00Z"));
         testEvent.setVenue(testVenue);
@@ -382,6 +383,22 @@ class OrderServiceTest {
     }
 
     @Test
+    @DisplayName("confirmOrder - cancelled event blocks confirmation")
+    void confirmOrder_givenCancelledEvent_throwsConflictException() {
+        testListing.getEvent().setStatus("CANCELLED");
+        when(orderRepository.findByOrderNumberForUpdate("MH-20260317-0001"))
+                .thenReturn(Optional.of(testOrder));
+
+        ConflictException ex = assertThrows(ConflictException.class,
+                () -> orderService.confirmOrder("MH-20260317-0001"),
+                "Should refuse to confirm an order for a cancelled event");
+        assertTrue(ex.getMessage().contains("CANCELLED"),
+                "Message should include the event status");
+        assertEquals(OrderStatus.PENDING, testOrder.getStatus(),
+                "Order should remain PENDING");
+    }
+
+    @Test
     @DisplayName("failOrder - duplicate failure is idempotent")
     void failOrder_givenDuplicateFailure_isIdempotent() {
         when(orderRepository.findByOrderNumberForUpdate("MH-20260317-0001"))
@@ -591,6 +608,20 @@ class OrderServiceTest {
 
         assertThrows(ResourceNotFoundException.class,
                 () -> orderService.getOrderEntityWithItems("MH-MISSING"));
+    }
+
+    @Test
+    @DisplayName("checkout - given cancelled event in cart - throws ConflictException")
+    void checkout_givenCancelledEventInCart_throwsConflictException() {
+        CheckoutRequest request = new CheckoutRequest("mock");
+        testListing.getEvent().setStatus("CANCELLED");
+        when(cartRepository.findByUser(testUser)).thenReturn(Optional.of(testCart));
+
+        ConflictException ex = assertThrows(ConflictException.class,
+                () -> orderService.checkout(testUser, request, null),
+                "Should refuse checkout when a carted event was cancelled");
+        assertTrue(ex.getMessage().contains("CANCELLED"),
+                "Message should include the event status");
     }
 
     @Test


### PR DESCRIPTION
Production had 7,853 ACTIVE listings on CANCELLED/COMPLETED events (the Ticketmaster status sync correctly cancelled 80 events on April 1, but nothing cascaded). Discovered via a live agent session — the 'stale price history' report turned out to be the pricing engine correctly ignoring a cancelled event that was still selling tickets.

**Changes (defense at every layer):**
- `ListingSearchSpecification`: event must be ACTIVE — `findTickets`/`compareTickets` stop surfacing dead inventory
- `CartService.addToCart`: rejects listings on non-ACTIVE events (website path; the MCP/chat path was already guarded by `EventInFutureCondition`'s status check)
- `OrderService.checkout`: rejects carted items whose event was cancelled after add-to-cart
- `OrderService.confirmOrder`: re-validates event status before completing the sale
- `LifecycleCleanupService`: expires listings and releases tickets for inactive events (LISTED tickets only — RESERVED tickets belong to pending orders). Production's 7,853 zombie listings heal automatically on the first cleanup cycle after deploy.

**Known gaps, deliberately deferred:** direct `getEventListings` on a specific cancelled event still shows listings until cleanup runs (purchase is blocked at four layers regardless); pending orders on cancelled events are failed at confirmation rather than proactively cancelled/refunded. Codex review noted both; integration-level purchase-path tests for these scenarios are follow-up work.

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)