### PR TITLE
Fix e2e: mock the pending-approvals poll in fake-auth sessions

### DIFF
--- a/frontend/e2e/cart-checkout.spec.ts
+++ b/frontend/e2e/cart-checkout.spec.ts
@@ -75,6 +75,15 @@ async function authenticateUser(page: Page) {
     });
   });
 
+  // Pending-approval badge polls this on every authenticated page
+  await page.route(/\/api\/v1\/agent-approvals/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
+  });
+
   await page.route(/\/api\/v1\/favorites/, async (route) => {
     await route.fulfill({
       status: 200,

--- a/frontend/e2e/seller.spec.ts
+++ b/frontend/e2e/seller.spec.ts
@@ -113,6 +113,15 @@ async function authenticateUser(page: Page) {
     });
   });
 
+  // Pending-approval badge polls this on every authenticated page
+  await page.route(/\/api\/v1\/agent-approvals/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify([]),
+    });
+  });
+
   await page.route(/\/api\/v1\/cart$/, async (route) => {
     await route.fulfill({
       status: 200,


### PR DESCRIPTION
Post-merge main CI failed on both e2e shards after #286: the new pending-approval badge polls `/api/v1/agent-approvals` on every authenticated page, and the unmocked call in Playwright fake-auth sessions returned 401 → token-refresh cascade → redirect to /login → every authenticated spec failed. Adds the same route mock the helpers already use for notifications/cart/favorites, in both files that authenticate (seller, cart-checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)