### PR TITLE
Purge dead-event data on lifecycle cleanup; snapshot prices only on change

### DIFF
--- a/backend/src/main/java/com/mockhub/lifecycle/LifecycleCleanupService.java
+++ b/backend/src/main/java/com/mockhub/lifecycle/LifecycleCleanupService.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -18,8 +19,10 @@ import com.mockhub.event.repository.EventRepository;
 import com.mockhub.notification.repository.NotificationRepository;
 import com.mockhub.paymentcredential.entity.PaymentCredentialStatus;
 import com.mockhub.paymentcredential.repository.PaymentCredentialRepository;
+import com.mockhub.pricing.repository.PriceHistoryRepository;
 import com.mockhub.ticket.entity.Listing;
 import com.mockhub.ticket.repository.ListingRepository;
+import com.mockhub.ticket.repository.TicketRepository;
 
 @Service
 public class LifecycleCleanupService {
@@ -36,19 +39,29 @@ public class LifecycleCleanupService {
     private final PaymentCredentialRepository paymentCredentialRepository;
     private final AgentPurchaseApprovalRepository approvalRepository;
     private final JdbcTemplate jdbcTemplate;
+    private final PriceHistoryRepository priceHistoryRepository;
+    private final TicketRepository ticketRepository;
+    private final int priceHistoryRetentionDays;
 
     public LifecycleCleanupService(ListingRepository listingRepository,
                                    EventRepository eventRepository,
                                    NotificationRepository notificationRepository,
                                    PaymentCredentialRepository paymentCredentialRepository,
                                    AgentPurchaseApprovalRepository approvalRepository,
-                                   JdbcTemplate jdbcTemplate) {
+                                   JdbcTemplate jdbcTemplate,
+                                   PriceHistoryRepository priceHistoryRepository,
+                                   TicketRepository ticketRepository,
+                                   @Value("${mockhub.pricing.history-retention-days:90}")
+                                   int priceHistoryRetentionDays) {
         this.listingRepository = listingRepository;
         this.eventRepository = eventRepository;
         this.notificationRepository = notificationRepository;
         this.paymentCredentialRepository = paymentCredentialRepository;
         this.approvalRepository = approvalRepository;
         this.jdbcTemplate = jdbcTemplate;
+        this.priceHistoryRepository = priceHistoryRepository;
+        this.ticketRepository = ticketRepository;
+        this.priceHistoryRetentionDays = priceHistoryRetentionDays;
     }
 
     @Scheduled(fixedRateString = "${mockhub.lifecycle.cleanup-interval:900000}")
@@ -65,18 +78,24 @@ public class LifecycleCleanupService {
         int expiredApprovals = expireProposedApprovals(now);
         int deletedOAuth2Authorizations = deleteExpiredOAuth2Authorizations(now);
         int deletedOAuth2Clients = deleteStaleUnauthorizedOAuth2Clients(now);
+        int purgedPriceRows = purgeDeadPriceHistory(now);
+        int purgedListings = purgeOrphanedListingsForInactiveEvents();
+        int purgedTickets = purgeOrphanedTicketsForInactiveEvents();
 
         if (expiredByDeadline + expiredByEvent + expiredByInactiveEvent + completedEvents
                 + deletedNotifications + expiredPaymentCredentials + expiredApprovals
-                + deletedOAuth2Authorizations + deletedOAuth2Clients > 0) {
+                + deletedOAuth2Authorizations + deletedOAuth2Clients
+                + purgedPriceRows + purgedListings + purgedTickets > 0) {
             log.info("Lifecycle cleanup: expired {} listings (deadline), {} listings (past events), "
                     + "{} listings (cancelled/inactive events), "
                     + "completed {} events, deleted {} old notifications, expired {} payment credentials, "
                     + "expired {} purchase approvals, deleted {} expired OAuth2 authorizations, "
-                    + "deleted {} stale OAuth2 clients",
+                    + "deleted {} stale OAuth2 clients, purged {} price snapshots, "
+                    + "purged {} orphaned listings, purged {} orphaned tickets",
                     expiredByDeadline, expiredByEvent, expiredByInactiveEvent, completedEvents,
                     deletedNotifications, expiredPaymentCredentials, expiredApprovals,
-                    deletedOAuth2Authorizations, deletedOAuth2Clients);
+                    deletedOAuth2Authorizations, deletedOAuth2Clients,
+                    purgedPriceRows, purgedListings, purgedTickets);
         }
     }
 
@@ -102,6 +121,30 @@ public class LifecycleCleanupService {
         List<Listing> listings = listingRepository.findActiveListingsForInactiveEvents();
         expireListingsAndReleaseTickets(listings);
         return listings.size();
+    }
+
+    /**
+     * Dead events don't need price history, and live events don't need it
+     * forever (one snapshot per price change; retention window still bounds it).
+     * ponytail: single-statement bulk deletes — the first production run removes
+     * ~3M rows in one transaction; batch it if that ever times out.
+     */
+    int purgeDeadPriceHistory(Instant now) {
+        int purged = priceHistoryRepository.deleteForInactiveEvents();
+        Instant cutoff = now.minus(priceHistoryRetentionDays, ChronoUnit.DAYS);
+        return purged + priceHistoryRepository.deleteRecordedBefore(cutoff);
+    }
+
+    /**
+     * Inventory for dead events is unsellable; keep only rows that order
+     * history references. Listings go first so their tickets become orphans.
+     */
+    int purgeOrphanedListingsForInactiveEvents() {
+        return listingRepository.deleteOrphanedForInactiveEvents();
+    }
+
+    int purgeOrphanedTicketsForInactiveEvents() {
+        return ticketRepository.deleteOrphanedForInactiveEvents();
     }
 
     int markPastEventsAsCompleted(Instant now) {

--- a/backend/src/main/java/com/mockhub/pricing/repository/PriceHistoryRepository.java
+++ b/backend/src/main/java/com/mockhub/pricing/repository/PriceHistoryRepository.java
@@ -2,15 +2,32 @@ package com.mockhub.pricing.repository;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.mockhub.pricing.entity.PriceHistory;
 
 public interface PriceHistoryRepository extends JpaRepository<PriceHistory, Long> {
 
+    @Modifying
+    @Query("""
+            DELETE FROM PriceHistory ph
+            WHERE ph.event.id IN (SELECT e.id FROM Event e WHERE e.status <> 'ACTIVE')
+            """)
+    int deleteForInactiveEvents();
+
+    @Modifying
+    @Query("DELETE FROM PriceHistory ph WHERE ph.recordedAt < :cutoff")
+    int deleteRecordedBefore(@Param("cutoff") Instant cutoff);
+
     List<PriceHistory> findByEventIdOrderByRecordedAtDesc(Long eventId);
+
+    Optional<PriceHistory> findFirstByEventIdOrderByRecordedAtDesc(Long eventId);
 
     List<PriceHistory> findByEventIdOrderByRecordedAtDesc(Long eventId, Pageable pageable);
 

--- a/backend/src/main/java/com/mockhub/pricing/service/PricingUpdateService.java
+++ b/backend/src/main/java/com/mockhub/pricing/service/PricingUpdateService.java
@@ -44,7 +44,18 @@ public class PricingUpdateService {
             return;
         }
 
-        listingService.updateListingPrices(eventId, multiplier);
+        // Skip-if-unchanged: with static supply/demand the engine used to write
+        // an identical snapshot every 5 minutes (3.3M rows in production, one
+        // real price change). Same multiplier means computed listing prices are
+        // already correct, so only a listing-set change can move the price.
+        PriceHistory lastSnapshot = priceHistoryRepository
+                .findFirstByEventIdOrderByRecordedAtDesc(eventId).orElse(null);
+        boolean multiplierUnchanged = lastSnapshot != null
+                && lastSnapshot.getMultiplier().compareTo(multiplier) == 0;
+
+        if (!multiplierUnchanged) {
+            listingService.updateListingPrices(eventId, multiplier);
+        }
 
         BigDecimal[] priceRange = listingService.getComputedPriceRange(eventId);
         BigDecimal newMinPrice = priceRange[0] != null
@@ -53,6 +64,10 @@ public class PricingUpdateService {
         BigDecimal newMaxPrice = priceRange[1] != null
                 ? priceRange[1]
                 : newMinPrice;
+        if (multiplierUnchanged && lastSnapshot.getPrice().compareTo(newMinPrice) == 0) {
+            return; // nothing moved — no event write, no snapshot
+        }
+
         event.setMinPrice(newMinPrice);
         event.setMaxPrice(newMaxPrice);
         eventRepository.save(event);

--- a/backend/src/main/java/com/mockhub/pricing/service/PricingUpdateService.java
+++ b/backend/src/main/java/com/mockhub/pricing/service/PricingUpdateService.java
@@ -44,18 +44,13 @@ public class PricingUpdateService {
             return;
         }
 
-        // Skip-if-unchanged: with static supply/demand the engine used to write
-        // an identical snapshot every 5 minutes (3.3M rows in production, one
-        // real price change). Same multiplier means computed listing prices are
-        // already correct, so only a listing-set change can move the price.
+        // updateListingPrices only touches listings whose stored multiplier
+        // differs (new listings start at 1.000), so this is a cheap no-op when
+        // nothing changed.
+        listingService.updateListingPrices(eventId, multiplier);
+
         PriceHistory lastSnapshot = priceHistoryRepository
                 .findFirstByEventIdOrderByRecordedAtDesc(eventId).orElse(null);
-        boolean multiplierUnchanged = lastSnapshot != null
-                && lastSnapshot.getMultiplier().compareTo(multiplier) == 0;
-
-        if (!multiplierUnchanged) {
-            listingService.updateListingPrices(eventId, multiplier);
-        }
 
         BigDecimal[] priceRange = listingService.getComputedPriceRange(eventId);
         BigDecimal newMinPrice = priceRange[0] != null
@@ -64,7 +59,15 @@ public class PricingUpdateService {
         BigDecimal newMaxPrice = priceRange[1] != null
                 ? priceRange[1]
                 : newMinPrice;
-        if (multiplierUnchanged && lastSnapshot.getPrice().compareTo(newMinPrice) == 0) {
+        // Skip-if-unchanged: with static supply/demand the engine used to write
+        // an identical snapshot every 5 minutes (3.3M rows in production, one
+        // real price change). Snapshot only when something actually moved.
+        boolean unchanged = lastSnapshot != null
+                && lastSnapshot.getMultiplier().compareTo(multiplier) == 0
+                && lastSnapshot.getPrice().compareTo(newMinPrice) == 0
+                && event.getMaxPrice() != null
+                && event.getMaxPrice().compareTo(newMaxPrice) == 0;
+        if (unchanged) {
             return; // nothing moved — no event write, no snapshot
         }
 

--- a/backend/src/main/java/com/mockhub/ticket/repository/ListingRepository.java
+++ b/backend/src/main/java/com/mockhub/ticket/repository/ListingRepository.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -113,4 +114,13 @@ public interface ListingRepository extends JpaRepository<Listing, Long>, JpaSpec
                 AND t.status = 'LISTED'
             """)
     List<Listing> findActiveListingsForInactiveEvents();
+
+    @Modifying
+    @Query("""
+            DELETE FROM Listing l
+            WHERE l.event.id IN (SELECT e.id FROM Event e WHERE e.status <> 'ACTIVE')
+                AND NOT EXISTS (SELECT 1 FROM OrderItem oi WHERE oi.listing = l)
+                AND NOT EXISTS (SELECT 1 FROM CartItem ci WHERE ci.listing = l)
+            """)
+    int deleteOrphanedForInactiveEvents();
 }

--- a/backend/src/main/java/com/mockhub/ticket/repository/TicketRepository.java
+++ b/backend/src/main/java/com/mockhub/ticket/repository/TicketRepository.java
@@ -4,12 +4,22 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import com.mockhub.ticket.entity.Ticket;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
+
+    @Modifying
+    @Query("""
+            DELETE FROM Ticket t
+            WHERE t.event.id IN (SELECT e.id FROM Event e WHERE e.status <> 'ACTIVE')
+                AND NOT EXISTS (SELECT 1 FROM Listing l WHERE l.ticket = t)
+                AND NOT EXISTS (SELECT 1 FROM OrderItem oi WHERE oi.ticket = t)
+            """)
+    int deleteOrphanedForInactiveEvents();
 
     List<Ticket> findByEventId(Long eventId);
 

--- a/backend/src/main/java/com/mockhub/ticket/service/ListingService.java
+++ b/backend/src/main/java/com/mockhub/ticket/service/ListingService.java
@@ -147,14 +147,21 @@ public class ListingService {
     public void updateListingPrices(Long eventId, BigDecimal multiplier) {
         List<Listing> activeListings = listingRepository.findByEventIdAndStatus(eventId, STATUS_ACTIVE);
 
-        for (Listing listing : activeListings) {
+        // Only touch listings whose multiplier actually differs — new listings
+        // start at 1.000 and must be repriced even when the event multiplier
+        // hasn't moved since the last pricing run.
+        List<Listing> stale = activeListings.stream()
+                .filter(listing -> listing.getPriceMultiplier().compareTo(multiplier) != 0)
+                .toList();
+
+        for (Listing listing : stale) {
             BigDecimal computedPrice = listing.getListedPrice().multiply(multiplier);
             listing.setComputedPrice(computedPrice);
             listing.setPriceMultiplier(multiplier);
         }
 
-        listingRepository.saveAll(activeListings);
-        log.debug("Updated {} listing prices for event {}", activeListings.size(), eventId);
+        listingRepository.saveAll(stale);
+        log.debug("Updated {} listing prices for event {}", stale.size(), eventId);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/resources/db/migration/V37__add_fk_indexes_for_purge.sql
+++ b/backend/src/main/resources/db/migration/V37__add_fk_indexes_for_purge.sql
@@ -1,0 +1,7 @@
+-- FK indexes required by the dead-event purge bulk deletes. Without these,
+-- every deleted listing/ticket forces PostgreSQL to sequentially scan the
+-- referencing tables (price_history, order_items, cart_items) for FK checks.
+CREATE INDEX IF NOT EXISTS idx_price_history_listing ON price_history (listing_id);
+CREATE INDEX IF NOT EXISTS idx_order_items_listing ON order_items (listing_id);
+CREATE INDEX IF NOT EXISTS idx_order_items_ticket ON order_items (ticket_id);
+CREATE INDEX IF NOT EXISTS idx_cart_items_listing ON cart_items (listing_id);

--- a/backend/src/test/java/com/mockhub/DeadEventDataPurgeIntegrationTest.java
+++ b/backend/src/test/java/com/mockhub/DeadEventDataPurgeIntegrationTest.java
@@ -1,0 +1,228 @@
+package com.mockhub;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.mockhub.auth.entity.Role;
+import com.mockhub.auth.entity.User;
+import com.mockhub.auth.repository.RoleRepository;
+import com.mockhub.auth.repository.UserRepository;
+import com.mockhub.event.entity.Category;
+import com.mockhub.event.entity.Event;
+import com.mockhub.event.repository.CategoryRepository;
+import com.mockhub.event.repository.EventRepository;
+import com.mockhub.order.entity.Order;
+import com.mockhub.order.entity.OrderItem;
+import com.mockhub.order.entity.OrderStatus;
+import com.mockhub.order.repository.OrderRepository;
+import com.mockhub.pricing.entity.PriceHistory;
+import com.mockhub.pricing.repository.PriceHistoryRepository;
+import com.mockhub.ticket.entity.Listing;
+import com.mockhub.ticket.entity.Ticket;
+import com.mockhub.ticket.repository.ListingRepository;
+import com.mockhub.ticket.repository.TicketRepository;
+import com.mockhub.venue.entity.Section;
+import com.mockhub.venue.entity.Venue;
+import com.mockhub.venue.repository.VenueRepository;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Verifies the dead-event purge bulk deletes against real PostgreSQL:
+ * unreferenced inventory and price history for non-ACTIVE events is removed,
+ * while anything referenced by order history survives.
+ */
+@Transactional
+class DeadEventDataPurgeIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired private EventRepository eventRepository;
+    @Autowired private VenueRepository venueRepository;
+    @Autowired private CategoryRepository categoryRepository;
+    @Autowired private TicketRepository ticketRepository;
+    @Autowired private ListingRepository listingRepository;
+    @Autowired private PriceHistoryRepository priceHistoryRepository;
+    @Autowired private OrderRepository orderRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private RoleRepository roleRepository;
+    @Autowired private PasswordEncoder passwordEncoder;
+
+    private Event deadEvent;
+    private Event liveEvent;
+    private Ticket orphanTicket;
+    private Listing orphanListing;
+    private Ticket orderedTicket;
+    private Listing orderedListing;
+    private PriceHistory deadEventSnapshot;
+    private PriceHistory freshLiveSnapshot;
+    private PriceHistory staleLiveSnapshot;
+
+    @BeforeEach
+    void setUp() {
+        long stamp = System.nanoTime();
+
+        Venue venue = new Venue();
+        venue.setName("Purge Venue " + stamp);
+        venue.setSlug("purge-venue-" + stamp);
+        venue.setCity("Hartford");
+        venue.setState("CT");
+        venue.setAddressLine1("1 Purge Way");
+        venue.setZipCode("06103");
+        venue.setCountry("US");
+        venue.setCapacity(100);
+        venue.setVenueType("ARENA");
+
+        Section section = new Section();
+        section.setVenue(venue);
+        section.setName("GA");
+        section.setSectionType("GENERAL_ADMISSION");
+        section.setCapacity(100);
+        section.setSortOrder(1);
+        venue.getSections().add(section);
+        venue = venueRepository.save(venue);
+        section = venue.getSections().getFirst();
+
+        Category category = categoryRepository.findAll().stream().findFirst()
+                .orElseGet(() -> {
+                    Category cat = new Category();
+                    cat.setName("Concerts");
+                    cat.setSlug("concerts");
+                    return categoryRepository.save(cat);
+                });
+
+        deadEvent = createEvent("purge-dead-" + stamp, "CANCELLED", venue, category);
+        liveEvent = createEvent("purge-live-" + stamp, "ACTIVE", venue, category);
+
+        orphanTicket = createTicket(deadEvent, section, "PURGE-ORPHAN-" + stamp);
+        orphanListing = createListing(deadEvent, orphanTicket, "EXPIRED");
+
+        orderedTicket = createTicket(deadEvent, section, "PURGE-ORDERED-" + stamp);
+        orderedListing = createListing(deadEvent, orderedTicket, "SOLD");
+        createConfirmedOrder(orderedTicket, orderedListing, stamp);
+
+        deadEventSnapshot = createSnapshot(deadEvent, Instant.now().minus(1, ChronoUnit.DAYS));
+        freshLiveSnapshot = createSnapshot(liveEvent, Instant.now().minus(1, ChronoUnit.DAYS));
+        staleLiveSnapshot = createSnapshot(liveEvent, Instant.now().minus(400, ChronoUnit.DAYS));
+    }
+
+    @Test
+    @DisplayName("purge deletes unreferenced dead-event listings and tickets, keeps order-referenced rows")
+    void purge_deletesOrphans_keepsOrderReferencedRows() {
+        listingRepository.deleteOrphanedForInactiveEvents();
+        ticketRepository.deleteOrphanedForInactiveEvents();
+        listingRepository.flush();
+
+        assertFalse(listingRepository.existsById(orphanListing.getId()),
+                "Unreferenced dead-event listing should be purged");
+        assertFalse(ticketRepository.existsById(orphanTicket.getId()),
+                "Unreferenced dead-event ticket should be purged");
+        assertTrue(listingRepository.existsById(orderedListing.getId()),
+                "Order-referenced listing must survive");
+        assertTrue(ticketRepository.existsById(orderedTicket.getId()),
+                "Order-referenced ticket must survive");
+    }
+
+    @Test
+    @DisplayName("price history purge removes dead-event and stale rows, keeps fresh live rows")
+    void priceHistoryPurge_removesDeadAndStale_keepsFreshLive() {
+        priceHistoryRepository.deleteForInactiveEvents();
+        priceHistoryRepository.deleteRecordedBefore(Instant.now().minus(90, ChronoUnit.DAYS));
+        priceHistoryRepository.flush();
+
+        assertFalse(priceHistoryRepository.existsById(deadEventSnapshot.getId()),
+                "Dead-event snapshot should be purged");
+        assertFalse(priceHistoryRepository.existsById(staleLiveSnapshot.getId()),
+                "Snapshot older than retention should be purged");
+        assertTrue(priceHistoryRepository.existsById(freshLiveSnapshot.getId()),
+                "Fresh live-event snapshot must survive");
+    }
+
+    private Event createEvent(String slug, String status, Venue venue, Category category) {
+        Event event = new Event();
+        event.setName(slug);
+        event.setSlug(slug);
+        event.setDescription("Purge test event");
+        event.setVenue(venue);
+        event.setCategory(category);
+        event.setEventDate(Instant.now().plus(30, ChronoUnit.DAYS));
+        event.setStatus(status);
+        event.setBasePrice(new BigDecimal("50.00"));
+        event.setMinPrice(new BigDecimal("40.00"));
+        event.setMaxPrice(new BigDecimal("100.00"));
+        event.setTotalTickets(100);
+        event.setAvailableTickets(100);
+        return eventRepository.save(event);
+    }
+
+    private Ticket createTicket(Event event, Section section, String barcode) {
+        Ticket ticket = new Ticket();
+        ticket.setEvent(event);
+        ticket.setSection(section);
+        ticket.setTicketType("GENERAL_ADMISSION");
+        ticket.setFaceValue(new BigDecimal("50.00"));
+        ticket.setStatus("AVAILABLE");
+        ticket.setBarcode(barcode);
+        return ticketRepository.save(ticket);
+    }
+
+    private Listing createListing(Event event, Ticket ticket, String status) {
+        Listing listing = new Listing();
+        listing.setTicket(ticket);
+        listing.setEvent(event);
+        listing.setListedPrice(new BigDecimal("75.00"));
+        listing.setComputedPrice(new BigDecimal("75.00"));
+        listing.setPriceMultiplier(BigDecimal.ONE);
+        listing.setStatus(status);
+        listing.setListedAt(Instant.now());
+        return listingRepository.save(listing);
+    }
+
+    private void createConfirmedOrder(Ticket ticket, Listing listing, long stamp) {
+        Role role = roleRepository.findByName("ROLE_BUYER")
+                .orElseGet(() -> roleRepository.save(new Role("ROLE_BUYER")));
+        User user = new User();
+        user.setEmail("purge-" + stamp + "@test.com");
+        user.setFirstName("Purge");
+        user.setLastName("Tester");
+        user.setPasswordHash(passwordEncoder.encode("test-password"));
+        user.setRoles(java.util.Set.of(role));
+        user = userRepository.save(user);
+
+        Order order = new Order();
+        order.setUser(user);
+        order.setOrderNumber("MH-PURGE-" + (stamp % 100000000L));
+        order.setStatus(OrderStatus.CONFIRMED);
+        order.setSubtotal(new BigDecimal("75.00"));
+        order.setServiceFee(new BigDecimal("7.50"));
+        order.setTotal(new BigDecimal("82.50"));
+        order.setPaymentMethod("mock");
+        order.setConfirmedAt(Instant.now());
+
+        OrderItem item = new OrderItem();
+        item.setOrder(order);
+        item.setListing(listing);
+        item.setTicket(ticket);
+        item.setPricePaid(new BigDecimal("75.00"));
+        order.getItems().add(item);
+        orderRepository.save(order);
+    }
+
+    private PriceHistory createSnapshot(Event event, Instant recordedAt) {
+        PriceHistory snapshot = new PriceHistory();
+        snapshot.setEvent(event);
+        snapshot.setPrice(new BigDecimal("42.00"));
+        snapshot.setMultiplier(new BigDecimal("1.000"));
+        snapshot.setSupplyRatio(new BigDecimal("1.0000"));
+        snapshot.setDaysToEvent(30);
+        snapshot.setRecordedAt(recordedAt);
+        return priceHistoryRepository.save(snapshot);
+    }
+}

--- a/backend/src/test/java/com/mockhub/DeadEventDataPurgeIntegrationTest.java
+++ b/backend/src/test/java/com/mockhub/DeadEventDataPurgeIntegrationTest.java
@@ -15,6 +15,9 @@ import com.mockhub.auth.entity.Role;
 import com.mockhub.auth.entity.User;
 import com.mockhub.auth.repository.RoleRepository;
 import com.mockhub.auth.repository.UserRepository;
+import com.mockhub.cart.entity.Cart;
+import com.mockhub.cart.entity.CartItem;
+import com.mockhub.cart.repository.CartRepository;
 import com.mockhub.event.entity.Category;
 import com.mockhub.event.entity.Event;
 import com.mockhub.event.repository.CategoryRepository;
@@ -51,6 +54,7 @@ class DeadEventDataPurgeIntegrationTest extends AbstractIntegrationTest {
     @Autowired private ListingRepository listingRepository;
     @Autowired private PriceHistoryRepository priceHistoryRepository;
     @Autowired private OrderRepository orderRepository;
+    @Autowired private CartRepository cartRepository;
     @Autowired private UserRepository userRepository;
     @Autowired private RoleRepository roleRepository;
     @Autowired private PasswordEncoder passwordEncoder;
@@ -61,6 +65,7 @@ class DeadEventDataPurgeIntegrationTest extends AbstractIntegrationTest {
     private Listing orphanListing;
     private Ticket orderedTicket;
     private Listing orderedListing;
+    private Listing cartedListing;
     private PriceHistory deadEventSnapshot;
     private PriceHistory freshLiveSnapshot;
     private PriceHistory staleLiveSnapshot;
@@ -106,7 +111,11 @@ class DeadEventDataPurgeIntegrationTest extends AbstractIntegrationTest {
 
         orderedTicket = createTicket(deadEvent, section, "PURGE-ORDERED-" + stamp);
         orderedListing = createListing(deadEvent, orderedTicket, "SOLD");
-        createConfirmedOrder(orderedTicket, orderedListing, stamp);
+        User buyer = createConfirmedOrder(orderedTicket, orderedListing, stamp);
+
+        Ticket cartedTicket = createTicket(deadEvent, section, "PURGE-CARTED-" + stamp);
+        cartedListing = createListing(deadEvent, cartedTicket, "ACTIVE");
+        createCartWithItem(buyer, cartedListing);
 
         deadEventSnapshot = createSnapshot(deadEvent, Instant.now().minus(1, ChronoUnit.DAYS));
         freshLiveSnapshot = createSnapshot(liveEvent, Instant.now().minus(1, ChronoUnit.DAYS));
@@ -128,6 +137,8 @@ class DeadEventDataPurgeIntegrationTest extends AbstractIntegrationTest {
                 "Order-referenced listing must survive");
         assertTrue(ticketRepository.existsById(orderedTicket.getId()),
                 "Order-referenced ticket must survive");
+        assertTrue(listingRepository.existsById(cartedListing.getId()),
+                "Cart-referenced listing must survive");
     }
 
     @Test
@@ -185,7 +196,7 @@ class DeadEventDataPurgeIntegrationTest extends AbstractIntegrationTest {
         return listingRepository.save(listing);
     }
 
-    private void createConfirmedOrder(Ticket ticket, Listing listing, long stamp) {
+    private User createConfirmedOrder(Ticket ticket, Listing listing, long stamp) {
         Role role = roleRepository.findByName("ROLE_BUYER")
                 .orElseGet(() -> roleRepository.save(new Role("ROLE_BUYER")));
         User user = new User();
@@ -213,6 +224,20 @@ class DeadEventDataPurgeIntegrationTest extends AbstractIntegrationTest {
         item.setPricePaid(new BigDecimal("75.00"));
         order.getItems().add(item);
         orderRepository.save(order);
+        return user;
+    }
+
+    private void createCartWithItem(User user, Listing listing) {
+        Cart cart = new Cart();
+        cart.setUser(user);
+        cart.setExpiresAt(Instant.now().plus(15, ChronoUnit.MINUTES));
+        CartItem item = new CartItem();
+        item.setCart(cart);
+        item.setListing(listing);
+        item.setPriceAtAdd(listing.getComputedPrice());
+        item.setAddedAt(Instant.now());
+        cart.getItems().add(item);
+        cartRepository.save(cart);
     }
 
     private PriceHistory createSnapshot(Event event, Instant recordedAt) {

--- a/backend/src/test/java/com/mockhub/lifecycle/LifecycleCleanupServiceTest.java
+++ b/backend/src/test/java/com/mockhub/lifecycle/LifecycleCleanupServiceTest.java
@@ -20,9 +20,11 @@ import com.mockhub.event.repository.EventRepository;
 import com.mockhub.notification.repository.NotificationRepository;
 import com.mockhub.paymentcredential.entity.PaymentCredentialStatus;
 import com.mockhub.paymentcredential.repository.PaymentCredentialRepository;
+import com.mockhub.pricing.repository.PriceHistoryRepository;
 import com.mockhub.ticket.entity.Listing;
 import com.mockhub.ticket.entity.Ticket;
 import com.mockhub.ticket.repository.ListingRepository;
+import com.mockhub.ticket.repository.TicketRepository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -54,13 +56,20 @@ class LifecycleCleanupServiceTest {
     @Mock
     private JdbcTemplate jdbcTemplate;
 
+    @Mock
+    private PriceHistoryRepository priceHistoryRepository;
+
+    @Mock
+    private TicketRepository ticketRepository;
+
     private LifecycleCleanupService cleanupService;
 
     @BeforeEach
     void setUp() {
         cleanupService = new LifecycleCleanupService(
                 listingRepository, eventRepository, notificationRepository,
-                paymentCredentialRepository, approvalRepository, jdbcTemplate);
+                paymentCredentialRepository, approvalRepository, jdbcTemplate,
+                priceHistoryRepository, ticketRepository, 90);
     }
 
     @Test
@@ -87,6 +96,10 @@ class LifecycleCleanupServiceTest {
         verify(listingRepository).findActiveListingsPastDeadline(any(Instant.class));
         verify(listingRepository).findActiveListingsForPastEvents(any(Instant.class));
         verify(listingRepository).findActiveListingsForInactiveEvents();
+        verify(priceHistoryRepository).deleteForInactiveEvents();
+        verify(priceHistoryRepository).deleteRecordedBefore(any(Instant.class));
+        verify(listingRepository).deleteOrphanedForInactiveEvents();
+        verify(ticketRepository).deleteOrphanedForInactiveEvents();
         verify(eventRepository).markPastEventsAsCompleted(any(Instant.class));
         verify(notificationRepository).deleteReadNotificationsOlderThan(any(Instant.class));
         verify(paymentCredentialRepository).expireActiveCredentials(
@@ -122,6 +135,29 @@ class LifecycleCleanupServiceTest {
         assertEquals(1, result);
         assertEquals("EXPIRED", listing.getStatus());
         assertEquals("AVAILABLE", listing.getTicket().getStatus());
+    }
+
+    @Test
+    @DisplayName("purgeDeadPriceHistory - sums dead-event and retention deletions with correct cutoff")
+    void purgeDeadPriceHistory_sumsDeletionsWithRetentionCutoff() {
+        Instant now = Instant.now();
+        when(priceHistoryRepository.deleteForInactiveEvents()).thenReturn(3_000_000);
+        when(priceHistoryRepository.deleteRecordedBefore(now.minus(90, ChronoUnit.DAYS)))
+                .thenReturn(1_000);
+
+        int result = cleanupService.purgeDeadPriceHistory(now);
+
+        assertEquals(3_001_000, result);
+    }
+
+    @Test
+    @DisplayName("purge operations - delegate to repository bulk deletes")
+    void purgeOperations_delegateToRepositoryBulkDeletes() {
+        when(listingRepository.deleteOrphanedForInactiveEvents()).thenReturn(59_053);
+        when(ticketRepository.deleteOrphanedForInactiveEvents()).thenReturn(169_214);
+
+        assertEquals(59_053, cleanupService.purgeOrphanedListingsForInactiveEvents());
+        assertEquals(169_214, cleanupService.purgeOrphanedTicketsForInactiveEvents());
     }
 
     @Test

--- a/backend/src/test/java/com/mockhub/pricing/service/PricingUpdateServiceTest.java
+++ b/backend/src/test/java/com/mockhub/pricing/service/PricingUpdateServiceTest.java
@@ -182,6 +182,7 @@ class PricingUpdateServiceTest {
         PriceHistory last = new PriceHistory();
         last.setMultiplier(new BigDecimal("1.250"));
         last.setPrice(new BigDecimal("125.00"));
+        testEvent.setMaxPrice(new BigDecimal("125.00"));
         when(eventRepository.findById(1L)).thenReturn(Optional.of(testEvent));
         when(priceHistoryRepository.findFirstByEventIdOrderByRecordedAtDesc(1L))
                 .thenReturn(Optional.of(last));
@@ -190,13 +191,13 @@ class PricingUpdateServiceTest {
 
         pricingUpdateService.updateEventPricing(1L, multiplier);
 
-        verify(listingService, never()).updateListingPrices(any(), any());
+        verify(listingService).updateListingPrices(1L, multiplier);
         verify(eventRepository, never()).save(any(Event.class));
         verify(priceHistoryRepository, never()).save(any(PriceHistory.class));
     }
 
     @Test
-    @DisplayName("updateEventPricing - given same multiplier but moved price - writes snapshot without relisting")
+    @DisplayName("updateEventPricing - given same multiplier but moved price - writes snapshot")
     void updateEventPricing_givenSameMultiplierMovedPrice_writesSnapshotOnly() {
         BigDecimal multiplier = new BigDecimal("1.250");
         PriceHistory last = new PriceHistory();
@@ -210,11 +211,31 @@ class PricingUpdateServiceTest {
 
         pricingUpdateService.updateEventPricing(1L, multiplier);
 
-        verify(listingService, never()).updateListingPrices(any(), any());
         verify(eventRepository).save(testEvent);
         verify(priceHistoryRepository).save(any(PriceHistory.class));
         assertEquals(new BigDecimal("99.00"), testEvent.getMinPrice(),
                 "Min price should reflect the moved listing floor");
+    }
+
+    @Test
+    @DisplayName("updateEventPricing - given max-only price change - writes snapshot")
+    void updateEventPricing_givenMaxOnlyPriceChange_writesSnapshot() {
+        BigDecimal multiplier = new BigDecimal("1.250");
+        PriceHistory last = new PriceHistory();
+        last.setMultiplier(new BigDecimal("1.250"));
+        last.setPrice(new BigDecimal("125.00"));
+        testEvent.setMaxPrice(new BigDecimal("125.00"));
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(testEvent));
+        when(priceHistoryRepository.findFirstByEventIdOrderByRecordedAtDesc(1L))
+                .thenReturn(Optional.of(last));
+        when(listingService.getComputedPriceRange(1L))
+                .thenReturn(new BigDecimal[]{new BigDecimal("125.00"), new BigDecimal("300.00")});
+
+        pricingUpdateService.updateEventPricing(1L, multiplier);
+
+        verify(eventRepository).save(testEvent);
+        assertEquals(new BigDecimal("300.00"), testEvent.getMaxPrice(),
+                "Max price should update when only the ceiling moved");
     }
 
     @Test

--- a/backend/src/test/java/com/mockhub/pricing/service/PricingUpdateServiceTest.java
+++ b/backend/src/test/java/com/mockhub/pricing/service/PricingUpdateServiceTest.java
@@ -176,6 +176,48 @@ class PricingUpdateServiceTest {
     }
 
     @Test
+    @DisplayName("updateEventPricing - given unchanged multiplier and price - writes nothing")
+    void updateEventPricing_givenUnchangedMultiplierAndPrice_writesNothing() {
+        BigDecimal multiplier = new BigDecimal("1.250");
+        PriceHistory last = new PriceHistory();
+        last.setMultiplier(new BigDecimal("1.250"));
+        last.setPrice(new BigDecimal("125.00"));
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(testEvent));
+        when(priceHistoryRepository.findFirstByEventIdOrderByRecordedAtDesc(1L))
+                .thenReturn(Optional.of(last));
+        when(listingService.getComputedPriceRange(1L))
+                .thenReturn(new BigDecimal[]{new BigDecimal("125.00"), new BigDecimal("125.00")});
+
+        pricingUpdateService.updateEventPricing(1L, multiplier);
+
+        verify(listingService, never()).updateListingPrices(any(), any());
+        verify(eventRepository, never()).save(any(Event.class));
+        verify(priceHistoryRepository, never()).save(any(PriceHistory.class));
+    }
+
+    @Test
+    @DisplayName("updateEventPricing - given same multiplier but moved price - writes snapshot without relisting")
+    void updateEventPricing_givenSameMultiplierMovedPrice_writesSnapshotOnly() {
+        BigDecimal multiplier = new BigDecimal("1.250");
+        PriceHistory last = new PriceHistory();
+        last.setMultiplier(new BigDecimal("1.250"));
+        last.setPrice(new BigDecimal("125.00"));
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(testEvent));
+        when(priceHistoryRepository.findFirstByEventIdOrderByRecordedAtDesc(1L))
+                .thenReturn(Optional.of(last));
+        when(listingService.getComputedPriceRange(1L))
+                .thenReturn(new BigDecimal[]{new BigDecimal("99.00"), new BigDecimal("140.00")});
+
+        pricingUpdateService.updateEventPricing(1L, multiplier);
+
+        verify(listingService, never()).updateListingPrices(any(), any());
+        verify(eventRepository).save(testEvent);
+        verify(priceHistoryRepository).save(any(PriceHistory.class));
+        assertEquals(new BigDecimal("99.00"), testEvent.getMinPrice(),
+                "Min price should reflect the moved listing floor");
+    }
+
+    @Test
     @DisplayName("updateEventPricing - given event with COMPLETED status - does nothing")
     void updateEventPricing_givenCompletedEvent_doesNothing() {
         testEvent.setStatus("COMPLETED");

--- a/backend/src/test/java/com/mockhub/ticket/service/ListingServiceTest.java
+++ b/backend/src/test/java/com/mockhub/ticket/service/ListingServiceTest.java
@@ -208,6 +208,22 @@ class ListingServiceTest {
     }
 
     @Test
+    @DisplayName("updateListingPrices - reprices only listings whose multiplier differs")
+    void updateListingPrices_repricesOnlyStaleListings() {
+        BigDecimal multiplier = new BigDecimal("1.5");
+        testListing.setPriceMultiplier(new BigDecimal("1.500"));
+        testListing.setComputedPrice(new BigDecimal("112.50"));
+        when(listingRepository.findByEventIdAndStatus(1L, "ACTIVE"))
+                .thenReturn(List.of(testListing));
+
+        listingService.updateListingPrices(1L, multiplier);
+
+        verify(listingRepository).saveAll(List.of());
+        assertEquals(new BigDecimal("112.50"), testListing.getComputedPrice(),
+                "Already-current listing should not be touched");
+    }
+
+    @Test
     @DisplayName("getActiveListingsByEventId - given active listings - returns listing DTOs")
     void getActiveListingsByEventId_givenActiveListings_returnsListingDtos() {
         when(listingRepository.findByEventIdAndStatus(1L, "ACTIVE"))


### PR DESCRIPTION
Production was ~3.6M rows with ~3.4M belonging to dead events; the pricing engine wrote an identical snapshot per active event every 5 minutes forever (3.3M rows containing one real price change).

**Changes:**
- `LifecycleCleanupService`: recurring bulk purges — price history for non-ACTIVE events + 90-day retention window (`mockhub.pricing.history-retention-days`); dead-event listings/tickets not referenced by orders or carts (order history always survives)
- `PricingUpdateService`: snapshots only when the multiplier or price range actually moved — idle site now writes zero rows
- `ListingService.updateListingPrices`: reprices only listings whose stored multiplier differs, and runs unconditionally, fixing a Codex-caught bug where new listings (created at multiplier 1.000) were never adjusted while the event multiplier stayed constant
- `V37`: FK indexes on `price_history.listing_id`, `order_items.listing_id`/`ticket_id`, `cart_items.listing_id` — without them each purged row forced sequential FK-check scans

**Production note:** the one-time heavy purge was run manually with the indexes in place before this deploys (3.17M price rows, 169K tickets, 59K listings deleted in ~35s; DB now ~250K rows), so the scheduled job only handles steady-state increments. Bulk SQL verified against real PostgreSQL in `DeadEventDataPurgeIntegrationTest`, including order- and cart-referenced survival guards.

Closes #282

🤖 Generated with [Claude Code](https://claude.com/claude-code)