### PR TITLE
Fix Venue EntityGraph so Ticketmaster sync works on Hibernate 7 (fixes #294)

### DIFF
--- a/backend/src/main/java/com/mockhub/venue/repository/VenueRepository.java
+++ b/backend/src/main/java/com/mockhub/venue/repository/VenueRepository.java
@@ -13,10 +13,14 @@ public interface VenueRepository extends JpaRepository<Venue, Long> {
 
     Optional<Venue> findBySlug(String slug);
 
-    @EntityGraph(attributePaths = {"sections", "sections.seatRows", "sections.seatRows.seats"})
+    // Hibernate 7 (Spring Boot 4.1) cannot plan multi-level nested bag fetches
+    // (sections.seatRows.seats) on derived queries — it throws "Could not
+    // generate fetch" and broke the nightly Ticketmaster sync (#294). Fetch one
+    // level; seatRows/seats lazy-load inside the sync's @Transactional boundary.
+    @EntityGraph(attributePaths = {"sections"})
     Optional<Venue> findByTicketmasterVenueId(String ticketmasterVenueId);
 
-    @EntityGraph(attributePaths = {"sections", "sections.seatRows", "sections.seatRows.seats"})
+    @EntityGraph(attributePaths = {"sections"})
     Optional<Venue> findByNameAndCity(String name, String city);
 
     Page<Venue> findByCity(String city, Pageable pageable);

--- a/backend/src/test/java/com/mockhub/venue/repository/VenueRepositoryIntegrationTest.java
+++ b/backend/src/test/java/com/mockhub/venue/repository/VenueRepositoryIntegrationTest.java
@@ -1,0 +1,43 @@
+package com.mockhub.venue.repository;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.mockhub.AbstractIntegrationTest;
+import com.mockhub.venue.entity.Venue;
+
+/**
+ * Executes the venue lookup queries against real PostgreSQL/Hibernate.
+ *
+ * The nightly Ticketmaster sync broke silently after the Spring Boot 4.1
+ * upgrade (#294): Hibernate 7 rejects the multi-level nested bag fetch the
+ * old @EntityGraph declared ("Could not generate fetch : Venue(v) ->
+ * sections"), and the mocked sync tests never execute real query
+ * generation. These tests fail on any EntityGraph Hibernate can't plan.
+ */
+@DisplayName("VenueRepository")
+class VenueRepositoryIntegrationTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private VenueRepository venueRepository;
+
+    @Test
+    @DisplayName("findByTicketmasterVenueId - executes real query without fetch error")
+    void findByTicketmasterVenueId_executesRealQuery() {
+        Optional<Venue> result = venueRepository.findByTicketmasterVenueId("tm-venue-does-not-exist");
+
+        Assertions.assertTrue(result.isEmpty());
+    }
+
+    @Test
+    @DisplayName("findByNameAndCity - executes real query without fetch error")
+    void findByNameAndCity_executesRealQuery() {
+        Optional<Venue> result = venueRepository.findByNameAndCity("No Such Venue", "Nowhere");
+
+        Assertions.assertTrue(result.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- Nightly Ticketmaster sync has silently processed **zero events since the Spring Boot 4.1.0 upgrade** — every run logs `0 new, 0 updated, 150 skipped`, with each event failing on `Could not generate fetch : Venue(v) -> sections`
- Hibernate 7 cannot plan the multi-level nested bag fetch (`sections`, `sections.seatRows`, `sections.seatRows.seats`) on `VenueRepository`'s derived queries
- Fix: single-level `@EntityGraph({"sections"})`; deeper levels lazy-load inside the sync's `@Transactional` boundary
- New `VenueRepositoryIntegrationTest` (Testcontainers) executes the real queries — reproduces the exact production error before the fix, green after. The mocked sync tests never ran Hibernate query generation, which is why this was invisible.

## Testing
- RED: both repository tests fail with the exact production error (`Could not generate fetch`)
- GREEN with the fix; full backend suite passes
- Codex review skipped: its secrets-scanner keychain issue persists (see #293) and this is a time-critical two-annotation change with a real-database regression test

## Post-merge
Trigger `POST /api/v1/admin/ticketmaster/sync` (admin) to repopulate events before tonight's 4 AM cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)