### PR TITLE
Bound and diversify homepage featured events; evict caches on sync (fixes #296)

### DIFF
--- a/backend/src/main/java/com/mockhub/event/service/EventService.java
+++ b/backend/src/main/java/com/mockhub/event/service/EventService.java
@@ -3,6 +3,7 @@ package com.mockhub.event.service;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
@@ -44,6 +45,7 @@ import com.mockhub.venue.repository.VenueRepository;
 public class EventService {
 
     private static final String SORT_EVENT_DATE = "eventDate";
+    private static final int MAX_FEATURED_EVENTS = 8;
 
     private final EventRepository eventRepository;
     private final CategoryRepository categoryRepository;
@@ -101,8 +103,15 @@ public class EventService {
     @Transactional(readOnly = true)
     @Cacheable(value = "featuredEvents")
     public List<EventSummaryDto> listFeatured() {
-        List<Event> featured = eventRepository.findFeaturedEvents();
-        return featured.stream()
+        // The Ticketmaster sync marks every synced event featured, and the
+        // query is date-ordered — unbounded, the homepage would show ~100
+        // cards dominated by whichever tour has the most dates. Keep the
+        // earliest event per artist, capped to a homepage-sized grid.
+        Set<String> seenArtists = new HashSet<>();
+        return eventRepository.findFeaturedEvents().stream()
+                .filter(event -> seenArtists.add(
+                        event.getArtistName() != null ? event.getArtistName() : event.getName()))
+                .limit(MAX_FEATURED_EVENTS)
                 .map(this::toEventSummaryDto)
                 .toList();
     }

--- a/backend/src/main/java/com/mockhub/ticketmaster/service/TicketmasterSyncService.java
+++ b/backend/src/main/java/com/mockhub/ticketmaster/service/TicketmasterSyncService.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -61,6 +62,9 @@ public class TicketmasterSyncService {
     }
 
     @Scheduled(cron = "${mockhub.ticketmaster.sync-cron:0 0 4 * * *}")
+    // The events/featuredEvents caches have no TTL — without this eviction the
+    // homepage serves pre-sync data until the next restart (#296).
+    @CacheEvict(value = {"events", "featuredEvents"}, allEntries = true)
     public void syncEvents() {
         log.info("Starting Ticketmaster event sync");
 

--- a/backend/src/test/java/com/mockhub/event/service/EventServiceTest.java
+++ b/backend/src/test/java/com/mockhub/event/service/EventServiceTest.java
@@ -175,6 +175,52 @@ class EventServiceTest {
     }
 
     @Test
+    @DisplayName("listFeatured - given many events by same artist - returns one per artist")
+    void listFeatured_givenManyEventsBySameArtist_returnsOnePerArtist() {
+        Event jam1 = cloneTestEvent(2L, "Monster Jam", "monster-jam-1");
+        Event jam2 = cloneTestEvent(3L, "Monster Jam", "monster-jam-2");
+        Event other = cloneTestEvent(4L, "Lady A", "lady-a-1");
+        when(eventRepository.findFeaturedEvents()).thenReturn(List.of(jam1, jam2, other));
+
+        List<EventSummaryDto> result = eventService.listFeatured();
+
+        assertEquals(2, result.size(), "Should keep only the first event per artist");
+        assertEquals("monster-jam-1", result.get(0).slug(), "First event per artist wins (earliest date)");
+    }
+
+    @Test
+    @DisplayName("listFeatured - given more than eight artists - caps at eight")
+    void listFeatured_givenMoreThanEightArtists_capsAtEight() {
+        List<Event> many = new java.util.ArrayList<>();
+        for (int i = 0; i < 12; i++) {
+            many.add(cloneTestEvent(10L + i, "Artist " + i, "artist-" + i));
+        }
+        when(eventRepository.findFeaturedEvents()).thenReturn(many);
+
+        List<EventSummaryDto> result = eventService.listFeatured();
+
+        assertEquals(8, result.size(), "Featured list should cap at 8 for the homepage grid");
+    }
+
+    private Event cloneTestEvent(Long id, String artistName, String slug) {
+        Event event = new Event();
+        event.setId(id);
+        event.setName(artistName + " Live");
+        event.setSlug(slug);
+        event.setArtistName(artistName);
+        event.setEventDate(testEvent.getEventDate());
+        event.setStatus("ACTIVE");
+        event.setBasePrice(testEvent.getBasePrice());
+        event.setMinPrice(testEvent.getMinPrice());
+        event.setMaxPrice(testEvent.getMaxPrice());
+        event.setAvailableTickets(100);
+        event.setFeatured(true);
+        event.setVenue(testVenue);
+        event.setCategory(testCategory);
+        return event;
+    }
+
+    @Test
     @DisplayName("createEvent - given valid request - returns created event DTO")
     void createEvent_givenValidRequest_returnsCreatedEventDto() {
         EventCreateRequest request = new EventCreateRequest(

--- a/backend/src/test/java/com/mockhub/ticketmaster/service/TicketmasterSyncServiceTest.java
+++ b/backend/src/test/java/com/mockhub/ticketmaster/service/TicketmasterSyncServiceTest.java
@@ -4,7 +4,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -507,5 +509,21 @@ class TicketmasterSyncServiceTest {
         venue.setZipCode("89169");
         venue.setCountry("US");
         return venue;
+    }
+
+    @Test
+    @DisplayName("syncEvents - evicts event caches so the homepage sees fresh data")
+    void syncEvents_declaresCacheEviction() throws NoSuchMethodException {
+        // The featuredEvents cache has no TTL; without this eviction the
+        // homepage serves pre-sync data until the next restart (#296).
+        org.springframework.cache.annotation.CacheEvict evict = TicketmasterSyncService.class
+                .getMethod("syncEvents")
+                .getAnnotation(org.springframework.cache.annotation.CacheEvict.class);
+
+        Assertions.assertNotNull(evict, "syncEvents must evict caches");
+        Assertions.assertTrue(evict.allEntries(), "must evict all entries");
+        List<String> caches = List.of(evict.value());
+        Assertions.assertTrue(caches.contains("featuredEvents") && caches.contains("events"),
+                "must evict both events and featuredEvents caches");
     }
 }


### PR DESCRIPTION
## Summary
- `listFeatured()` keeps the earliest event per artist and caps at 8 — without this, refreshing the cache would put ~100 cards on the homepage, the first ~48 all Monster Jam (sync marks every event featured; query is unbounded, date-ascending)
- `syncEvents()` now evicts `events`/`featuredEvents` caches (no TTL — homepage served pre-sync data until restart)
- Deploying this also naturally refreshes the currently stale featured cache

## Testing
- TDD: three new tests (one-per-artist dedupe, cap at 8, cache-evict declaration) verified RED before the fix, GREEN after
- Full backend suite passes; JaCoCo run locally
- Codex review unavailable (persistent local keychain issue with its secrets scanner, see #293/#295); change is service-layer stream logic + one annotation, fully covered by the new tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)